### PR TITLE
docs: add C5/C6 signoff checklist

### DIFF
--- a/docs/plans/phase4-c5-c6-signoff-checklist.md
+++ b/docs/plans/phase4-c5-c6-signoff-checklist.md
@@ -8,7 +8,7 @@
 
 | Gate | Command | Result |
 |---|---|---|
-| Frontend/unit/integration tests | `npm run test -- --run` | ✅ 21 files, 103 tests passed |
+| Frontend/unit/integration tests | `npm run test -- --run` | ✅ 22 files, 113 tests passed |
 | TypeScript | `./node_modules/.bin/tsc --noEmit` | ✅ clean |
 | API regression | `npm run test:api` | ✅ 24 tests passed |
 

--- a/docs/plans/phase4-c5-c6-signoff-checklist.md
+++ b/docs/plans/phase4-c5-c6-signoff-checklist.md
@@ -1,0 +1,139 @@
+# PARSE Phase 4 — C5/C6 Signoff Checklist
+
+> **Purpose:** prepare the manual signoff gate before any C7 legacy removal. Hermes can automate supporting checks, but **Lucas must personally sign off C5 and C6**.
+
+## Current baseline (captured 2026-04-09)
+
+### Automated gates
+
+| Gate | Command | Result |
+|---|---|---|
+| Frontend/unit/integration tests | `npm run test -- --run` | ✅ 21 files, 103 tests passed |
+| TypeScript | `./node_modules/.bin/tsc --noEmit` | ✅ clean |
+| API regression | `npm run test:api` | ✅ 24 tests passed |
+
+### Non-blocking warnings observed during automated checks
+
+- Vitest prints React Router future-flag warnings in `AnnotateMode.test.tsx`.
+- `storePersistence.test.ts` prints `tagStore` `localStorage is not defined` warnings under jsdom, but the test suite still passes.
+
+These are **not** currently treated as gate failures, but they should be kept in mind if test output is tightened later.
+
+---
+
+## Test environment for manual signoff
+
+Start both services from the canonical repo:
+
+```bash
+# Terminal 1
+python3 python/server.py
+
+# Terminal 2
+npm run dev
+```
+
+Primary URLs:
+
+- Annotate: `http://localhost:5173/`
+- Compare: `http://localhost:5173/compare`
+
+Legacy fallback pages on `:8766` are **not** the signoff target for C5/C6.
+If the Python server banner prints `parse.html` / `compare.html` URLs, ignore those for this phase and stay on the React/Vite routes above.
+
+---
+
+## C5 — LingPy TSV export signoff
+
+**Goal:** verify the thesis-critical export from the React workflow, not the legacy HTML pages.
+
+### Steps
+
+1. Open `http://localhost:5173/compare`
+2. Click the **Export LingPy TSV** button
+3. Open the downloaded file in a spreadsheet editor or text editor
+4. Verify all of the following:
+   - [ ] file downloads successfully
+   - [ ] file is non-empty
+   - [ ] headers include: `ID`, `DOCULECT`, `CONCEPT`, `IPA`, `COGID`, `TOKENS`, `NOTE`
+   - [ ] row count matches expected concept × speaker coverage for the current dataset
+   - [ ] `DOCULECT` values match the expected speaker names
+   - [ ] `CONCEPT` values are correct for sampled rows
+   - [ ] `IPA` values match known annotations for at least one trusted speaker (e.g. `Fail01`)
+   - [ ] `COGID` values are populated in a way that matches current compare decisions
+   - [ ] no obvious TSV corruption (misaligned columns, broken quoting, blank body)
+
+### Evidence to record
+
+- date/time of signoff
+- sample exported filename
+- sample row count
+- any anomalies found
+
+### Status
+
+- [ ] **Lucas C5 signoff complete**
+
+---
+
+## C6 — browser regression signoff
+
+**Goal:** validate the current React/Vite PARSE workflow end-to-end in the browser.
+
+### Annotate mode
+
+- [ ] Waveform loads for each T1 speaker: `Fail01`, `Fail02`, `Kalh01`, `Mand01`, `Qasr01`, `Saha01`
+- [ ] Play/pause works without audio glitch
+- [ ] Dragging a region updates annotation context correctly
+- [ ] Editing an IPA field auto-saves within ~1 second
+- [ ] STT pipeline runs to completion for at least one concept
+- [ ] Import TextGrid populates tiers correctly
+- [ ] Export CSV produces a valid file
+- [ ] Hard refresh preserves existing annotations
+- [ ] Onboarding flow reaches the AI assistant panel as intended (auth choices visible if no provider is signed in)
+
+### Compare mode
+
+- [ ] ConceptTable renders for all T1 speakers
+- [ ] Accept / Reject / Split / Merge actions persist to enrichments
+- [ ] TagManager creates, edits, and deletes tags correctly
+- [ ] Tag assignment survives page reload
+- [ ] EnrichmentsPanel shows computed values after compute flow
+- [ ] LingPy TSV export still works from Compare mode and matches C5 expectations
+
+### Cross-mode
+
+- [ ] Navigate Annotate → Compare → Annotate with no state loss
+- [ ] Python backend on port `8766` remains connected throughout the session
+- [ ] No blocking browser console errors appear during the workflow
+
+### Watchpoints during C6
+
+These are items to pay special attention to during browser signoff:
+
+- historical Compare interactivity bug noted in `docs/bugs.md`
+- onboarding-to-chat routing in Annotate mode
+- export behavior from the React Compare route, not the legacy fallback page
+
+### Evidence to record
+
+- browser used
+- speakers tested
+- export filename(s)
+- any console errors
+- any steps that still feel sticky or inconsistent
+
+### Status
+
+- [ ] **Lucas C6 signoff complete**
+
+---
+
+## Exit rule before C7
+
+Do **not** begin legacy removal (`parse.html`, `compare.html`, `js/`, Python static fallback cutover) until both are checked:
+
+- [ ] C5 complete
+- [ ] C6 complete
+
+Once both are signed off, Hermes can prepare the C7 unification PR.


### PR DESCRIPTION
## Summary
- add a focused Phase 4 checklist for manual C5/C6 signoff
- record the current automated baseline on main
- make the React/Vite `:5173` workflow the explicit signoff target

## Includes
- `docs/plans/phase4-c5-c6-signoff-checklist.md`
  - automated gate snapshot
  - C5 LingPy TSV verification checklist
  - C6 browser regression checklist
  - explicit rule that legacy `:8766/*.html` pages are not the signoff target
  - exit rule before any C7 legacy removal

## Automated baseline captured
- `npm run test -- --run` → 103 passed
- `./node_modules/.bin/tsc --noEmit` → clean
- `npm run test:api` → 24 passed

## Notes
- this PR does **not** claim C5 or C6 are signed off
- Lucas still has to run the manual browser/export checks personally before C7 can begin
