### PR TITLE
fix: open AI assistant after annotate onboarding

### DIFF
--- a/src/components/annotate/OnboardingFlow.test.tsx
+++ b/src/components/annotate/OnboardingFlow.test.tsx
@@ -79,6 +79,24 @@ describe("OnboardingFlow", () => {
     // Advance to step 2
     fireEvent.click(screen.getByText("Next"))
     expect(screen.getByText("Import speaker data")).toBeTruthy()
-    expect(screen.getByText("Open workspace")).toBeTruthy()
+    expect(screen.getByText("Open AI assistant")).toBeTruthy()
+  })
+
+  it("completing onboarding routes the workspace to the chat panel", () => {
+    render(<OnboardingFlow onComplete={onComplete} />)
+    fireEvent.click(screen.getByText("Next"))
+    fireEvent.click(screen.getByText("Next"))
+    fireEvent.click(screen.getByText("Open AI assistant"))
+
+    expect(screen.getByText("Opening AI assistant…")).toBeTruthy()
+
+    vi.advanceTimersByTime(1000)
+
+    expect(mockSetState).toHaveBeenCalledWith({
+      onboardingComplete: true,
+      activeSpeaker: null,
+      annotatePanel: "chat",
+    })
+    expect(onComplete).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/annotate/OnboardingFlow.tsx
+++ b/src/components/annotate/OnboardingFlow.tsx
@@ -23,7 +23,8 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     const timer = setTimeout(() => {
       useUIStore.setState({
         onboardingComplete: true,
-        activeSpeaker: "",
+        activeSpeaker: null,
+        annotatePanel: "chat",
       })
       onComplete()
     }, 1000)
@@ -138,7 +139,7 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
             style={btnStyle}
             onClick={() => setCurrentStep(3)}
           >
-            Open workspace
+            Open AI assistant
           </button>
         </div>
       </div>
@@ -152,7 +153,7 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
         <div style={{ fontSize: 12, color: "#64748b", marginBottom: 4 }}>
           Step 4 of 4
         </div>
-        <h2 style={titleStyle}>Ready.</h2>
+        <h2 style={titleStyle}>Opening AI assistant…</h2>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- route annotate onboarding completion directly to the chat/AI panel
- update onboarding copy so the CTA explicitly says "Open AI assistant"
- add a regression test covering the onboarding-to-chat transition

## Root cause
The merged onboarding PR changed the copy to mention AI import, but it never set `annotatePanel: "chat"` when onboarding completed. Users therefore landed in the default annotation panel and appeared stuck in the manual flow.

## Test plan
- [x] `npm run test -- --run`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] browser verification in the Vite app with the Python backend running

## Notes
- set `activeSpeaker` to `null` on onboarding completion for store-type consistency
- left unrelated untracked file `docs/plans/worktree-setup.md` out of the commit