### PR TITLE
docs: add phase-0 repo cleanup preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,17 +29,22 @@ Do not start C7 early.
 ## Branch + Worktree Policy
 
 ### Canonical repository path
-- `/home/lucas/gh/ArdeleanLucas/PARSE`
+- **Active execution repo:** `/home/lucas/gh/ardeleanlucas/parse`
+- **Archive/divergent clone:** `/home/lucas/gh/ArdeleanLucas/PARSE`
+  - This uppercase clone currently follows archival/worktree history and may not match `origin/main`.
+  - Do not use it as branch truth without an explicit fetch/prune check.
 
 ### Canonical worktrees
-- Integration root: `/home/lucas/gh/ArdeleanLucas/PARSE` → `feat/parse-react-vite`
-- Annotate lane: `/home/lucas/gh/worktrees/PARSE/annotate-react` → `feat/annotate-react`
-- Compare lane: `/home/lucas/gh/worktrees/PARSE/compare-react` → `feat/compare-react`
+- Historical React pivot worktrees remain useful for traceability:
+  - Integration root: `/home/lucas/gh/ArdeleanLucas/PARSE` → `feat/parse-react-vite`
+  - Annotate lane: `/home/lucas/gh/worktrees/PARSE/annotate-react` → `feat/annotate-react`
+  - Compare lane: `/home/lucas/gh/worktrees/PARSE/compare-react` → `feat/compare-react`
+- These worktrees describe migration history; they are not automatically the current runtime source of truth.
 
 ### Active development rule
-- `feat/annotate-react` and `feat/compare-react` are now merged into integration.
-- **New work should branch off `feat/parse-react-vite`.**
-- Do not commit new feature work on stale track branches.
+- **New work should branch from `origin/main` in `/home/lucas/gh/ardeleanlucas/parse` unless Lucas explicitly changes repo policy.**
+- `feat/annotate-react`, `feat/compare-react`, and `feat/parse-react-vite` are historical pivot lanes, not default bases for new work.
+- Do not assume stale track branches or archival clones reflect current `main`.
 
 ## Ownership + Coordination
 
@@ -48,7 +53,7 @@ Historical split remains useful for boundaries:
 - ParseBuilder domain: Annotate + shared platform
 - Oda domain: Compare mode components/stores/hooks
 
-However, on integration branch, coordinate shared-surface edits.
+However, on current `main`, coordinate shared-surface edits carefully.
 
 ### Shared surfaces requiring coordination before commit
 - `src/api/client.ts`
@@ -60,11 +65,12 @@ However, on integration branch, coordinate shared-surface edits.
 - Add provider test coverage under `python/compare/providers/test_*.py`
 - Improve Lexibank/WOLD setup docs and CKB coverage strategy
 - Expand provider metadata and scholarly-source coverage plans
+- Non-destructive documentation/policy clarification about React (`:5173`) vs legacy (`parse.html`/`compare.html`) entrypoints is allowed when needed to reduce operator confusion
 
 ## Do Not Touch
 
 - `src/components/compare/*` (ContactLexemePanel + compare components currently stable)
-- `python/server.py` beyond existing CLEF endpoints
+- `python/server.py` destructive routing/cutover changes before C5+C6 signoff
 - `config/sil_contact_languages.json` directly (runtime output file)
 - Any C7 cleanup/deletion before C5+C6 signoff
 

--- a/docs/plans/legacy-entrypoint-inventory.md
+++ b/docs/plans/legacy-entrypoint-inventory.md
@@ -1,0 +1,97 @@
+# PARSE Legacy Entrypoint Inventory
+
+**Purpose:** Enumerate current references to legacy entrypoints (`parse.html`, `compare.html`, `localhost:8766` legacy UI paths) and identify which phase should handle each reference.
+
+**Scope date:** 2026-04-09
+**Repo scanned:** `/home/lucas/gh/ardeleanlucas/parse`
+
+---
+
+## A. User-facing / operator-facing references that should be cleaned up in Phase 3
+
+| Path | Current reference | Why it matters | Planned phase |
+|---|---|---|---|
+| `README.md` | Describes Annotate as `parse.html`, Compare as `compare.html`; browser section points to `http://localhost:8766/parse.html` and `/compare.html` | Primary onboarding doc still points users to legacy UI | **Phase 3** |
+| `python/server.py` | Startup banner prints `http://localhost:{PORT}/parse.html` and `/compare.html` | Server output still tells users legacy is canonical | **Phase 3** |
+| `desktop/README.md` | Default desktop URLs still reference `http://127.0.0.1:8766/parse.html` and `/compare.html` | Desktop-oriented instructions still privilege legacy pages | **Phase 3** |
+| `Start Review Tool.bat` | Opens `http://localhost:8766/review_tool_dev.html` | Legacy launcher path remains user-visible; needs explicit archival/legacy labeling | **Phase 3 review**, possibly Phase 5 if replaced |
+
+---
+
+## B. Runtime legacy files/links that remain until C7 and must be handled in Phase 5
+
+| Path | Current reference | Why it matters | Planned phase |
+|---|---|---|---|
+| `parse.html` | Top-nav links to `parse.html` and `compare.html` | Actual legacy UI still present and navigable | **Phase 5 / C7** |
+| `compare.html` | Top-nav links to `parse.html` and `compare.html` | Actual legacy UI still present and navigable | **Phase 5 / C7** |
+| `js/` | Legacy frontend module tree still exists | Root of the legacy runtime | **Phase 5 / C7** |
+| `vite.config.ts` | Comment notes `/compare` is kept on SPA route while legacy `compare.html` still exists | Signals current hybrid transition | **Leave until C7**, then update |
+
+---
+
+## C. Historical/specification references that should usually be preserved, not blindly rewritten
+
+| Path | Current reference type | Why it exists | Planned action |
+|---|---|---|---|
+| `PROJECT_PLAN.md` | Architecture/spec lists `parse.html` and `compare.html` as project files | Historical/spec document, not live operator guidance | Keep unless Lucas wants spec refresh |
+| `CODING.md` | Restructure waves mention preserving `parse.html` / `compare.html` | Historical implementation protocol | Keep or annotate later |
+| `INTERFACES.md` | Contracts and notes refer to `parse.html` / `compare.html` boot flows | Interface/history document | Keep unless interface docs are modernized intentionally |
+| `docs/desktop_product_architecture.md` | Describes current/legacy desktop architecture with `parse.html`/`compare.html` | Useful architectural history | Keep, but may need explicit “legacy/current state” labels later |
+| `docs/plans/react-vite-pivot.md` | Pivot plan explicitly references replacing `parse.html` / `compare.html` and deleting them in C7 | This is the migration plan itself | Keep |
+
+---
+
+## D. React/Vite references that define the new active workflow
+
+| Path | Current reference | Why it matters | Planned action |
+|---|---|---|---|
+| `docs/bugs.md` | Repro uses `http://localhost:5173` | Confirms current active React dev path | Keep |
+| `docs/plans/oda/coordination.md` | Browser checklist uses `http://localhost:5173/compare` | Confirms React Compare validation path | Keep |
+| `docs/plans/oda/phase-0.md` | `curl http://localhost:5173/api/config` | Confirms Vite dev workflow | Keep |
+| `docs/plans/oda/oda-core.md` | Requires `curl localhost:5173/api/config` | Confirms Vite dev workflow | Keep |
+| `docs/plans/oda/b9-compare-mode.md` | Validate at `http://localhost:5173/compare` | Confirms React Compare workflow | Keep |
+
+---
+
+## E. Non-UI `localhost:8766` references that are not themselves legacy UI problems
+
+These do **not** automatically need rewriting just because they mention `:8766`.
+They often refer to the API backend, which remains valid.
+
+| Path | Reference type | Action |
+|---|---|---|
+| `src/api/client.ts` | Documents Vite proxy to backend `http://localhost:8766` | Keep |
+| `docs/plans/react-vite-pivot.md` | Describes Vite proxy and backend API on `:8766` | Keep |
+| `docs/plans/oda/b7-export.md` | Calls export API on `:8766/api/export/*` | Keep |
+
+---
+
+## Recommended handling summary
+
+### Change in Phase 3
+- `README.md`
+- `python/server.py` startup messaging
+- `desktop/README.md`
+- `Start Review Tool.bat` (at minimum label as legacy/special-purpose)
+- any additional operator-facing launcher/docs found during implementation
+
+### Change in Phase 5 / C7
+- `parse.html`
+- `compare.html`
+- `js/`
+- follow-up updates to any nav links or runtime assumptions tied to those files
+
+### Preserve for now
+- `PROJECT_PLAN.md`
+- `CODING.md`
+- `INTERFACES.md`
+- `docs/desktop_product_architecture.md`
+- `docs/plans/react-vite-pivot.md`
+- Oda planning docs using `:5173`
+
+---
+
+## Notes
+- This inventory distinguishes **legacy UI entrypoint references** from **legitimate backend API references**.
+- The presence of `localhost:8766` alone is not a bug; it is only a Phase 3 problem when it is presented as the primary frontend UI path.
+- `docs/plans/repo-state-cleanup-and-architecture-unification.md` intentionally discusses legacy entrypoints as part of the cleanup plan and is therefore not treated as a stale legacy reference.

--- a/docs/plans/repo-cleanup-preflight.md
+++ b/docs/plans/repo-cleanup-preflight.md
@@ -1,0 +1,121 @@
+# PARSE Repo Cleanup Preflight
+
+**Purpose:** Capture the minimum factual state needed before any destructive repo cleanup, branch deletion, or legacy frontend removal.
+
+**Captured on:** 2026-04-09
+**Active repo:** `/home/lucas/gh/ardeleanlucas/parse`
+**Active branch when captured:** `docs/phase0-repo-cleanup-preflight`
+
+---
+
+## 1. Current `origin/main`
+
+- **`origin/main` SHA:** `3ab3be5541db7892a7e13b9c5aec062fb23b4c53`
+- **Meaningful recent merges on `main`:**
+  - PR #3 — onboarding fix merged
+  - PR #1 — config/onboarding fixes merged
+  - PR #2 — `feat/parse-react-vite` integration merged earlier in the line
+
+---
+
+## 2. Current remote branch list
+
+- `origin/main`
+- `origin/feat/annotate-react`
+- `origin/feat/compare-react`
+- `origin/feat/parse-react-vite`
+- `origin/fix/onboarding-open-ai-assistant`
+
+---
+
+## 3. Branch ancestry / ahead-behind facts
+
+### `origin/feat/annotate-react`
+- Ahead vs `origin/main`: `0`
+- Behind vs `origin/main`: `31`
+- Branch-only commits relative to `origin/main`: none
+- Working classification: **cleanly subsumed historical branch**
+- Implication: safe deletion candidate once Lucas approves branch pruning
+
+### `origin/feat/parse-react-vite`
+- Ahead vs `origin/main`: `0`
+- Behind vs `origin/main`: `9`
+- Branch-only commits relative to `origin/main`: none
+- Working classification: **cleanly subsumed integration branch**
+- Implication: safe deletion candidate once Lucas approves branch pruning
+
+### `origin/fix/onboarding-open-ai-assistant`
+- Ahead vs `origin/main`: `0`
+- Behind vs `origin/main`: `1`
+- Branch-only commits relative to `origin/main`: none
+- Working classification: **cleanly subsumed landed fix branch**
+- Implication: safe deletion candidate once Lucas approves branch pruning
+
+### `origin/feat/compare-react`
+- Ahead vs `origin/main`: `1`
+- Behind vs `origin/main`: `8`
+- Branch-only commit(s):
+  - `b8ecd1e` — `merge: config+auth fixes (MC-281) into feat/compare-react`
+- Working classification: **ambiguous / not a clean ancestor**
+- Implication: **do not delete blindly**; requires explicit audit and Lucas decision
+
+---
+
+## 4. Uppercase clone warning
+
+Secondary clone:
+- `/home/lucas/gh/ArdeleanLucas/PARSE`
+
+Known state from prior audit:
+- its local `main` points at `archive/main`
+- it diverges heavily from `origin/main`
+- it is not a safe basis for branch truth or cleanup decisions without an explicit Lucas-approved repoint/reset
+
+Implication:
+- destructive cleanup decisions should be based on the lowercase active repo plus GitHub remote state, not the uppercase clone
+
+---
+
+## 5. Rollback recommendations
+
+### Before any branch deletions
+Recommended safety step:
+- capture the current remote branch list and corresponding SHAs in a PR comment or audit note
+- if Lucas wants an extra hedge, create local backup refs before deletion, e.g.:
+  - `backup/feat-annotate-react-<date>`
+  - `backup/feat-parse-react-vite-<date>`
+  - `backup/fix-onboarding-open-ai-assistant-<date>`
+
+### Before any C7 destructive cleanup
+Recommended safety step:
+- create a visible rollback point on the current `main`, e.g.:
+  - annotated tag: `pre-c7-legacy-removal`
+  - or backup branch: `backup/pre-c7-legacy-removal`
+- ensure the PR description records:
+  - `origin/main` SHA before deletion
+  - list of deleted files
+  - any launcher/server behavior changed
+
+### Before touching the uppercase clone
+Recommended safety step:
+- decide whether it is archival and should remain untouched
+- if Lucas wants it repointed, record current `archive/main` SHA before any reset
+
+---
+
+## 6. Preflight go / no-go summary
+
+### Go now
+- non-destructive docs/policy reconciliation
+- legacy reference inventory
+- compare-branch audit
+- non-destructive README/server messaging PRs
+
+### No-go until Lucas decision/signoff
+- branch deletions
+- uppercase clone reset/repoint
+- legacy frontend removal (`parse.html`, `compare.html`, `js/`)
+- Python-server frontend cutover to built React app
+
+### No-go until C5 + C6 cleared
+- any C7 destructive cleanup or canonical frontend cutover

--- a/docs/plans/repo-state-cleanup-and-architecture-unification.md
+++ b/docs/plans/repo-state-cleanup-and-architecture-unification.md
@@ -1,0 +1,450 @@
+# PARSE Repository State Cleanup and Architecture Unification Plan
+
+> **For Hermes:** Execute from the lowercase clone `/home/lucas/gh/ardeleanlucas/parse` unless Lucas explicitly decides otherwise. Do **not** merge to `main` directly. Open PRs; **Lucas must merge them**.
+
+**Goal:** Get PARSE into a clean post-pivot state with one canonical active repo, explicit React-vs-legacy boundaries, a defensible branch cleanup sequence, and a gated path to removing legacy HTML/JS.
+
+**Architecture:** PARSE is currently hybrid. The React + Vite app is live at `index.html` + `src/`, while legacy `parse.html`, `compare.html`, and `js/` still remain on `main` and are still advertised by the Python server and README. Cleanup must happen in phases so thesis-critical workflows are not broken before C5/C6 validation.
+
+**Tech Stack:** Git/GitHub, React 18, Vite, TypeScript, Zustand, Python `server.py`, legacy static HTML/JS.
+
+---
+
+## Current State Summary
+
+- **Canonical active repo for now:** `/home/lucas/gh/ardeleanlucas/parse`
+- **Archive/divergent clone:** `/home/lucas/gh/ArdeleanLucas/PARSE`
+  - Its `main` currently points at `archive/main`, not `origin/main`
+  - Do not trust it for current branch truth until Lucas explicitly approves a reset/repoint decision
+- **Current GitHub branches:**
+  - `main`
+  - `feat/annotate-react`
+  - `feat/compare-react`
+  - `feat/parse-react-vite`
+  - `fix/onboarding-open-ai-assistant`
+- **Merged PRs already on `main`:**
+  - PR #2 — `feat/parse-react-vite`
+  - PR #3 — `fix/onboarding-open-ai-assistant`
+- **Legacy is still present on `main`:**
+  - `parse.html`
+  - `compare.html`
+  - `js/`
+- **Legacy is still user-facing in docs/server output:**
+  - `README.md` still points users to `/parse.html` and `/compare.html`
+  - `python/server.py` startup output still prints `/parse.html` and `/compare.html`
+  - additional docs/scripts may still assume the legacy flow
+- **Policy conflict to reconcile:**
+  - current `AGENTS.md` still treats the uppercase clone/worktree model as canonical
+  - current `AGENTS.md` also warns against touching `python/server.py` pre-C6 except for CLEF endpoints
+- **Gate:** C7 cleanup is still blocked until Lucas explicitly clears **C5** and **C6**.
+
+---
+
+## Non-Negotiable Rules
+
+1. **No direct merge to `main` by Hermes.**
+   - If a code/doc change is needed, Hermes opens a PR.
+   - **Lucas merges it.**
+2. **No legacy deletion before C5/C6 signoff.**
+3. **No branch deletion without Lucas approval.**
+4. **No force-reset of the uppercase archival clone without Lucas approval.**
+5. **Lowercase repo is the source of truth for active dev until policy docs are explicitly updated.**
+6. **Any destructive cleanup must have a rollback point recorded first.**
+
+---
+
+## Responsibility Split
+
+| Area | Hermes | Lucas |
+|---|---|---|
+| Repo audits | Yes | Optional review |
+| Doc/code edits | Yes | Reviews via PR |
+| PR creation | Yes | N/A |
+| Merge to `main` | No | **Yes** |
+| Branch deletion | Prepare recommendation | **Approve / execute or authorize** |
+| Uppercase clone reset/repoint | Recommend only | **Approve** |
+| C5 signoff | Support / verify evidence | **Yes** |
+| C6 signoff | Support / verify evidence | **Yes** |
+| C7 destructive cleanup authorization | Recommend | **Yes** |
+
+---
+
+## Phase 0 — Preflight and Policy Reconciliation
+
+### Objective
+Remove ambiguity before any cleanup work starts.
+
+### Task 0.1 — Reconcile repo-path policy
+
+**Objective:** Make active-repo guidance consistent across planning docs.
+
+**Files:**
+- Modify: `AGENTS.md`
+- Optional modify: `README.md`
+- Optional modify: relevant docs under `docs/plans/`
+
+**Required change:**
+- State that active execution currently uses `/home/lucas/gh/ardeleanlucas/parse`
+- State that `/home/lucas/gh/ArdeleanLucas/PARSE` is currently archive/divergent unless Lucas later repoints it
+- Explicitly note that `python/server.py` messaging cleanup is allowed as a non-destructive documentation/UX fix, but legacy removal remains blocked until C5/C6
+
+**Verification:**
+- Read updated docs and confirm there is no longer a canonical-path contradiction
+
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+### Task 0.2 — Inventory all legacy references
+
+**Objective:** Build the full list of places that still advertise or depend on legacy entrypoints.
+
+**Files:**
+- Create: `docs/plans/legacy-entrypoint-inventory.md`
+
+**Search scope:**
+- `README.md`
+- `AGENTS.md`
+- `CODING.md`
+- `python/server.py`
+- `start_parse.sh`
+- `Start Review Tool.bat`
+- `desktop/`
+- `docs/`
+- any launchers or scripts that mention `parse.html`, `compare.html`, `localhost:8766`, or legacy JS assumptions
+
+**Verification:**
+- Inventory file lists exact paths and whether each reference must be changed in Phase 3 or Phase 5
+
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+### Task 0.3 — Record rollback and ancestry facts
+
+**Objective:** Ensure destructive steps can be reversed and branch decisions are evidence-based.
+
+**Files:**
+- Create: `docs/plans/repo-cleanup-preflight.md`
+
+**Required contents:**
+- current `origin/main` SHA
+- current remote branch list
+- ancestry / ahead-behind notes for:
+  - `feat/annotate-react`
+  - `feat/compare-react`
+  - `feat/parse-react-vite`
+  - `fix/onboarding-open-ai-assistant`
+- note whether each branch is cleanly merged, historical, or ambiguous
+- rollback point recommendation for pre-C7 and pre-deletion states
+
+**Verification:**
+- File is sufficient for Lucas to approve or reject destructive steps later
+
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+## Phase 1 — Canonicalize Local Repo Usage
+
+### Objective
+Make it impossible to accidentally inspect or run the wrong local clone.
+
+### Task 1.1 — Decide fate of uppercase archival clone
+
+**Objective:** Explicitly preserve or repoint the uppercase clone.
+
+**Files:**
+- No repo-file edits required until Lucas decides.
+
+**Options:**
+- **Option A: Preserve as archive clone**
+  - Keep it unchanged
+  - Document that it tracks `archive/main`
+- **Option B: Repoint/reset to `origin/main`**
+  - Only after Lucas approves destructive reset behavior
+  - Then make it match the active lowercase clone
+
+**Recommendation:**
+- Prefer **Option A for now** unless Lucas wants a strict single-clone workflow.
+
+**Needs Lucas action?** Yes — repo-maintenance decision.
+
+---
+
+## Phase 2 — Audit `feat/compare-react` Before Any Deletion
+
+### Objective
+Decide whether `feat/compare-react` is stale residue or still meaningful.
+
+### Task 2.1 — Produce a compare-branch audit note
+
+**Objective:** Determine whether the branch-only divergence should be preserved, rebased, or discarded.
+
+**Files:**
+- Create: `docs/plans/compare-branch-audit.md`
+
+**Required analysis:**
+1. Inspect `origin/main..origin/feat/compare-react`
+2. Identify whether the branch-only commit is semantically meaningful or just stale merge residue
+3. Compare branch intent against current `main`
+4. State one of three recommendations:
+   - delete
+   - keep as historical lane
+   - revive/rebase intentionally
+
+**Verification:**
+- Audit note gives Lucas enough evidence to approve or reject deletion
+
+**Needs Lucas permission?**
+- Audit: no
+- Deletion or revival after audit: yes
+
+---
+
+## Phase 3 — Non-Destructive Messaging and Documentation Cleanup
+
+### Objective
+Stop misleading users while legacy still exists.
+
+### Task 3.1 — Update README architecture and entrypoints
+
+**Objective:** Make React dev entrypoints explicit and label legacy pages correctly.
+
+**Files:**
+- Modify: `README.md`
+
+**Required changes:**
+- Update dev workflow to state React dev uses:
+  - `http://localhost:5173/`
+  - `http://localhost:5173/compare`
+- Label Python-served legacy pages as fallback/legacy only:
+  - `http://localhost:8766/parse.html`
+  - `http://localhost:8766/compare.html`
+- Update any sections that still describe PARSE as exclusively “no build step” or exclusively legacy-HTML based
+- Note that full legacy removal is gated on C5/C6 → C7
+
+**Verification:**
+- README no longer implies legacy is the primary architecture
+
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+### Task 3.2 — Update server startup messaging
+
+**Objective:** Stop `python/server.py` from implying legacy is the only correct entrypoint.
+
+**Files:**
+- Modify: `python/server.py`
+
+**Required changes:**
+- Keep printing legacy URLs if needed for fallback access
+- Also print React dev guidance, e.g.:
+  - React dev: `http://localhost:5173/`
+  - React compare: `http://localhost:5173/compare`
+- Explicitly label `/parse.html` and `/compare.html` as legacy entrypoints
+
+**Verification:**
+- Start server locally
+- Confirm startup output clearly distinguishes React dev vs legacy fallback
+
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+### Task 3.3 — Update secondary docs and launchers inventory-derived references
+
+**Objective:** Reduce lingering ambiguity outside the root README.
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `CODING.md` if needed
+- Modify: relevant files identified in `docs/plans/legacy-entrypoint-inventory.md`
+- Possibly modify: `start_parse.sh`, `Start Review Tool.bat`, desktop docs, launcher notes
+
+**Required change:**
+- Any surviving legacy references must be explicitly labeled as temporary / pre-C7
+- Any React dev workflow references must point to `:5173`
+
+**Verification:**
+- Inventory file can be checked off item-by-item
+
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+## Phase 4 — Clear C5 and C6 Before Any Legacy Removal
+
+### Objective
+Reach the cleanup gate honestly, not aspirationally.
+
+### Task 4.1 — C5 LingPy export signoff
+
+**Objective:** Lucas verifies LingPy TSV export correctness in browser.
+
+**Verification target:**
+- Row counts correct
+- Columns correct
+- Export reflects current React workflow outputs
+
+**Needs Lucas action?** Yes — manual signoff.
+
+---
+
+### Task 4.2 — C6 browser regression signoff
+
+**Objective:** Lucas verifies full user workflow in the React app.
+
+**Coverage:**
+- Annotate waveform / regions / STT / onboarding / chat
+- Compare grid / tags / nav / import / export affordances
+
+**Needs Lucas action?** Yes — manual signoff.
+
+---
+
+## Phase 5 — C7 Legacy Removal and True Architecture Unification
+
+### Objective
+Make PARSE expose only the new architecture.
+
+### Task 5.1 — Decide build artifact strategy for Python-served frontend
+
+**Objective:** Specify exactly what the Python server will serve after legacy removal.
+
+**Files:**
+- Modify: `README.md`
+- Modify: `python/server.py`
+- Modify: startup/build docs as needed
+
+**Required decision:**
+- Preferred path: `npm run build` produces `dist/`
+- Python server serves the built frontend from `dist/` for production-like/local-server usage
+- Vite `:5173` remains the dev-only workflow
+
+**Verification:**
+- Decision is documented before any legacy file deletion PR is opened
+
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+### Task 5.2 — Remove legacy frontend files and switch canonical serving
+
+**Objective:** Delete the no-longer-authoritative legacy UI and make the Python server serve the React build.
+
+**Files:**
+- Delete: `parse.html`
+- Delete: `compare.html`
+- Delete: `js/`
+- Modify: `python/server.py`
+- Modify: any file needed to support built frontend serving
+
+**Preconditions:**
+- Lucas has explicitly cleared C5 and C6
+- rollback point recorded in `docs/plans/repo-cleanup-preflight.md`
+
+**Acceptance criteria:**
+- `npm run build` succeeds and produces `dist/index.html` and required assets
+- Python server serves the built frontend for non-API routes
+- direct GET `/` returns the React app shell
+- direct GET `/compare` returns the React app shell via SPA fallback
+- `/api/*` routes still return JSON as before
+- audio/static behavior needed by thesis workflows still works
+- legacy `parse.html` / `compare.html` references are removed or intentionally redirected
+
+**Needs Lucas permission?** Yes — destructive cleanup.
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+### Task 5.3 — Remove remaining legacy references from docs and launchers in the same unification wave
+
+**Objective:** Finish cleanup so docs match reality on the same architecture cutover.
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `CODING.md` if needed
+- Modify: launchers/start scripts
+- Modify: relevant docs under `docs/`
+
+**Verification:**
+- No user-facing docs imply `parse.html` / `compare.html` are the primary interface
+- No launcher still assumes legacy HTML entrypoints are canonical
+
+**Needs Lucas merge?** Yes — PR required.
+
+---
+
+## Phase 6 — Branch Cleanup After Successful Merge/Signoff
+
+### Objective
+Prune the branch list only after the repo is in a stable, documented state.
+
+### Task 6.1 — Delete clearly historical merged branches
+
+**Candidate branches:**
+- `fix/onboarding-open-ai-assistant`
+- `feat/parse-react-vite`
+- `feat/annotate-react`
+
+**Why they should go:**
+- They are historical lanes or merged fix branches already subsumed by `main`
+- Keeping them makes GitHub look more architecturally fragmented than it should
+
+**Verification before deletion:**
+- Confirm each is merged/subsumed by current `main`
+- Confirm Lucas still wants them pruned
+
+**Needs Lucas permission?** Yes — destructive action.
+
+---
+
+### Task 6.2 — Resolve `feat/compare-react`
+
+**Objective:** Delete, preserve, or revive it intentionally based on the Phase 2 audit.
+
+**Needs Lucas action?** Yes — explicit decision required.
+
+---
+
+## Proposed Execution Order
+
+1. **PR: Phase 0 preflight + policy reconciliation**
+2. **Audit `feat/compare-react` and give Lucas a delete/keep/revive recommendation**
+3. **PR: Phase 3 non-destructive README / AGENTS / server / doc messaging cleanup**
+4. **Lucas merges those non-destructive PRs to `main`**
+5. **Lucas clears C5**
+6. **Lucas clears C6**
+7. **PR: Phase 5 C7 unification (build serving + legacy removal + launcher/doc cleanup)**
+8. **Lucas merges the C7 PR to `main`**
+9. **After stable merge/signoff, delete clearly historical branches with Lucas approval**
+
+---
+
+## Lucas Decisions Required
+
+1. Whether the uppercase clone should remain archive-only or later be reset to track `origin/main`
+2. Approval to merge any non-destructive policy/docs/server cleanup PRs
+3. Final decision on whether `feat/compare-react` should be preserved, deleted, or revived after audit
+4. C5 signoff
+5. C6 signoff
+6. Approval for destructive C7 cleanup PR merge
+7. Approval for branch deletions
+
+---
+
+## Definition of Proper Final State
+
+PARSE is in a proper final state when all of the following are true:
+
+- One local clone is treated as canonical for active development
+- The GitHub branch list is pruned to active work only
+- README, AGENTS, server output, and launchers no longer mislead users toward legacy entrypoints
+- Lucas has signed off on C5 and C6
+- Legacy `parse.html`, `compare.html`, and `js/` are removed
+- Python server serves the current React frontend as the canonical non-dev UI
+- `/` and `/compare` resolve correctly after cutover
+- `main` is the obvious single source of truth


### PR DESCRIPTION
## Summary
- reconcile AGENTS repo-path policy with the currently active lowercase PARSE clone
- add a legacy entrypoint inventory that separates user-facing legacy UI references from valid backend API references
- add a preflight note capturing branch ancestry, rollback guidance, and go/no-go rules
- commit the repo cleanup / architecture unification plan that explicitly requires Lucas to merge any PRs to `main`

## Why
PARSE is currently in a hybrid React + legacy state. Before any destructive cleanup or branch deletion, we need a documented preflight record and a consistent policy for which local repo/path is authoritative.

## Included files
- `AGENTS.md`
- `docs/plans/repo-state-cleanup-and-architecture-unification.md`
- `docs/plans/legacy-entrypoint-inventory.md`
- `docs/plans/repo-cleanup-preflight.md`

## Notes
- No runtime behavior changed
- No branches deleted
- No legacy frontend files removed
- Unrelated untracked file `docs/plans/worktree-setup.md` was left out of this PR

## Merge dependency
Hermes cannot merge to `main`. Lucas must merge this PR if approved.