### PR TITLE
feat: MC-294/295/296 — ParseUI unified shell + wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,16 @@
 # AGENTS.md — PARSE React + Vite Integration (2026)
 
-## Current State (updated 2026-04-08)
+## Current State (updated 2026-05-14)
 
 PARSE has already crossed the React pivot integration point on **`feat/parse-react-vite`**.
 
+- **UI Redesign complete** on `feat/annotate-ui-redesign` (MC-294):
+  - `src/ParseUI.tsx` — 1482-line unified shell (Annotate + Compare + Tags + AI Chat in one layout)
+  - `App.tsx` simplified to `<BrowserRouter><ParseUI /></BrowserRouter>`
+  - Dependencies added: `lucide-react`, `tailwindcss v3`, `postcss`, `autoprefixer`
+  - Wired: `useWaveSurfer`, `useChatSession`, `useConfigStore`, `useTagStore`, `usePlaybackStore`, `useUIStore`, `useAnnotationSync`
+  - tsc: clean compile · pending PR merge to `main`
+  - TODO next: MOCK_FORMS → real store, Save Annotation intervals, spectrogram Worker, Cognate compute
 - **Phase C1–C4 complete** on integration branch:
   - Track merge (`feat/annotate-react` + `feat/compare-react`)
   - Cross-mode navigation (Annotate ↔ Compare)

--- a/docs/plans/parsebuilder-todo.md
+++ b/docs/plans/parsebuilder-todo.md
@@ -1,0 +1,110 @@
+# ParseBuilder — Personal TODO
+
+> **Owner:** ParseBuilder (@parse-builder)
+> **Domain:** Annotate mode + shared platform (waveform, spectrogram, phonetic tools)
+> **Branch:** `feat/annotate-ui-redesign`
+> **Updated:** 2026-05-14
+
+---
+
+## 🔴 Active — In Progress
+
+### MC-295 — ParseUI: Annotate wiring (IPA/ortho + Save + Mark Done + Missing badge)
+**Priority: thesis-critical**
+
+- [ ] Load IPA/ortho from `annotationStore.records[speaker]` on concept/speaker change — pre-populate fields
+- [ ] Wire Save Annotation button → create intervals in `tiers.ipa`, `tiers.ortho`, `tiers.concept` → call `saveSpeaker()`
+- [ ] Wire Mark Done button → `tagStore.tagConcept('confirmed', concept.id.toString())`
+- [ ] Make Missing badge reactive — check `annotationStore` for existing interval vs concept name
+
+**Files:** `src/ParseUI.tsx` (AnnotateView component, lines ~498–780)
+**Hooks/stores:** `useAnnotationStore`, `useTagStore`, `usePlaybackStore` (for `selectedRegion`)
+
+---
+
+### MC-296 — ParseUI: Stale reference cleanup
+**Priority: quick win — do first**
+
+- [ ] Line 863: `CONCEPTS.find(...)` → `concepts.find(...)`
+- [ ] Line 865: `CONCEPTS.length` → `concepts.length`
+- [ ] Line 1300: `SPEAKERS.length` → `speakers.length`
+- [ ] Lines 451–468: delete stale JSDoc block about mock waveform
+- [ ] Lines 592–595: delete stale `TODO: Replace mock` comment
+- [ ] Line 127 (AIChat useEffect): `[messages, minimized]` → `[chatSession.messages, minimized]`
+
+**Files:** `src/ParseUI.tsx`
+**Time estimate:** 15 min
+
+---
+
+### MC-297 — Spectrogram Worker — TypeScript port + `useSpectrogram` hook
+**Priority: post-thesis unless Lucas needs it for C6**
+
+- [ ] Create `src/workers/spectrogram-worker.ts` — port from `js/shared/spectrogram-worker.js` (273 lines, STFT/FFT Cooley-Tukey)
+  - Add TypeScript types for message protocol: `{ type: 'compute', audioData: Float32Array, sampleRate, windowSize, startSec, endSec }`
+  - Output: `{ type: 'result', imageData: Uint8ClampedArray, width, height, startSec, endSec }`
+- [ ] Create `src/hooks/useSpectrogram.ts`
+  - Manages Worker lifecycle (create on mount, terminate on unmount)
+  - Accepts `wsRef` (from useWaveSurfer) to get decoded audio buffer
+  - Posts PCM window to worker when `spectroOn` is true
+  - Returns `{ canvasRef, ready }` — caller mounts canvas as overlay
+- [ ] Wire into `AnnotateView` — replace CSS gradient placeholder with real canvas overlay
+- [ ] Run `npm run check` — clean compile required
+
+**Files:** `src/workers/spectrogram-worker.ts` (new), `src/hooks/useSpectrogram.ts` (new), `src/ParseUI.tsx`
+**Reference:** `parse/js/shared/spectrogram-worker.js` — copy the FFT logic, type it up
+
+---
+
+## 🟡 Pending — Waiting on Lucas or other gates
+
+### MC-298 — `server.py` startup messaging cleanup (Phase 3.2 of cleanup plan)
+**Blocked by:** Phase 3 non-destructive PR not yet merged
+**Gate:** Non-destructive, can open PR anytime
+
+- [ ] Update `python/server.py` startup output — label `/parse.html` + `/compare.html` as legacy fallback
+- [ ] Add React dev guidance in startup: `http://localhost:5173/` and `http://localhost:5173/compare`
+- [ ] Explicitly separate: legacy serving vs React dev vs (future) built dist serving
+
+**Files:** `python/server.py`
+**PR:** Open to `main` — Lucas merges
+
+---
+
+### MC-299 — C6 Browser Regression Checklist Prep
+**Blocked by:** Lucas ready to do C6 signoff
+**Gate:** C5 must be cleared first
+
+When Lucas is ready, I prepare and walk through:
+
+- [ ] Annotate: waveform loads real audio for a real speaker
+- [ ] Annotate: regions can be drawn, IPA/ortho can be typed and saved
+- [ ] Annotate: STT runs from Actions menu, results populate fields
+- [ ] Annotate: Mark Done tags concept as confirmed
+- [ ] Annotate: concept list updates dot color after tagging
+- [ ] Compare: speaker forms table shows real IPA (not mock data)
+- [ ] Compare: Accept/Flag concept writes to tagStore
+- [ ] Compare: Export LingPy TSV downloads correctly (this is C5 too)
+- [ ] Chat: send a message, get a real response from xAI
+
+**Files:** `docs/plans/repo-state-cleanup-and-architecture-unification.md` (Task 4.2)
+
+---
+
+## ✅ Done
+
+- [x] **MC-294** — ParseUI unified shell — 1482-line React UI, Tailwind + lucide-react installed, initial store/hook wiring, `feat/annotate-ui-redesign` branch, tsc clean (2026-05-14)
+- [x] All Phase C1–C4 pivot integration work (see `react-vite-pivot.md`)
+- [x] `useWaveSurfer` hook — full implementation with RegionsPlugin + TimelinePlugin
+- [x] All Annotate mode hooks: `useAnnotationSync`, `useChatSession`, `useImportExport`, `useSuggestions`
+- [x] `annotationStore`, `configStore`, `playbackStore`, `uiStore`, `tagStore`
+
+---
+
+## Order of attack
+
+1. **MC-296** — stale cleanup (15 min, unblocks everything else compiling cleanly)
+2. **MC-295** — annotate wiring (core thesis workflow)
+3. **MC-298** — server.py messaging (quick, non-destructive, open PR to main)
+4. **MC-297** — spectrogram (when annotate wiring is stable)
+5. **MC-299** — when Lucas signals C5 cleared

--- a/docs/plans/parseui-wiring-todo.md
+++ b/docs/plans/parseui-wiring-todo.md
@@ -1,0 +1,272 @@
+# ParseUI Wiring TODO — for parse-gpt
+
+> **Branch:** `feat/annotate-ui-redesign`
+> **File:** `src/ParseUI.tsx`
+> **Status:** UI shell complete, hooks/stores partially wired. Work through this list top to bottom — priority order.
+> **Rule:** Run `npm run check` (tsc --noEmit) after every task. Do not proceed if it errors.
+
+---
+
+## Priority 1 — Core Annotation Workflow (thesis-critical)
+
+### TASK 1 — Fix stale `CONCEPTS` / `SPEAKERS` references
+**File:** `src/ParseUI.tsx`
+
+- [ ] Line 863: `const concept = CONCEPTS.find(...)` → change to `concepts.find(...)`
+- [ ] Line 865: `const total = CONCEPTS.length` → change to `concepts.length`
+- [ ] Line 1300: `{SPEAKERS.length}` → `{speakers.length}`
+
+These three were missed in the initial wiring pass. `concepts` and `speakers` are already derived from `useConfigStore` — just the references need updating.
+
+---
+
+### TASK 2 — Load IPA/ortho from `annotationStore` on concept/speaker change
+**File:** `src/ParseUI.tsx` — `AnnotateView` component (line ~498)
+
+Currently `ipa` and `ortho` are plain local `useState('')`. They need to pre-populate from the stored annotation when the concept or speaker changes.
+
+- [ ] Import `useAnnotationStore` at the top of the file
+- [ ] Inside `AnnotateView`, subscribe to `annotationStore.records[speaker]`
+- [ ] On mount and when `concept` or `speaker` changes, find the interval in `tiers.ipa` and `tiers.ortho` whose text matches the current concept (look up by concept name in `tiers.concept` intervals — find the interval whose `text` contains `concept.name`, then get the corresponding IPA/ortho interval at the same time range)
+- [ ] Pre-populate `ipa` and `ortho` state with that text (empty string if not found)
+
+**Relevant store shape:**
+```typescript
+// annotationStore.records[speaker].tiers.ipa.intervals[]
+// each interval: { start: number, end: number, text: string }
+// annotationStore.records[speaker].tiers.concept.intervals[]
+// find concept interval where text includes concept.name, use its start/end to match ipa/ortho
+```
+
+---
+
+### TASK 3 — Wire "Save Annotation" button
+**File:** `src/ParseUI.tsx` — `AnnotateView`, line ~733
+
+Currently renders with no `onClick`.
+
+- [ ] Import `useAnnotationStore` (if not already done from Task 2)
+- [ ] Get `selectedRegion` from `usePlaybackStore` (has `start` and `end` from the active WaveSurfer region)
+- [ ] On save: call `annotationStore.setInterval(speaker, 'ipa', { start, end, text: ipa })` and `annotationStore.setInterval(speaker, 'ortho', { start, end, text: ortho })`
+- [ ] Also write a `concept` tier interval: `annotationStore.setInterval(speaker, 'concept', { start, end, text: concept.name })`
+- [ ] Then call `annotationStore.saveSpeaker(speaker)` to persist
+
+Check `src/stores/annotationStore.ts` for the exact method signatures before implementing.
+
+---
+
+### TASK 4 — Wire "Mark Done" button
+**File:** `src/ParseUI.tsx` — `AnnotateView`, line ~736
+
+- [ ] On click: call `tagStore.tagConcept('confirmed', concept.id.toString())`
+- [ ] Visually: the concept dot in the sidebar will update automatically since `concepts` is derived from `getTagsForConcept`
+
+---
+
+### TASK 5 — Fix "Missing" badge — make it reactive
+**File:** `src/ParseUI.tsx` — `AnnotateView`, line 690–692
+
+Currently hardcoded `Missing` badge always shows.
+
+- [ ] Check `annotationStore.records[speaker]?.tiers.ipa.intervals` — if there is at least one interval whose time range overlaps with a concept tier interval for `concept.name`, consider it annotated
+- [ ] If annotated: show a green "Annotated" or "Done" badge instead
+- [ ] If not annotated: keep the rose "Missing" badge
+
+---
+
+### TASK 6 — Stale comment cleanup in `AnnotateView`
+**File:** `src/ParseUI.tsx`
+
+- [ ] Lines 451–468: delete the entire JSDoc block that says `The waveform below is a styled mock...` — the hook is already wired
+- [ ] Lines 592–595: delete the `{/* TODO: Replace mock... */}` comment block — already done
+- [ ] Line 127 (inside `AIChat` `useEffect`): change `[messages, minimized]` dependency to `[chatSession.messages, minimized]`
+
+---
+
+## Priority 2 — Compare Mode Real Data
+
+### TASK 7 — Replace `MOCK_FORMS` with real annotation data
+**File:** `src/ParseUI.tsx` — Compare mode, line ~1158
+
+`MOCK_FORMS` is a hardcoded array of 5 speaker forms. It needs to be derived from `annotationStore`.
+
+- [ ] Inside `ParseUI`, after stores are set up, build `speakerForms` with `useMemo`:
+  - For each speaker in `selectedSpeakers`:
+    - Get `annotationStore.records[speaker]`
+    - Find IPA interval(s) for the current concept (match via concept tier)
+    - Count utterance intervals for that concept
+    - Get `arabicSim` and `persianSim` from `enrichmentStore` (check `src/stores/enrichmentStore.ts` for shape)
+    - Get cognate group from enrichments (if available, else `'—'`)
+    - Get `flagged` from tagStore — is the concept tagged `problematic`?
+  - Return `SpeakerForm[]`
+- [ ] Replace `MOCK_FORMS.filter(f => selectedSpeakers.includes(f.speaker)).map(...)` at line 1158 with `speakerForms.map(...)`
+- [ ] If enrichment data isn't available for a speaker+concept, show `0.00` similarity and `'—'` cognate — do not crash
+
+---
+
+### TASK 8 — Wire Reference forms from `enrichmentStore`
+**File:** `src/ParseUI.tsx` — Compare mode, lines 1122–1140
+
+Currently hardcoded Arabic رماد and Persian خاکستر.
+
+- [ ] Check `src/stores/enrichmentStore.ts` for what data is available per concept
+- [ ] Get enrichments for the current `concept.name` from the store
+- [ ] Replace the hardcoded Arabic script + IPA with real values from enrichments
+- [ ] Replace the hardcoded Persian script + IPA with real values from enrichments
+- [ ] If enrichments not available for this concept: show a "No reference data" placeholder — do not crash
+- [ ] Wire the `Volume2` audio play buttons to play a reference audio file if one exists in enrichments (or leave as no-op with a `title="Reference audio not available"` if not)
+
+---
+
+### TASK 9 — Wire Accept / Flag concept buttons
+**File:** `src/ParseUI.tsx` — Compare mode, lines 1113–1118
+
+- [ ] **Flag button** (line 1113): `onClick={() => tagStore.tagConcept('problematic', concept.id.toString())}`
+- [ ] **Accept concept button** (line 1116): `onClick={() => tagStore.tagConcept('confirmed', concept.id.toString())}`
+- [ ] Make the buttons visually reflect current state — if already confirmed, show filled/active state; same for flagged
+
+---
+
+### TASK 10 — Wire Notes field persistence
+**File:** `src/ParseUI.tsx` — Compare mode, line ~1220
+
+Currently `notes` is local `useState`. It needs to persist.
+
+- [ ] On blur (or debounced onChange): write to `annotationStore` — either as a dedicated `notes` tier interval or as metadata on the record
+- [ ] On concept/speaker change: load the saved note for that concept (empty string if none)
+- [ ] Check whether `annotationStore` has a mechanism for free-form notes — if not, store in `localStorage` keyed by `concept.id` as a minimal interim solution
+
+---
+
+### TASK 11 — Wire per-speaker Flag toggle in Compare table
+**File:** `src/ParseUI.tsx` — Compare mode, line ~1176
+
+Currently the flag button renders `f.flagged` from `MOCK_FORMS` with no `onClick`.
+
+- [ ] After TASK 7, `f.flagged` comes from `tagStore`. Wire the button `onClick` to toggle:
+  - If flagged: `tagStore.untagConcept('problematic', concept.id.toString())`
+  - If not: `tagStore.tagConcept('problematic', concept.id.toString())`
+
+---
+
+### TASK 12 — Wire `reviewed` count
+**File:** `src/ParseUI.tsx` — line 864
+
+Currently `const reviewed = 0`.
+
+- [ ] Compute: count how many concepts in the current concept list have at least one confirmed tag (`tagStore.getTagsForConcept(c.id.toString()).some(t => t.id === 'confirmed')`)
+- [ ] Use that as `reviewed`
+
+---
+
+## Priority 3 — Actions Menu (Pipeline Triggers)
+
+### TASK 13 — Wire Actions menu items to real API endpoints
+**File:** `src/ParseUI.tsx` — lines 966–988
+
+All items currently just call `setActionsMenuOpen(false)`.
+
+Wire each to its real endpoint using `fetch` + poll pattern (same as used in legacy `parse.html`):
+
+| Label | Endpoint | Notes |
+|---|---|---|
+| Import Speaker Data… | Open onboarding modal or `POST /api/import/upload` | Can be a modal trigger for now |
+| Run Audio Normalization | `POST /api/normalize` + poll `GET /api/normalize/status/<jobId>` | Show progress in topbar |
+| Run Orthographic STT | `POST /api/stt` with `{ model: 'razhan' }` + poll | Show progress |
+| Run IPA Transcription | `POST /api/pipeline/run` with `{ ipa_only: true }` + poll | Show progress |
+| Run Full Pipeline | Sequential: normalize → STT → IPA | Client-side orchestration |
+| Run Cross-Speaker Match | `POST /api/compute/contact-lexemes` | Uses `useComputeJob` |
+| Load Decisions | File input → parse JSON → merge into stores | |
+| Save Decisions | `GET /api/export/lingpy` → download TSV | |
+| Reset Project | Confirmation modal → clear all stores + localStorage | |
+
+- [ ] Add a `runningAction` local state to show inline progress in the topbar area
+- [ ] Each action should: close the dropdown → show progress → complete/error
+
+---
+
+## Priority 4 — Compare Compute
+
+### TASK 14 — Wire Compute panel Run + Refresh buttons
+**File:** `src/ParseUI.tsx` — right panel, lines 1351–1357
+
+- [ ] Import `useComputeJob` from `src/hooks/useComputeJob.ts`
+- [ ] **Run button**: call `useComputeJob` to `POST /api/compute/contact-lexemes` for current selectedSpeakers + concept
+- [ ] **Refresh button**: re-fetch enrichments from store
+- [ ] Show a loading spinner or disabled state while job is running
+
+---
+
+### TASK 15 — Wire Cognate decision buttons
+**File:** `src/ParseUI.tsx` — lines 1189–1201
+
+Accept / Split / Merge / Cycle — these modify cognate groupings in the compute result.
+
+- [ ] Check what API endpoints exist for cognate decisions (look in `python/server.py` for `/api/decisions` or similar)
+- [ ] Wire Accept: save current grouping as a decision
+- [ ] Wire Split / Merge / Cycle: mutate cognate groupings locally and persist to decisions JSON
+- [ ] If no backend endpoint exists yet: write to `localStorage` keyed by `concept.id` as interim
+
+---
+
+## Priority 5 — Tags Mode
+
+### TASK 16 — Wire concept checkboxes in ManageTagsView
+**File:** `src/ParseUI.tsx` — `ManageTagsView` component, line ~433
+
+- [ ] Add local `checkedConcepts: Set<string>` state inside `ManageTagsView`
+- [ ] `onChange` on each checkbox: toggle that concept's id in `checkedConcepts`
+- [ ] Pre-check concepts that already have `selectedTag` applied: check if `selectedTag.id` is in `tagStore.getTagsForConcept(c.id.toString()).map(t => t.id)`
+- [ ] **Apply to selected button** (line 411): for each id in `checkedConcepts`, call `tagConcept(selectedTag.id, conceptId)` — pass `tagConcept` + `untagConcept` as props from `ParseUI`
+- [ ] **Clear selection button** (line 408): reset `checkedConcepts` to empty Set
+
+---
+
+## Priority 6 — Spectrogram (post-thesis, low urgency)
+
+### TASK 17 — Port spectrogram worker to TypeScript
+**Files:** New: `src/workers/spectrogram-worker.ts`, `src/hooks/useSpectrogram.ts`
+
+The legacy worker lives at `parse/js/shared/spectrogram-worker.js` (273 lines, STFT/FFT pipeline).
+
+- [ ] Copy logic to `src/workers/spectrogram-worker.ts` — add TypeScript types
+- [ ] Create `src/hooks/useSpectrogram.ts` — manages the Worker lifecycle, posts PCM data, receives `Uint8ClampedArray` image data
+- [ ] In `AnnotateView`: when `spectroOn` is true, get the decoded audio buffer from WaveSurfer (`wsRef.current?.getDecodedData()`), post it to the worker, draw result on a `<canvas>` overlay inside the waveform container
+- [ ] Replace the CSS gradient placeholder with the real canvas
+
+---
+
+## Right rail Save buttons (Annotate + Compare)
+
+### TASK 18 — Wire right rail Save buttons
+**File:** `src/ParseUI.tsx`
+
+- [ ] **Annotate mode right rail "Save annotations"** (line ~1471): same as TASK 3 — call `annotationStore.saveSpeaker(speaker)`
+- [ ] **Compare mode right rail "Save decisions"** (line ~1407): same as TASK 15 — persist decisions JSON
+- [ ] **Compare mode right rail "Load decisions"** (line ~1405): same as TASK 13 Load Decisions
+
+---
+
+## Verification checklist after all tasks done
+
+```bash
+# In /home/lucas/gh/ardeleanlucas/parse
+npm run check          # must be 0 errors
+npm run test -- --run  # must be >=102 passing
+```
+
+Then open in browser at `http://localhost:5173`:
+- [ ] Switch to Annotate mode → select a speaker → waveform loads real audio
+- [ ] IPA field pre-populates if annotation exists
+- [ ] Type IPA → Save → reload → IPA still there
+- [ ] Mark Done → concept dot turns green in sidebar
+- [ ] Switch to Compare mode → speaker forms table shows real IPA (not ash/bark placeholder data)
+- [ ] Accept concept → confirmed badge updates
+- [ ] Tags mode → check a concept → Apply to selected → concept dot updates
+- [ ] Actions menu → Run Audio Normalization → progress shows in topbar
+
+---
+
+> **parse-gpt:** Work task by task. Do not batch multiple tasks into one commit.
+> Commit message format: `feat(parseui): wire <task name> (#<task number>)`
+> Open a PR to `feat/annotate-ui-redesign` — do not merge to `main`.

--- a/docs/plans/react-vite-pivot.md
+++ b/docs/plans/react-vite-pivot.md
@@ -43,6 +43,7 @@ with a React + Vite frontend, keeping the Python backend (port 8766) completely 
 | B9 Browser integration | — | PENDING Lucas | manual |
 | agent-gpt EnrichmentsPanel rebase | feat/compare-react | PENDING agent-gpt | rebase onto ad09bcf |
 | Phase C merge | feat/parse-react-vite | BLOCKED — wait for agent-gpt rebase | — |
+| **UI Redesign — ParseUI unified shell** | **feat/annotate-ui-redesign** | **DONE fd955cc** | **tsc clean** |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "parse-react",
       "version": "2.0.0-alpha",
       "dependencies": {
+        "lucide-react": "^1.8.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.0",
@@ -20,10 +21,26 @@
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "autoprefixer": "^10.4.27",
         "jsdom": "^24.1.0",
+        "postcss": "^8.5.9",
+        "tailwindcss": "^3.4.19",
         "typescript": "^5.4.5",
         "vite": "^5.2.12",
         "vitest": "^1.6.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -908,6 +925,44 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1631,6 +1686,34 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1659,6 +1742,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
@@ -1670,6 +1790,32 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -1730,6 +1876,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001787",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
@@ -1783,6 +1939,44 @@
         "node": "*"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1794,6 +1988,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/confbox": {
@@ -1823,6 +2027,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cssstyle": {
@@ -1926,6 +2143,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -1935,6 +2159,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -2111,6 +2342,59 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -2126,6 +2410,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fsevents": {
@@ -2223,6 +2521,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/gopd": {
@@ -2344,6 +2655,68 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -2370,6 +2743,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2444,6 +2827,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/local-pkg": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
@@ -2493,6 +2896,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -2530,6 +2942,30 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -2594,6 +3030,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2619,6 +3067,16 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -2655,6 +3113,26 @@
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/onetime": {
       "version": "6.0.0",
@@ -2711,6 +3189,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -2734,6 +3219,39 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/pkg-types": {
       "version": "1.3.1",
@@ -2783,6 +3301,140 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -2827,6 +3479,27 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/react": {
@@ -2904,12 +3577,67 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -2962,6 +3690,30 @@
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3102,6 +3854,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -3109,12 +3897,121 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tinypool": {
       "version": "0.8.4",
@@ -3134,6 +4031,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tough-cookie": {
@@ -3164,6 +4074,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
@@ -3256,6 +4173,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -4,22 +4,26 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "lucide-react": "^1.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.0",
-    "zustand": "^4.5.2",
-    "wavesurfer.js": "^7.8.0"
+    "wavesurfer.js": "^7.8.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "autoprefixer": "^10.4.27",
+    "jsdom": "^24.1.0",
+    "postcss": "^8.5.9",
+    "tailwindcss": "^3.4.19",
     "typescript": "^5.4.5",
     "vite": "^5.2.12",
-    "vitest": "^1.6.0",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.5.2",
-    "jsdom": "^24.1.0"
+    "vitest": "^1.6.0"
   },
   "scripts": {
     "dev": "vite",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,10 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { AnnotateMode } from "./components/annotate/AnnotateMode";
-import { CompareMode } from "./components/compare/CompareMode";
+import { BrowserRouter } from "react-router-dom";
+import { ParseUI } from "./ParseUI";
 
 export function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<AnnotateMode />} />
-        <Route path="/compare" element={<CompareMode />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
+      <ParseUI />
     </BrowserRouter>
   );
 }

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1,0 +1,1482 @@
+import React, { useState, useMemo, useRef, useEffect } from 'react';
+import {
+  Search, ChevronLeft, ChevronRight, Check, Flag, Split, GitMerge,
+  RotateCw, Play, RefreshCw, Save, Upload, Sparkles,
+  Layers, ChevronDown, ChevronUp, Plus, X, AlertCircle,
+  CheckCircle2, ArrowUpDown, Volume2, Filter, Send, Minus,
+  GripHorizontal, Bot, User, Database, Users as UsersIcon, Cpu,
+  PanelRightClose, Tag, Tags, Import, AudioLines, Type, Mic,
+  Workflow, Network, Trash2, ChevronDown as CDown,
+  Video, Scissors, Activity, SlidersHorizontal,
+  Pause, SkipBack, SkipForward, ZoomIn, ZoomOut, MessageSquare, Anchor,
+  Sun, Moon
+} from 'lucide-react';
+
+type TagState = 'all' | 'untagged' | 'review' | 'confirmed' | 'problematic';
+type ConceptTag = 'untagged' | 'review' | 'confirmed' | 'problematic';
+type ModeTab = 'all' | 'unreviewed' | 'flagged' | 'borrowings';
+type AppMode = 'annotate' | 'compare' | 'tags';
+
+interface LingTag {
+  id: string; name: string; color: string; dotClass: string; count: number;
+}
+
+interface Concept { id: number; name: string; tag: ConceptTag; }
+interface SpeakerForm {
+  speaker: string; ipa: string; utterances: number;
+  arabicSim: number; persianSim: number;
+  cognate: 'A' | 'B' | 'C' | '—'; flagged: boolean;
+}
+interface ChatMessage {
+  id: number; role: 'user' | 'ai'; content: string; streaming?: boolean;
+}
+
+const CONCEPTS: Concept[] = [
+  'ash','bark','big','bird','black','blood','bone','bride','claw','cloud',
+  'cold','dog','dry','ear','egg','eye','feather','finger','fire','fish',
+  'five','fly','foot','four','full','good','green','hair','hand','head',
+  'heart','honey','horn','hot','i','knee','leaf','liver','long','louse',
+  'man','milk','moon','mouth','name','neck','new','night','nose','not',
+  'one','person','rain','red','road','root','round','salt','sand','say',
+  'see','seed','sit','skin','sleep','small','smoke','stand','star','stone',
+  'sun','swim','tail','that','this','three','tongue','tooth','tree','two',
+  'warm','water'
+].map((name, i) => ({
+  id: i + 1, name,
+  tag: (['untagged','review','confirmed','problematic','untagged','confirmed'][i % 6]) as ConceptTag,
+}));
+
+const SPEAKERS = ['Fail01','Fail02','Kzn03','Kzn04','Shz05','Shz06','Tbr07','Tbr08','Isf09','Isf10','Teh11'];
+
+const MOCK_FORMS: SpeakerForm[] = [
+  { speaker: 'Fail01', ipa: 'ramaːd',   utterances: 3, arabicSim: 0.92, persianSim: 0.41, cognate: 'A', flagged: false },
+  { speaker: 'Kzn03',  ipa: 'xɑːkestæɾ', utterances: 2, arabicSim: 0.18, persianSim: 0.96, cognate: 'B', flagged: false },
+  { speaker: 'Shz05',  ipa: 'xakestær',  utterances: 4, arabicSim: 0.20, persianSim: 0.94, cognate: 'B', flagged: false },
+  { speaker: 'Tbr07',  ipa: 'ramɑd',     utterances: 1, arabicSim: 0.88, persianSim: 0.39, cognate: 'A', flagged: true  },
+  { speaker: 'Isf09',  ipa: 'xɑkestaɾ',  utterances: 2, arabicSim: 0.21, persianSim: 0.93, cognate: 'B', flagged: false },
+];
+
+const tagDot: Record<ConceptTag, string> = {
+  untagged: 'bg-slate-300', review: 'bg-amber-400',
+  confirmed: 'bg-emerald-500', problematic: 'bg-rose-500',
+};
+const simColor = (v: number) =>
+  v >= 0.8 ? 'text-emerald-600' : v >= 0.5 ? 'text-amber-600' : 'text-slate-400';
+const simBar = (v: number) =>
+  v >= 0.8 ? 'bg-emerald-500' : v >= 0.5 ? 'bg-amber-400' : 'bg-slate-300';
+
+const SimBar: React.FC<{ value: number }> = ({ value }) => (
+  <div className="flex items-center gap-2">
+    <div className="h-1.5 w-14 rounded-full bg-slate-100 overflow-hidden">
+      <div className={`h-full rounded-full ${simBar(value)}`} style={{ width: `${value * 100}%` }} />
+    </div>
+    <span className={`text-xs font-mono tabular-nums ${simColor(value)}`}>{value.toFixed(2)}</span>
+  </div>
+);
+
+const Pill: React.FC<{ children: React.ReactNode; tone?: 'slate'|'emerald'|'indigo' }> = ({ children, tone='slate' }) => {
+  const tones: Record<string,string> = {
+    slate: 'bg-slate-100 text-slate-600 ring-slate-200',
+    emerald: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    indigo: 'bg-indigo-50 text-indigo-700 ring-indigo-200',
+  };
+  return <span className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11px] font-medium ring-1 ${tones[tone]}`}>{children}</span>;
+};
+
+const SectionCard: React.FC<{ title: string; aside?: React.ReactNode; children: React.ReactNode }> = ({ title, aside, children }) => (
+  <section className="rounded-xl border border-slate-200/80 bg-white shadow-[0_1px_0_rgba(15,23,42,0.03)]">
+    <header className="flex items-center justify-between px-5 pt-4 pb-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-[0.09em] text-slate-500">{title}</h3>
+      {aside}
+    </header>
+    <div className="px-5 pb-5">{children}</div>
+  </section>
+);
+
+// ---------- AI Chat Panel ----------
+interface AIChatProps {
+  height: number;
+  minimized: boolean;
+  onResizeStart: (e: React.MouseEvent) => void;
+  onMinimize: () => void;
+  conceptName: string;
+  conceptId: number;
+  speakerCount: number;
+}
+
+const QUICK_ACTIONS = [
+  'Analyze cognates',
+  'Explain why Fail01 diverges',
+  'Suggest borrowings',
+  'Help decide grouping',
+  'Compare IPA alignments',
+];
+
+const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMinimize, conceptName, conceptId, speakerCount }) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { id: 1, role: 'ai', content: `Hi — I'm looking at concept "${conceptName}" across ${speakerCount} speakers. Fail01 /ramaːd/ stands out from the Persian cluster with a 0.92 Arabic similarity. Want me to investigate it as a potential borrowing?` },
+  ]);
+  const [input, setInput] = useState('');
+  const [collapsedInput, setCollapsedInput] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!minimized) {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+    }
+  }, [messages, minimized]);
+
+  const send = (text: string) => {
+    const q = text.trim();
+    if (!q) return;
+    const uid = Date.now();
+    setMessages(m => [...m, { id: uid, role: 'user', content: q }]);
+    setInput('');
+    setCollapsedInput('');
+    const aid = uid + 1;
+    setMessages(m => [...m, { id: aid, role: 'ai', content: '', streaming: true }]);
+    const full = `Analyzing "${conceptName}" across the selected speakers. Based on current cognate groupings, I'd recommend splitting Fail01 and Tbr07 (Group A, /ramaːd/-type) from the Persian cluster (Group B, /xɑkestær/-type). The 0.92 Arabic similarity on Fail01 strongly suggests an Arabic borrowing rather than a cognate.`;
+    let i = 0;
+    const tick = () => {
+      i += 3;
+      setMessages(m => m.map(msg => msg.id === aid ? { ...msg, content: full.slice(0, i), streaming: i < full.length } : msg));
+      if (i < full.length) setTimeout(tick, 18);
+    };
+    setTimeout(tick, 250);
+  };
+
+  // ---------- Collapsed: thin command bar ----------
+  if (minimized) {
+    return (
+      <div
+        className="relative flex h-14 shrink-0 items-center border-t border-slate-200 bg-slate-50/80 backdrop-blur-sm transition-all duration-300 shadow-[0_-1px_0_rgba(15,23,42,0.02)]"
+      >
+        <form
+          onClick={() => onMinimize()}
+          onSubmit={e => { e.preventDefault(); if (collapsedInput.trim()) { onMinimize(); setTimeout(() => send(collapsedInput), 250); } }}
+          className="mx-auto flex w-full max-w-4xl items-center gap-3 px-6"
+        >
+          <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">PARSE AI</span>
+          <div className="h-4 w-px bg-slate-200"/>
+          <input
+            value={collapsedInput}
+            onChange={e => setCollapsedInput(e.target.value)}
+            onClick={e => e.stopPropagation()}
+            onFocus={() => onMinimize()}
+            placeholder={`Ask PARSE AI about ${conceptName} (#${conceptId})…`}
+            className="flex-1 bg-transparent text-[13px] text-slate-700 placeholder:text-slate-400 focus:outline-none"
+          />
+          <button
+            type="submit"
+            onClick={e => e.stopPropagation()}
+            className="grid h-8 w-8 place-items-center rounded-md text-slate-400 transition hover:bg-slate-200/60 hover:text-slate-700"
+            title="Send"
+          >
+            <Send className="h-3.5 w-3.5"/>
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  // ---------- Expanded: elevated panel ----------
+  return (
+    <div
+      className="relative flex flex-col overflow-hidden border-t-2 border-slate-200 bg-indigo-50/40 backdrop-blur-md transition-[height] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] shadow-[0_-12px_40px_-12px_rgba(15,23,42,0.18)]"
+      style={{ height }}
+    >
+      {/* Resize handle */}
+      <div
+        onMouseDown={onResizeStart}
+        className="group absolute inset-x-0 top-0 z-10 flex h-2.5 cursor-ns-resize items-center justify-center"
+      >
+        <div className="h-1 w-12 rounded-full bg-slate-300 transition group-hover:bg-slate-500"/>
+      </div>
+
+      {/* Header */}
+      <div className="flex shrink-0 items-center justify-between border-b border-slate-200/70 px-6 pt-4 pb-3">
+        <div>
+          <div className="text-[13px] font-semibold tracking-tight text-slate-900">PARSE AI</div>
+          <div className="mt-0.5 text-[11px] text-slate-500">
+            Asking about: <span className="font-semibold text-slate-700">{conceptName}</span>
+            <span className="font-mono text-slate-400"> (#{conceptId})</span>
+            <span className="mx-1.5 text-slate-300">•</span>
+            {speakerCount} speakers selected
+          </div>
+        </div>
+        <button
+          onClick={onMinimize}
+          title="Minimize"
+          className="grid h-7 w-7 place-items-center rounded-md text-slate-400 hover:bg-white/60 hover:text-slate-700"
+        >
+          <ChevronDown className="h-4 w-4"/>
+        </button>
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="mx-auto max-w-3xl space-y-3">
+          {messages.map(m => (
+            <div key={m.id} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <div className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed ${
+                m.role === 'user'
+                  ? 'bg-slate-900 text-white'
+                  : 'bg-white text-slate-800 ring-1 ring-slate-200/70 shadow-sm'
+              }`}>
+                {m.content}
+                {m.streaming && <span className="ml-0.5 inline-block h-3.5 w-[2px] translate-y-0.5 animate-pulse bg-slate-500"/>}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Quick actions + input */}
+      <div className="shrink-0 border-t border-slate-200/70 bg-white/50 px-6 py-3 backdrop-blur-sm">
+        <div className="mx-auto max-w-3xl">
+          <div className="mb-2 flex flex-wrap gap-1.5">
+            {QUICK_ACTIONS.map(a => (
+              <button
+                key={a}
+                onClick={() => send(a)}
+                className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900"
+              >
+                {a}
+              </button>
+            ))}
+          </div>
+          <form
+            onSubmit={e => { e.preventDefault(); send(input); }}
+            className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 focus-within:border-slate-400 focus-within:ring-2 focus-within:ring-slate-100"
+          >
+            <input
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              placeholder={`Ask PARSE AI about ${conceptName}…`}
+              className="flex-1 bg-transparent text-[13px] text-slate-800 placeholder:text-slate-400 focus:outline-none"
+              autoFocus
+            />
+            <button
+              type="submit"
+              disabled={!input.trim()}
+              className="inline-flex items-center gap-1 rounded-lg bg-slate-900 px-3 py-1.5 text-[11px] font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+            >
+              Send <Send className="h-3 w-3"/>
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------- Manage Tags View ----------
+interface ManageTagsProps {
+  tags: LingTag[];
+  onCreateTag: (name: string, color: string) => void;
+  tagSearch: string; setTagSearch: (s: string) => void;
+  newTagName: string; setNewTagName: (s: string) => void;
+  newTagColor: string; setNewTagColor: (s: string) => void;
+  showUntagged: boolean; setShowUntagged: (b: boolean) => void;
+  selectedTagId: string | null; setSelectedTagId: (s: string | null) => void;
+  conceptSearch: string; setConceptSearch: (s: string) => void;
+}
+
+const SWATCHES = ['#6366f1','#10b981','#f59e0b','#f43f5e','#8b5cf6','#06b6d4','#ec4899','#64748b'];
+
+const ManageTagsView: React.FC<ManageTagsProps> = ({
+  tags, onCreateTag, tagSearch, setTagSearch, newTagName, setNewTagName,
+  newTagColor, setNewTagColor, showUntagged, setShowUntagged,
+  selectedTagId, setSelectedTagId, conceptSearch, setConceptSearch
+}) => {
+  const filteredTags = tags.filter(t => t.name.toLowerCase().includes(tagSearch.toLowerCase()));
+  const selectedTag = tags.find(t => t.id === selectedTagId);
+  const filteredConcepts = CONCEPTS.filter(c => c.name.toLowerCase().includes(conceptSearch.toLowerCase()));
+
+  return (
+    <div className="flex flex-1 min-h-0 bg-slate-50">
+      {/* LEFT: tags panel */}
+      <div className="w-[360px] shrink-0 overflow-y-auto border-r border-slate-200 bg-white">
+        <div className="p-6">
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">Linguistic tags</h2>
+          <p className="mt-1 text-xs text-slate-400">Organize concepts by review state, borrowing, or custom labels.</p>
+
+          <div className="relative mt-5">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-400"/>
+            <input
+              value={tagSearch}
+              onChange={e => setTagSearch(e.target.value)}
+              placeholder="Filter tags…"
+              className="w-full rounded-lg border border-slate-200 bg-slate-50/60 py-2 pl-9 pr-3 text-xs text-slate-700 placeholder:text-slate-400 focus:border-indigo-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-100"
+            />
+          </div>
+
+          {/* Create new tag */}
+          <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50/40 p-3">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Create tag</div>
+            <div className="mt-2 flex items-center gap-2">
+              <input
+                value={newTagName}
+                onChange={e => setNewTagName(e.target.value)}
+                placeholder="New tag name…"
+                className="flex-1 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-700 placeholder:text-slate-400 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+              />
+              <div className="relative">
+                <div
+                  className="h-7 w-7 rounded-md ring-2 ring-white"
+                  style={{ background: newTagColor, boxShadow: '0 0 0 1px rgb(226 232 240)' }}
+                />
+              </div>
+            </div>
+            <div className="mt-2 flex gap-1.5">
+              {SWATCHES.map(c => (
+                <button
+                  key={c}
+                  onClick={() => setNewTagColor(c)}
+                  className={`h-5 w-5 rounded-full transition ${newTagColor===c ? 'ring-2 ring-offset-1 ring-slate-400' : 'ring-1 ring-slate-200 hover:scale-110'}`}
+                  style={{ background: c }}
+                />
+              ))}
+            </div>
+            <button
+              onClick={() => onCreateTag(newTagName, newTagColor)}
+              disabled={!newTagName.trim()}
+              className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-indigo-600 py-1.5 text-[11px] font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-200"
+            >
+              <Plus className="h-3 w-3"/> Create
+            </button>
+          </div>
+
+          {/* Toggle */}
+          <div className="mt-5 flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2">
+            <span className="text-xs font-medium text-slate-700">Show untagged</span>
+            <button
+              onClick={() => setShowUntagged(!showUntagged)}
+              className={`relative h-5 w-9 rounded-full transition ${showUntagged ? 'bg-indigo-600' : 'bg-slate-300'}`}
+            >
+              <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all ${showUntagged ? 'left-4' : 'left-0.5'}`}/>
+            </button>
+          </div>
+
+          {/* Tag list */}
+          <div className="mt-5">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Tags · {filteredTags.length}</div>
+            <div className="mt-2 space-y-1">
+              {filteredTags.map(t => {
+                const active = selectedTagId === t.id;
+                return (
+                  <button
+                    key={t.id}
+                    onClick={() => setSelectedTagId(t.id)}
+                    className={`group flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition ${active ? 'bg-indigo-50 ring-1 ring-indigo-200' : 'hover:bg-slate-50'}`}
+                  >
+                    <span className="h-2.5 w-2.5 rounded-full ring-2 ring-white" style={{ background: t.color, boxShadow: '0 0 0 1px rgb(226 232 240)' }}/>
+                    <span className={`flex-1 text-[13px] ${active ? 'font-semibold text-indigo-900' : 'font-medium text-slate-700'}`}>{t.name}</span>
+                    <span className="rounded-md bg-slate-100 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">{t.count}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* RIGHT: main content */}
+      <div className="flex-1 overflow-y-auto">
+        {!selectedTag ? (
+          <div className="grid h-full place-items-center px-10 py-20">
+            <div className="text-center">
+              <div className="mx-auto grid h-14 w-14 place-items-center rounded-2xl bg-gradient-to-br from-indigo-50 to-violet-50 ring-1 ring-indigo-100">
+                <Tag className="h-6 w-6 text-indigo-500"/>
+              </div>
+              <h3 className="mt-5 text-lg font-semibold text-slate-900">Select a tag to assign concepts</h3>
+              <p className="mt-2 max-w-md text-sm text-slate-500">
+                Choose a linguistic tag on the left to browse and bulk-assign it across your 82 concepts.
+                You can also create a new tag above.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="px-10 py-8">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <span className="h-3 w-3 rounded-full ring-2 ring-white" style={{ background: selectedTag.color, boxShadow: '0 0 0 1px rgb(226 232 240)' }}/>
+                <h1 className="text-2xl font-semibold tracking-tight text-slate-900">{selectedTag.name}</h1>
+                <Pill tone="indigo">{selectedTag.count} concepts</Pill>
+              </div>
+              <div className="flex gap-2">
+                <button className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50">
+                  <X className="h-3.5 w-3.5"/> Clear selection
+                </button>
+                <button className="inline-flex items-center gap-1.5 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-700">
+                  <Check className="h-3.5 w-3.5"/> Apply to selected
+                </button>
+              </div>
+            </div>
+
+            <div className="relative mt-6">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"/>
+              <input
+                value={conceptSearch}
+                onChange={e => setConceptSearch(e.target.value)}
+                placeholder="Search concepts to assign…"
+                className="w-full rounded-xl border border-slate-200 bg-white py-2.5 pl-10 pr-4 text-sm text-slate-700 placeholder:text-slate-400 focus:border-indigo-300 focus:outline-none focus:ring-4 focus:ring-indigo-50"
+              />
+            </div>
+
+            <div className="mt-6 grid grid-cols-2 gap-2 lg:grid-cols-3 xl:grid-cols-4">
+              {filteredConcepts.map(c => (
+                <label
+                  key={c.id}
+                  className="group flex cursor-pointer items-center gap-3 rounded-xl border border-slate-200 bg-white p-3 transition hover:border-indigo-300 hover:shadow-sm"
+                >
+                  <input type="checkbox" className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"/>
+                  <span className={`h-1.5 w-1.5 rounded-full ${tagDot[c.tag]}`}/>
+                  <span className="flex-1 text-sm font-medium text-slate-800">{c.name}</span>
+                  <span className="font-mono text-[10px] text-slate-300">#{c.id}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ---------- Annotate View ----------
+/**
+ * AnnotateView — full-page annotation workspace.
+ *
+ * The waveform below is a styled mock that visually mimics wavesurfer.js v7.8.0.
+ * To replace with the real implementation:
+ *
+ *   // TODO: Replace mock with real hook
+ *   import { useWaveSurfer } from 'src/hooks/useWaveSurfer';
+ *   const containerRef = useRef<HTMLDivElement>(null);
+ *   const { wavesurfer, isPlaying, currentTime, duration, play, pause,
+ *           loadAudio, addRegion, zoom } = useWaveSurfer(containerRef, {
+ *     plugins: [RegionsPlugin, TimelinePlugin],
+ *     waveColor: '#c7d2fe',
+ *     progressColor: '#4f46e5',
+ *     cursorColor: '#0f172a',
+ *   });
+ *
+ * The real hook (src/hooks/useWaveSurfer.ts) mounts WaveSurfer into a plain
+ * <div ref={containerRef}/> and wires up RegionsPlugin + TimelinePlugin.
+ *
+ * Spectrogram: the Spectrogram toggle below should later be wired to a worker-
+ * backed overlay. See src/workers/spectrogram-worker.ts — plan is a dedicated
+ * useSpectrogram(containerRef) hook that posts PCM windows to the worker and
+ * draws an FFT heatmap on a sibling canvas.
+ */
+
+interface AnnotateViewProps {
+  concept: Concept;
+  speaker: string;
+  totalConcepts: number;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+// Deterministic pseudo-waveform (stable per render)
+const WAVE_BARS = Array.from({ length: 220 }, (_, i) => {
+  const x = i / 220;
+  const env = Math.sin(x * Math.PI); // rise-and-fall envelope
+  const noise = Math.abs(Math.sin(i * 1.9) + Math.sin(i * 0.37) * 0.8 + Math.sin(i * 7.1) * 0.4);
+  return Math.max(0.08, Math.min(1, env * 0.85 * noise));
+});
+
+// Mock segmented regions on the virtual timeline
+const REGIONS = [
+  { id: 'r1', start: 0.08, end: 0.18, label: 'one',   color: 'rgba(99,102,241,0.25)',  ring: 'rgba(99,102,241,0.7)'  },
+  { id: 'r2', start: 0.26, end: 0.41, label: 'two',   color: 'rgba(16,185,129,0.22)',  ring: 'rgba(16,185,129,0.7)'  },
+  { id: 'r3', start: 0.52, end: 0.66, label: 'three', color: 'rgba(244,114,182,0.22)', ring: 'rgba(244,114,182,0.7)' },
+  { id: 'r4', start: 0.74, end: 0.88, label: 'four',  color: 'rgba(251,191,36,0.25)',  ring: 'rgba(251,191,36,0.7)'  },
+];
+
+const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConcepts, onPrev, onNext }) => {
+  const [ipa, setIpa] = useState('');
+  const [ortho, setOrtho] = useState('');
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playhead, setPlayhead] = useState(0.32); // 0..1 fraction
+  const [zoom, setZoom] = useState(1);
+  const [spectroOn, setSpectroOn] = useState(false);
+  const [activeRegion, setActiveRegion] = useState<string | null>('r2');
+  const [hoverRegion, setHoverRegion] = useState<string | null>(null);
+  const [lexAnchor, setLexAnchor] = useState<'word' | 'concept'>('concept');
+  const waveRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+
+  // Mock duration / current time derived from playhead
+  const duration = 4.82;
+  const currentTime = playhead * duration;
+
+  const fmt = (t: number) => {
+    const m = Math.floor(t / 60).toString().padStart(2, '0');
+    const s = Math.floor(t % 60).toString().padStart(2, '0');
+    const ms = Math.floor((t * 100) % 100).toString().padStart(2, '0');
+    return `${m}:${s}.${ms}`;
+  };
+
+  const handleSeek = (e: React.MouseEvent) => {
+    const rect = waveRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = (e.clientX - rect.left) / rect.width;
+    setPlayhead(Math.max(0, Math.min(1, x)));
+  };
+
+  const startDrag = (e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    handleSeek(e);
+    const onMove = (ev: MouseEvent) => {
+      if (!draggingRef.current || !waveRef.current) return;
+      const rect = waveRef.current.getBoundingClientRect();
+      const x = (ev.clientX - rect.left) / rect.width;
+      setPlayhead(Math.max(0, Math.min(1, x)));
+    };
+    const onUp = () => {
+      draggingRef.current = false;
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  return (
+    <main className="flex-1 overflow-y-auto bg-slate-50">
+      {/* ======= WAVEFORM / VIRTUAL TIMELINE ======= */}
+      <section className="border-b border-slate-200 bg-white">
+        {/* Toolbar */}
+        <div className="flex items-center justify-between border-b border-slate-100 px-5 py-2.5">
+          <div className="flex items-center gap-1">
+            <button title="Previous segment" className="grid h-7 w-7 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800">
+              <SkipBack className="h-3.5 w-3.5"/>
+            </button>
+            <button title="Next segment" className="grid h-7 w-7 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800">
+              <SkipForward className="h-3.5 w-3.5"/>
+            </button>
+            <div className="mx-2 h-5 w-px bg-slate-200"/>
+            <button onClick={() => setZoom(z => Math.max(0.5, z - 0.25))} title="Zoom out" className="grid h-7 w-7 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800">
+              <ZoomOut className="h-3.5 w-3.5"/>
+            </button>
+            <div className="rounded bg-slate-100 px-2 py-0.5 font-mono text-[10px] text-slate-500">{zoom.toFixed(2)}×</div>
+            <button onClick={() => setZoom(z => Math.min(4, z + 0.25))} title="Zoom in" className="grid h-7 w-7 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800">
+              <ZoomIn className="h-3.5 w-3.5"/>
+            </button>
+            <div className="mx-2 h-5 w-px bg-slate-200"/>
+            {/* Lexical anchor align — word vs concept alignment */}
+            <div className="inline-flex items-center gap-1 rounded-md bg-slate-100 p-0.5" title="Lexical anchor align — snap regions to concept boundaries or individual word anchors">
+              <Anchor className="ml-1 h-3 w-3 text-slate-400"/>
+              <button onClick={() => setLexAnchor('concept')} className={`rounded px-2 py-0.5 text-[10px] font-semibold transition ${lexAnchor==='concept' ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-500'}`}>Concept</button>
+              <button onClick={() => setLexAnchor('word')} className={`rounded px-2 py-0.5 text-[10px] font-semibold transition ${lexAnchor==='word' ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-500'}`}>Word</button>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            {/* Spectrogram toggle — wire to src/workers/spectrogram-worker.ts later */}
+            <button
+              onClick={() => setSpectroOn(v => !v)}
+              title="Toggle spectrogram (worker-backed, coming soon)"
+              className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-semibold transition ${spectroOn ? 'bg-indigo-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:bg-slate-50'}`}
+            >
+              <Activity className="h-3 w-3"/> Spectrogram
+            </button>
+          </div>
+        </div>
+
+        {/* Waveform container */}
+        <div className="relative px-5 pt-4 pb-2">
+          {/* TODO: Replace mock with real hook
+              const { wavesurfer, isPlaying, loadAudio, ... } = useWaveSurfer(containerRef, {
+                plugins: [RegionsPlugin, TimelinePlugin]
+              });
+              <div ref={containerRef} /> will be mounted by WaveSurfer. */}
+          <div
+            ref={waveRef}
+            onMouseDown={startDrag}
+            className="relative h-32 w-full cursor-crosshair select-none overflow-hidden rounded-lg bg-gradient-to-b from-slate-50 to-white ring-1 ring-slate-100"
+            style={{ backgroundImage: 'linear-gradient(to right, rgba(148,163,184,0.08) 1px, transparent 1px)', backgroundSize: `${100/20}% 100%` }}
+          >
+            {/* Optional spectrogram underlay placeholder */}
+            {spectroOn && (
+              <div
+                className="pointer-events-none absolute inset-0 opacity-70"
+                style={{
+                  background: 'repeating-linear-gradient(90deg, rgba(79,70,229,0.35) 0 2px, rgba(236,72,153,0.25) 2px 4px, rgba(16,185,129,0.25) 4px 6px, transparent 6px 8px)',
+                  mixBlendMode: 'multiply',
+                }}
+                title="Spectrogram placeholder — real FFT heatmap via spectrogram-worker.ts"
+              />
+            )}
+
+            {/* Regions overlay */}
+            {REGIONS.map(r => (
+              <div
+                key={r.id}
+                onMouseEnter={() => setHoverRegion(r.id)}
+                onMouseLeave={() => setHoverRegion(null)}
+                onClick={(e) => { e.stopPropagation(); setActiveRegion(r.id); }}
+                className="absolute inset-y-0 cursor-pointer transition-all"
+                style={{
+                  left: `${r.start * 100}%`,
+                  width: `${(r.end - r.start) * 100}%`,
+                  background: r.color,
+                  boxShadow: (activeRegion === r.id || hoverRegion === r.id) ? `inset 0 0 0 2px ${r.ring}` : `inset 0 0 0 1px ${r.ring}`,
+                }}
+              >
+                <div className="absolute left-1 top-1 rounded bg-white/90 px-1.5 py-0.5 font-mono text-[9px] font-semibold text-slate-700 shadow-sm">
+                  {r.label}
+                </div>
+              </div>
+            ))}
+
+            {/* Waveform bars */}
+            <div className="pointer-events-none absolute inset-0 flex items-center px-0.5">
+              {WAVE_BARS.map((h, i) => {
+                const frac = i / WAVE_BARS.length;
+                const played = frac <= playhead;
+                return (
+                  <div
+                    key={i}
+                    className="mx-[0.5px] flex-1 rounded-full"
+                    style={{
+                      height: `${h * 90}%`,
+                      background: played ? '#4f46e5' : '#c7d2fe',
+                    }}
+                  />
+                );
+              })}
+            </div>
+
+            {/* Playhead */}
+            <div
+              className="pointer-events-none absolute inset-y-0 w-[2px] bg-slate-900"
+              style={{ left: `calc(${playhead * 100}% - 1px)` }}
+            >
+              <div className="absolute -top-1 -left-1.5 h-3 w-3 rounded-full bg-slate-900 ring-2 ring-white shadow"/>
+            </div>
+          </div>
+
+          {/* Timeline ruler */}
+          <div className="relative mt-1 h-5 select-none font-mono text-[9px] text-slate-400">
+            {[0, 0.25, 0.5, 0.75, 1].map((f, i) => (
+              <span key={i} className="absolute -translate-x-1/2" style={{ left: `${f * 100}%` }}>
+                {fmt(f * duration)}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ======= CONCEPT HEADER ======= */}
+      <section className="px-8 pt-6">
+        <div className="mx-auto max-w-4xl">
+          <div className="flex items-center gap-3">
+            <button onClick={onPrev} className="grid h-9 w-9 place-items-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:text-slate-800">
+              <ChevronLeft className="h-4 w-4"/>
+            </button>
+            <div className="flex-1">
+              <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wider text-slate-400">
+                Concept <span className="font-mono">#{concept.id}</span> <span>·</span> {concept.id} of {totalConcepts}
+              </div>
+              <div className="mt-0.5 flex items-center gap-3">
+                <h1 className="text-[32px] font-semibold tracking-tight text-slate-900">{concept.name}</h1>
+                <span className="inline-flex items-center gap-1 rounded-md bg-slate-100 px-2 py-0.5 font-mono text-[11px] font-semibold text-slate-700">
+                  {speaker}
+                </span>
+                <span className="inline-flex items-center gap-1 rounded-md bg-rose-50 px-2 py-0.5 text-[11px] font-semibold text-rose-600 ring-1 ring-rose-200">
+                  Missing
+                </span>
+              </div>
+              <div className="mt-1 flex items-center gap-1 font-mono text-[11px] text-slate-400">
+                <span className="text-[9px] uppercase tracking-wider text-slate-400">Source</span>
+                <span className="text-slate-500">{speaker}.wav</span>
+              </div>
+            </div>
+            <button onClick={onNext} className="grid h-9 w-9 place-items-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:text-slate-800">
+              <ChevronRight className="h-4 w-4"/>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* ======= TRANSCRIPTION FIELDS ======= */}
+      <section className="px-8 py-6">
+        <div className="mx-auto max-w-4xl space-y-5">
+          <div>
+            <label className="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-500">IPA Transcription</label>
+            <input
+              value={ipa}
+              onChange={e => setIpa(e.target.value)}
+              placeholder="Enter IPA…"
+              dir="ltr"
+              className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 font-mono text-lg text-slate-900 placeholder:text-slate-300 focus:border-indigo-300 focus:outline-none focus:ring-4 focus:ring-indigo-50"
+            />
+          </div>
+
+          <div>
+            <label className="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-500">Orthographic (Kurdish)</label>
+            <input
+              value={ortho}
+              onChange={e => setOrtho(e.target.value)}
+              placeholder="Enter orthographic form…"
+              dir="rtl"
+              className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 font-serif text-xl text-slate-900 placeholder:text-slate-300 focus:border-indigo-300 focus:outline-none focus:ring-4 focus:ring-indigo-50"
+            />
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-3 pt-2">
+            <button className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700">
+              <Save className="h-4 w-4"/> Save Annotation
+            </button>
+            <button className="inline-flex items-center gap-2 rounded-xl border border-rose-200 bg-white px-5 py-2.5 text-sm font-semibold text-rose-600 transition hover:bg-rose-50">
+              <Check className="h-4 w-4"/> Mark Done
+            </button>
+            <div className="ml-auto text-[11px] text-slate-400">
+              Region <span className="font-mono text-slate-600">{activeRegion ?? '—'}</span> · Anchor: <span className="font-mono text-slate-600">{lexAnchor}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ======= BOTTOM PLAYBACK BAR ======= */}
+      <section className="sticky bottom-0 border-t border-slate-200 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center gap-3 px-8 py-3">
+          <button className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><SkipBack className="h-4 w-4"/></button>
+          <button onClick={() => setPlayhead(p => Math.max(0, p - 0.05))} className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><ChevronLeft className="h-4 w-4"/></button>
+          <button
+            onClick={() => setIsPlaying(p => !p)}
+            className="grid h-10 w-10 place-items-center rounded-full bg-slate-900 text-white shadow-sm hover:bg-slate-700"
+          >
+            {isPlaying ? <Pause className="h-4 w-4"/> : <Play className="h-4 w-4 translate-x-[1px]"/>}
+          </button>
+          <button onClick={() => setPlayhead(p => Math.min(1, p + 0.05))} className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><ChevronRight className="h-4 w-4"/></button>
+          <button className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><SkipForward className="h-4 w-4"/></button>
+
+          <div className="ml-2 font-mono text-[11px] tabular-nums text-slate-500">
+            {fmt(currentTime)} <span className="text-slate-300">/</span> {fmt(duration)}
+          </div>
+
+          <div className="ml-auto flex items-center gap-2">
+            <select className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-600 focus:border-indigo-300 focus:outline-none">
+              <option>0.5x</option>
+              <option>0.75x</option>
+              <option defaultValue="1">1.0x</option>
+              <option>1.25x</option>
+              <option>1.5x</option>
+              <option>2.0x</option>
+            </select>
+            <button className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600 hover:bg-slate-50">
+              <MessageSquare className="h-3 w-3"/> Chat
+            </button>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+};
+
+// ---------- Main Component ----------
+export function ParseUI() {
+  const [query, setQuery] = useState('');
+  const [sortMode, setSortMode] = useState<'az'|'1n'>('1n');
+  const [tagFilter, setTagFilter] = useState<TagState>('all');
+  const [conceptId, setConceptId] = useState(1);
+  const [modeTab, setModeTab] = useState<ModeTab>('all');
+  const [selectedSpeakers, setSelectedSpeakers] = useState<string[]>(['Fail01','Kzn03','Shz05','Tbr07','Isf09']);
+  const [speakerPicker, setSpeakerPicker] = useState('Fail02');
+  const [computeMode, setComputeMode] = useState('cognates');
+  const [notes, setNotes] = useState('');
+  const [borrowingsOpen, setBorrowingsOpen] = useState(true);
+  const [panelOpen, setPanelOpen] = useState(true);
+  const [currentMode, setCurrentMode] = useState<AppMode>('compare');
+  const [modeMenuOpen, setModeMenuOpen] = useState(false);
+  const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
+  const [tagsList, setTagsList] = useState<LingTag[]>([
+    { id: 'review', name: 'Review needed', color: '#f59e0b', dotClass: 'bg-amber-400', count: 14 },
+    { id: 'confirmed', name: 'Confirmed', color: '#10b981', dotClass: 'bg-emerald-500', count: 23 },
+    { id: 'problematic', name: 'Problematic', color: '#f43f5e', dotClass: 'bg-rose-500', count: 6 },
+  ]);
+  const [tagSearch, setTagSearch] = useState('');
+  const [newTagName, setNewTagName] = useState('');
+  const [newTagColor, setNewTagColor] = useState('#6366f1');
+  const [showUntagged, setShowUntagged] = useState(true);
+  const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
+  const [tagConceptSearch, setTagConceptSearch] = useState('');
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  // AI bottom panel
+  const [aiHeight, setAiHeight] = useState(() => Math.round(window.innerHeight * 0.4));
+  const [aiMinimized, setAiMinimized] = useState(true);
+  const resizingRef = useRef(false);
+
+  useEffect(() => {
+    if (currentMode === 'annotate') {
+      setSelectedSpeakers(sel => sel.length ? [sel[0]] : ['Fail01']);
+    }
+  }, [currentMode]);
+
+  const onResizeStart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    resizingRef.current = true;
+    const startY = e.clientY;
+    const startH = aiHeight;
+    const onMove = (ev: MouseEvent) => {
+      if (!resizingRef.current) return;
+      const dy = startY - ev.clientY;
+      const next = Math.min(Math.max(startH + dy, 120), window.innerHeight - 180);
+      setAiHeight(next);
+    };
+    const onUp = () => {
+      resizingRef.current = false;
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  const filtered = useMemo(() => {
+    let list = CONCEPTS.filter(c => c.name.toLowerCase().includes(query.toLowerCase()));
+    if (tagFilter !== 'all') list = list.filter(c => c.tag === tagFilter);
+    if (modeTab === 'unreviewed') list = list.filter(c => c.tag === 'untagged' || c.tag === 'review');
+    if (modeTab === 'flagged') list = list.filter(c => c.tag === 'problematic');
+    if (modeTab === 'borrowings') list = list.filter(c => c.id % 5 === 0);
+    // In annotate mode, scope concept list to the single selected speaker's dataset
+    if (currentMode === 'annotate' && selectedSpeakers[0]) {
+      const seed = selectedSpeakers[0].charCodeAt(0) + selectedSpeakers[0].charCodeAt(1);
+      list = list.filter(c => (c.id + seed) % 3 !== 0);
+    }
+    if (sortMode === 'az') list = [...list].sort((a,b) => a.name.localeCompare(b.name));
+    else list = [...list].sort((a,b) => a.id - b.id);
+    return list;
+  }, [query, tagFilter, sortMode, modeTab, currentMode, selectedSpeakers]);
+
+  const concept = CONCEPTS.find(c => c.id === conceptId) ?? CONCEPTS[0];
+  const reviewed = 0;
+  const total = CONCEPTS.length;
+
+  const goPrev = () => setConceptId(id => Math.max(1, id - 1));
+  const goNext = () => setConceptId(id => Math.min(total, id + 1));
+  const toggleSpeaker = (s: string) => {
+    if (currentMode === 'annotate') {
+      setSelectedSpeakers([s]);
+      return;
+    }
+    setSelectedSpeakers(sel => sel.includes(s) ? sel.filter(x => x !== s) : [...sel, s]);
+  };
+  const addSpeaker = () => {
+    if (!selectedSpeakers.includes(speakerPicker)) setSelectedSpeakers([...selectedSpeakers, speakerPicker]);
+  };
+
+  const modeTabs: { key: ModeTab; label: string }[] = [
+    { key: 'all', label: 'All' },
+    { key: 'unreviewed', label: 'Unreviewed' },
+    { key: 'flagged', label: 'Flagged' },
+    { key: 'borrowings', label: 'Borrowings' },
+  ];
+
+  return (
+    <div className="h-screen overflow-hidden bg-slate-50 text-slate-800 font-sans antialiased flex flex-col">
+      {/* ============ MINIMAL TOP BAR ============ */}
+      <header className="relative z-50 shrink-0 h-14 border-b border-slate-200/80 bg-white/90 backdrop-blur-xl">
+        <div className="flex h-full items-center justify-between px-5">
+          <div className="flex items-center gap-5">
+            <div className="flex items-center gap-2">
+              <div className="grid h-7 w-7 place-items-center rounded-md bg-gradient-to-br from-indigo-500 to-violet-600 text-white shadow-sm">
+                <Layers className="h-4 w-4" />
+              </div>
+              <span className="text-[15px] font-semibold tracking-tight text-slate-900">PARSE Compare</span>
+            </div>
+            <div className="hidden items-center gap-3 md:flex">
+              <div className="text-[11px] font-medium text-slate-500 tabular-nums">{reviewed} / {total} reviewed</div>
+              <div className="h-1.5 w-32 overflow-hidden rounded-full bg-slate-100">
+                <div className="h-full rounded-full bg-gradient-to-r from-indigo-500 to-violet-500" style={{ width: `${(reviewed/total)*100}%` }}/>
+              </div>
+            </div>
+          </div>
+
+          <nav className="hidden items-center gap-1 rounded-lg bg-slate-100/80 p-0.5 md:flex">
+            {modeTabs.map(t => (
+              <button
+                key={t.key}
+                onClick={() => setModeTab(t.key)}
+                className={`rounded-md px-3 py-1 text-xs font-medium transition ${modeTab === t.key ? 'bg-white text-slate-900 shadow-sm ring-1 ring-slate-200' : 'text-slate-500 hover:text-slate-800'}`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
+
+          <div className="flex items-center gap-2">
+            {/* Mode dropdown */}
+            <div className="relative">
+              <button
+                onClick={() => { setModeMenuOpen(v => !v); setActionsMenuOpen(false); }}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+              >
+                {currentMode === 'annotate' ? 'Annotate' : currentMode === 'compare' ? 'Compare' : 'Manage Tags'}
+                <CDown className="h-3 w-3 text-slate-400"/>
+              </button>
+              {modeMenuOpen && (
+                <>
+                  <div className="fixed inset-0 z-30" onClick={() => setModeMenuOpen(false)}/>
+                  <div className="absolute right-0 z-[60] mt-1.5 w-48 overflow-hidden rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
+                    {([
+                      ['annotate','Annotate', Type],
+                      ['compare','Compare', Layers],
+                      ['tags','Manage Tags', Tags],
+                    ] as const).map(([key,label,Icon]) => (
+                      <button
+                        key={key}
+                        onClick={() => { setCurrentMode(key); setModeMenuOpen(false); }}
+                        className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs transition ${currentMode===key ? 'bg-indigo-50 font-semibold text-indigo-800' : 'text-slate-700 hover:bg-slate-50'}`}
+                      >
+                        <Icon className="h-3.5 w-3.5 text-slate-400"/>
+                        <span className="flex-1">{label}</span>
+                        {currentMode===key && <Check className="h-3.5 w-3.5 text-indigo-600"/>}
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Actions dropdown */}
+            <div className="relative">
+              <button
+                onClick={() => { setActionsMenuOpen(v => !v); setModeMenuOpen(false); }}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+              >
+                Actions
+                <CDown className="h-3 w-3 text-slate-400"/>
+              </button>
+              {actionsMenuOpen && (
+                <>
+                  <div className="fixed inset-0 z-30" onClick={() => setActionsMenuOpen(false)}/>
+                  <div className="absolute right-0 z-[60] mt-1.5 w-60 overflow-hidden rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
+                    {([
+                      ['Import Speaker Data…', Import],
+                      ['Run Audio Normalization', AudioLines],
+                      ['Run Orthographic STT', Mic],
+                      ['Run IPA Transcription', Type],
+                      ['Run Full Pipeline', Workflow],
+                      ['Run Cross-Speaker Match', Network],
+                    ] as const).map(([label, Icon]) => (
+                      <button key={label} onClick={() => setActionsMenuOpen(false)} className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50">
+                        <Icon className="h-3.5 w-3.5 text-slate-400"/> {label}
+                      </button>
+                    ))}
+                    <div className="my-1 border-t border-slate-100"/>
+                    <button onClick={() => setActionsMenuOpen(false)} className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50">
+                      <Upload className="h-3.5 w-3.5 text-slate-400"/> Load Decisions
+                    </button>
+                    <button onClick={() => setActionsMenuOpen(false)} className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50">
+                      <Save className="h-3.5 w-3.5 text-slate-400"/> Save Decisions
+                    </button>
+                    <div className="my-1 border-t border-slate-100"/>
+                    <button onClick={() => setActionsMenuOpen(false)} className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-rose-600 hover:bg-rose-50">
+                      <Trash2 className="h-3.5 w-3.5"/> Reset Project
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+
+            <button
+              onClick={() => setDarkMode(v => !v)}
+              title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+              className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"
+            >
+              {darkMode ? <Sun className="h-4 w-4"/> : <Moon className="h-4 w-4"/>}
+            </button>
+            <div className="h-7 w-7 rounded-full bg-gradient-to-br from-amber-200 to-rose-300 ring-2 ring-white" />
+          </div>
+        </div>
+      </header>
+
+      {/* ============ BODY: left sidebar / main / right panel ============ */}
+      <div className="flex min-h-0 flex-1">
+        {/* LEFT SIDEBAR */}
+        <aside className="w-[250px] shrink-0 border-r border-slate-200/80 bg-white flex flex-col">
+          <div className="p-4 shrink-0">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-400" />
+              <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Search concepts…"
+                className="w-full rounded-lg border border-slate-200 bg-slate-50/60 py-1.5 pl-8 pr-3 text-xs text-slate-700 placeholder:text-slate-400 focus:border-indigo-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-100"/>
+            </div>
+            <div className="mt-3 flex items-center justify-between">
+              <div className="inline-flex rounded-md bg-slate-100 p-0.5">
+                <button onClick={() => setSortMode('az')} className={`px-2 py-0.5 text-[10px] font-semibold rounded ${sortMode==='az'?'bg-white text-slate-800 shadow-sm':'text-slate-500'}`}>A→Z</button>
+                <button onClick={() => setSortMode('1n')} className={`px-2 py-0.5 text-[10px] font-semibold rounded ${sortMode==='1n'?'bg-white text-slate-800 shadow-sm':'text-slate-500'}`}>1→N</button>
+              </div>
+              <span className="text-[10px] text-slate-400">{filtered.length} concepts</span>
+            </div>
+          </div>
+          <nav className="flex-1 overflow-y-auto px-2 pb-6">
+            {filtered.map(c => {
+              const active = c.id === conceptId;
+              return (
+                <button key={c.id} onClick={() => setConceptId(c.id)}
+                  className={`group mb-0.5 flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left transition ${active ? 'bg-indigo-50 text-indigo-900' : 'text-slate-600 hover:bg-slate-50'}`}>
+                  <span className={`h-1.5 w-1.5 rounded-full ${tagDot[c.tag]}`} />
+                  <span className={`flex-1 text-[13px] ${active ? 'font-semibold' : 'font-medium'}`}>{c.name}</span>
+                  <span className={`font-mono text-[10px] ${active ? 'text-indigo-400' : 'text-slate-300'}`}>#{c.id}</span>
+                </button>
+              );
+            })}
+          </nav>
+        </aside>
+
+        {/* MAIN + AI STACK */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {currentMode === 'tags' ? (
+          <>
+            <ManageTagsView
+              tags={tagsList}
+              onCreateTag={(name, color) => {
+                if (!name.trim()) return;
+                setTagsList(t => [...t, { id: name.toLowerCase().replace(/\s+/g,'-'), name, color, dotClass: '', count: 0 }]);
+                setNewTagName('');
+              }}
+              tagSearch={tagSearch}
+              setTagSearch={setTagSearch}
+              newTagName={newTagName}
+              setNewTagName={setNewTagName}
+              newTagColor={newTagColor}
+              setNewTagColor={setNewTagColor}
+              showUntagged={showUntagged}
+              setShowUntagged={setShowUntagged}
+              selectedTagId={selectedTagId}
+              setSelectedTagId={setSelectedTagId}
+              conceptSearch={tagConceptSearch}
+              setConceptSearch={setTagConceptSearch}
+            />
+            <AIChat
+              height={aiHeight}
+              minimized={aiMinimized}
+              onResizeStart={onResizeStart}
+              onMinimize={() => setAiMinimized(v => !v)}
+              conceptName={concept.name}
+              conceptId={concept.id}
+              speakerCount={selectedSpeakers.length}
+            />
+          </>
+          ) : currentMode === 'annotate' ? (
+          <>
+            <AnnotateView
+              concept={concept}
+              speaker={selectedSpeakers[0] ?? 'Mand01'}
+              totalConcepts={total}
+              onPrev={goPrev}
+              onNext={goNext}
+            />
+            <AIChat
+              height={aiHeight}
+              minimized={aiMinimized}
+              onResizeStart={onResizeStart}
+              onMinimize={() => setAiMinimized(v => !v)}
+              conceptName={concept.name}
+              conceptId={concept.id}
+              speakerCount={selectedSpeakers.length}
+            />
+          </>
+          ) : (
+          <>
+          <main className="flex-1 overflow-y-auto px-8 py-6">
+            <div className="mx-auto max-w-5xl space-y-5">
+
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <button onClick={goPrev} className="grid h-9 w-9 place-items-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:border-slate-300 hover:text-slate-800">
+                    <ChevronLeft className="h-4 w-4"/>
+                  </button>
+                  <div>
+                    <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wider text-slate-400">
+                      Concept <span className="font-mono">#{concept.id}</span> <span>·</span> <span>{concept.id} of {total}</span>
+                    </div>
+                    <h1 className="mt-0.5 text-[28px] font-semibold tracking-tight text-slate-900">{concept.name}</h1>
+                  </div>
+                  <button onClick={goNext} className="grid h-9 w-9 place-items-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:border-slate-300 hover:text-slate-800">
+                    <ChevronRight className="h-4 w-4"/>
+                  </button>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button className="inline-flex items-center gap-1.5 rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-700 hover:bg-amber-100">
+                    <Flag className="h-3.5 w-3.5"/> Flag
+                  </button>
+                  <button className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3.5 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700">
+                    <Check className="h-3.5 w-3.5"/> Accept concept
+                  </button>
+                </div>
+              </div>
+
+              <SectionCard title="Reference forms">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="rounded-lg border border-slate-100 bg-slate-50/40 p-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-[10px] font-semibold uppercase tracking-wider text-rose-500">Arabic</span>
+                      <button className="text-slate-300 hover:text-slate-500"><Volume2 className="h-3.5 w-3.5"/></button>
+                    </div>
+                    <div className="mt-2 font-serif text-2xl text-slate-900" dir="rtl">رماد</div>
+                    <div className="mt-1 font-mono text-[11px] text-slate-400">/ra.maːd/</div>
+                  </div>
+                  <div className="rounded-lg border border-slate-100 bg-slate-50/40 p-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-[10px] font-semibold uppercase tracking-wider text-indigo-500">Persian</span>
+                      <button className="text-slate-300 hover:text-slate-500"><Volume2 className="h-3.5 w-3.5"/></button>
+                    </div>
+                    <div className="mt-2 font-serif text-2xl text-slate-900" dir="rtl">خاکستر</div>
+                    <div className="mt-1 font-mono text-[11px] text-slate-400">/xɑː.kes.tær/</div>
+                  </div>
+                </div>
+              </SectionCard>
+
+              <SectionCard title={`Speaker forms · ${selectedSpeakers.length} selected`}
+                aside={<button className="inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 hover:text-slate-800"><ArrowUpDown className="h-3 w-3"/> Sort by similarity</button>}>
+                <div className="overflow-hidden rounded-lg border border-slate-100">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="bg-slate-50/70 text-[10px] uppercase tracking-wider text-slate-500">
+                        <th className="px-3 py-2 text-left font-semibold">Speaker</th>
+                        <th className="px-3 py-2 text-left font-semibold">IPA & utterances</th>
+                        <th className="px-3 py-2 text-left font-semibold">Arabic sim.</th>
+                        <th className="px-3 py-2 text-left font-semibold">Persian sim.</th>
+                        <th className="px-3 py-2 text-left font-semibold">Cognate</th>
+                        <th className="px-3 py-2 text-right font-semibold">Flag</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-100">
+                      {MOCK_FORMS.filter(f => selectedSpeakers.includes(f.speaker)).map(f => (
+                        <tr key={f.speaker} className="bg-white transition hover:bg-indigo-50/30">
+                          <td className="px-3 py-2.5 font-mono text-[11px] font-medium text-slate-700">{f.speaker}</td>
+                          <td className="px-3 py-2.5">
+                            <div className="font-mono text-[13px] text-slate-800">/{f.ipa}/</div>
+                            <div className="text-[10px] text-slate-400">{f.utterances} utterance{f.utterances!==1?'s':''}</div>
+                          </td>
+                          <td className="px-3 py-2.5"><SimBar value={f.arabicSim}/></td>
+                          <td className="px-3 py-2.5"><SimBar value={f.persianSim}/></td>
+                          <td className="px-3 py-2.5">
+                            <span className={`inline-flex h-5 min-w-[20px] items-center justify-center rounded px-1 font-mono text-[10px] font-bold ${
+                              f.cognate==='A'?'bg-indigo-100 text-indigo-700':
+                              f.cognate==='B'?'bg-violet-100 text-violet-700':
+                              f.cognate==='C'?'bg-fuchsia-100 text-fuchsia-700':
+                              'bg-slate-100 text-slate-400'
+                            }`}>{f.cognate}</span>
+                          </td>
+                          <td className="px-3 py-2.5 text-right">
+                            <button className={`inline-grid h-6 w-6 place-items-center rounded-md ${f.flagged?'bg-amber-100 text-amber-600':'text-slate-300 hover:bg-slate-100 hover:text-slate-500'}`}>
+                              <Flag className="h-3 w-3"/>
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </SectionCard>
+
+              <SectionCard title="Cognate decision" aside={<Pill tone="indigo">2 groups proposed</Pill>}>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button className="inline-flex items-center gap-1.5 rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800">
+                    <Check className="h-3.5 w-3.5"/> Accept grouping
+                  </button>
+                  <button className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50">
+                    <Split className="h-3.5 w-3.5"/> Split
+                  </button>
+                  <button className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50">
+                    <GitMerge className="h-3.5 w-3.5"/> Merge
+                  </button>
+                  <button className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50">
+                    <RotateCw className="h-3.5 w-3.5"/> Cycle
+                  </button>
+                </div>
+              </SectionCard>
+
+              <SectionCard title="Potential borrowings"
+                aside={<button onClick={() => setBorrowingsOpen(v=>!v)} className="text-slate-400 hover:text-slate-700">{borrowingsOpen ? <ChevronUp className="h-4 w-4"/> : <ChevronDown className="h-4 w-4"/>}</button>}>
+                {borrowingsOpen ? (
+                  <div className="flex items-start gap-3 rounded-lg border border-amber-100 bg-amber-50/40 p-3">
+                    <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500"/>
+                    <div className="text-xs text-slate-600">
+                      <span className="font-semibold text-amber-800">Fail01</span> /ramaːd/ shows a strong Arabic match (0.92) within a predominantly Persian cluster —
+                      possible <span className="font-semibold">Arabic borrowing</span>.
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-xs text-slate-400">1 candidate hidden</div>
+                )}
+              </SectionCard>
+
+              <SectionCard title="Notes">
+                <textarea value={notes} onChange={e => setNotes(e.target.value)}
+                  placeholder="Add observations, etymological notes, or questions for review…"
+                  className="min-h-[90px] w-full resize-none rounded-lg border border-slate-200 bg-slate-50/40 p-3 text-xs text-slate-700 placeholder:text-slate-400 focus:border-indigo-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-100"/>
+              </SectionCard>
+
+              <div className="flex items-center justify-between border-t border-slate-200 pt-5">
+                <span className="text-[11px] text-slate-400">Concept {concept.id} of {total}</span>
+                <div className="flex gap-2">
+                  <button onClick={goPrev} className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50">
+                    <ChevronLeft className="h-3.5 w-3.5"/> Previous
+                  </button>
+                  <button onClick={goNext} className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50">
+                    Next <ChevronRight className="h-3.5 w-3.5"/>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </main>
+
+          {/* BOTTOM AI CHAT */}
+          <AIChat
+            height={aiHeight}
+            minimized={aiMinimized}
+            onResizeStart={onResizeStart}
+            onMinimize={() => setAiMinimized(v => !v)}
+            conceptName={concept.name}
+            conceptId={concept.id}
+            speakerCount={selectedSpeakers.length}
+          />
+          </>
+          )}
+        </div>
+
+        {/* RIGHT PANEL */}
+        <aside
+          className={`relative shrink-0 border-l border-slate-200/80 bg-white transition-[width] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] ${panelOpen ? 'w-[250px]' : 'w-[52px]'}`}
+        >
+          {/* Toggle */}
+          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-slate-100 bg-white/90 px-3 py-2.5 backdrop-blur">
+            <span className={`text-[10px] font-semibold uppercase tracking-wider text-slate-500 transition-opacity duration-300 ${panelOpen ? 'opacity-100' : 'opacity-0'}`}>
+              Controls
+            </span>
+            <button
+              onClick={() => setPanelOpen(v => !v)}
+              title={panelOpen ? 'Collapse' : 'Expand'}
+              className="grid h-7 w-7 place-items-center rounded-md text-slate-500 transition hover:bg-slate-100 hover:text-slate-800"
+            >
+              <PanelRightClose className={`h-3.5 w-3.5 transition-transform duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] ${panelOpen ? '' : 'rotate-180'}`}/>
+            </button>
+          </div>
+
+          {/* Collapsed icon rail */}
+          <div className={`absolute inset-x-0 top-[46px] flex flex-col items-center gap-1 py-3 transition-opacity duration-300 ${panelOpen ? 'pointer-events-none opacity-0' : 'opacity-100 delay-200'}`}>
+            {[
+              { icon: Database, label: 'Project' },
+              { icon: UsersIcon, label: 'Speakers' },
+              { icon: Cpu, label: 'Compute' },
+              { icon: Filter, label: 'Filters' },
+              { icon: Save, label: 'Decisions' },
+            ].map(({ icon: Icon, label }) => (
+              <button
+                key={label}
+                title={label}
+                onClick={() => setPanelOpen(true)}
+                className="grid h-9 w-9 place-items-center rounded-lg text-slate-400 transition hover:bg-indigo-50 hover:text-indigo-600"
+              >
+                <Icon className="h-4 w-4"/>
+              </button>
+            ))}
+          </div>
+
+          {/* Expanded content */}
+          <div className={`h-[calc(100%-46px)] overflow-y-auto overflow-x-hidden transition-opacity duration-300 ${panelOpen ? 'opacity-100 delay-200' : 'pointer-events-none opacity-0'}`} style={{ width: 250 }}>
+            {/* --- COMMON: Speakers --- */}
+            <div className="border-b border-slate-100 p-4">
+              <div className="mb-2 flex items-center justify-between">
+                <h4 className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                  Speakers {currentMode === 'annotate' && <span className="ml-1 rounded bg-indigo-50 px-1 py-0.5 font-mono text-[8px] text-indigo-600">SINGLE</span>}
+                </h4>
+                <span className="text-[10px] text-slate-400">
+                  {currentMode === 'annotate' ? '1' : selectedSpeakers.length} / {SPEAKERS.length}
+                </span>
+              </div>
+              <div className="mb-2 flex gap-1">
+                <select
+                  value={currentMode === 'annotate' ? (selectedSpeakers[0] ?? '') : speakerPicker}
+                  onChange={e => {
+                    if (currentMode === 'annotate') setSelectedSpeakers([e.target.value]);
+                    else setSpeakerPicker(e.target.value);
+                  }}
+                  className="flex-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] text-slate-700 focus:border-indigo-300 focus:outline-none">
+                  {SPEAKERS.map(s => <option key={s}>{s}</option>)}
+                </select>
+                {currentMode === 'compare' && (
+                  <button onClick={addSpeaker} className="grid h-6 w-6 place-items-center rounded-md bg-slate-900 text-white hover:bg-slate-700">
+                    <Plus className="h-3 w-3"/>
+                  </button>
+                )}
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {SPEAKERS.map(s => {
+                  const active = currentMode === 'annotate' ? selectedSpeakers[0] === s : selectedSpeakers.includes(s);
+                  return (
+                    <button key={s} onClick={() => toggleSpeaker(s)}
+                      className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 font-mono text-[10px] transition ${active ? 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-200' : 'bg-slate-50 text-slate-400 ring-1 ring-slate-100 hover:text-slate-600'}`}>
+                      {s}{active && currentMode === 'compare' && <X className="h-2.5 w-2.5"/>}
+                      {active && currentMode === 'annotate' && <Check className="h-2.5 w-2.5"/>}
+                    </button>
+                  );
+                })}
+              </div>
+              {currentMode === 'annotate' && (
+                <p className="mt-2 text-[10px] leading-snug text-slate-400">
+                  Concept list scoped to <span className="font-mono text-slate-600">{selectedSpeakers[0]}</span>'s dataset.
+                </p>
+              )}
+            </div>
+
+            {currentMode === 'compare' ? (
+              <>
+                {/* --- COMPARE: Compute --- */}
+                <div className="border-b border-slate-100 p-4">
+                  <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">Compute</h4>
+                  <select value={computeMode} onChange={e => setComputeMode(e.target.value)}
+                    className="w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-[11px] text-slate-700 focus:border-indigo-300 focus:outline-none">
+                    <option value="cognates">Cognates</option>
+                    <option value="similarity">Phonetic similarity</option>
+                    <option value="alignment">Alignment</option>
+                    <option value="borrowings">Borrowing detection</option>
+                  </select>
+                  <div className="mt-2 grid grid-cols-2 gap-1.5">
+                    <button className="inline-flex items-center justify-center gap-1 rounded-md bg-indigo-600 py-1.5 text-[11px] font-semibold text-white hover:bg-indigo-700">
+                      <Play className="h-3 w-3"/> Run
+                    </button>
+                    <button className="inline-flex items-center justify-center gap-1 rounded-md border border-slate-200 bg-white py-1.5 text-[11px] font-semibold text-slate-600 hover:bg-slate-50">
+                      <RefreshCw className="h-3 w-3"/> Refresh
+                    </button>
+                  </div>
+                </div>
+
+                {/* --- COMPARE: Status --- */}
+                <div className="border-b border-slate-100 p-4">
+                  <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">Status</h4>
+                  <div className="mb-2 flex items-center gap-2">
+                    <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500"/>
+                    <span className="text-[11px] font-semibold text-slate-700">project.json</span>
+                    <span className="ml-auto text-[10px] text-slate-400">loaded</span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 text-[11px]">
+                    <div className="rounded-md bg-slate-50 px-2 py-1.5">
+                      <div className="font-mono text-sm font-semibold text-slate-900">11</div>
+                      <div className="text-[9px] uppercase tracking-wider text-slate-400">speakers</div>
+                    </div>
+                    <div className="rounded-md bg-slate-50 px-2 py-1.5">
+                      <div className="font-mono text-sm font-semibold text-slate-900">82</div>
+                      <div className="text-[9px] uppercase tracking-wider text-slate-400">concepts</div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* --- COMPARE: Filter by tag --- */}
+                <div className="border-b border-slate-100 p-4">
+                  <h4 className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                    <Filter className="h-3 w-3"/> Filter by tag
+                  </h4>
+                  <div className="space-y-1">
+                    {([
+                      ['all','All concepts','bg-slate-400'],
+                      ['untagged','Untagged','bg-slate-300'],
+                      ['review','Review needed','bg-amber-400'],
+                      ['confirmed','Confirmed','bg-emerald-500'],
+                      ['problematic','Problematic','bg-rose-500'],
+                    ] as const).map(([key,label,dot]) => (
+                      <button key={key} onClick={() => setTagFilter(key)}
+                        className={`flex w-full items-center gap-2 rounded-md px-2 py-1 text-[11px] transition ${tagFilter===key ? 'bg-indigo-50 font-semibold text-indigo-800' : 'text-slate-600 hover:bg-slate-50'}`}>
+                        <span className={`h-1.5 w-1.5 rounded-full ${dot}`}/>{label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="p-4">
+                  <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">Decisions</h4>
+                  <div className="space-y-1.5">
+                    <button className="flex w-full items-center gap-2 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-[11px] font-medium text-slate-700 hover:bg-slate-50">
+                      <Upload className="h-3 w-3"/> Load decisions
+                    </button>
+                    <button className="flex w-full items-center gap-2 rounded-md bg-emerald-600 px-2.5 py-1.5 text-[11px] font-semibold text-white hover:bg-emerald-700">
+                      <Save className="h-3 w-3"/> Save decisions
+                    </button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                {/* --- ANNOTATE: Phonetic Tools --- */}
+                <div className="border-b border-slate-100 p-4">
+                  <h4 className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                    <Activity className="h-3 w-3"/> Phonetic tools
+                  </h4>
+                  <p className="mb-3 text-[10px] leading-snug text-slate-400">
+                    Tools operate on PARSE's virtual timeline — every action is scoped to the current audio segment.
+                  </p>
+
+                  <button className="mb-1.5 flex w-full items-center gap-2 rounded-md bg-indigo-50 px-2.5 py-1.5 text-[11px] font-semibold text-indigo-800 ring-1 ring-indigo-200 hover:bg-indigo-100">
+                    <Layers className="h-3.5 w-3.5"/>
+                    <span className="flex-1 text-left">Spectrogram workspace</span>
+                    <span className="rounded bg-white/70 px-1 font-mono text-[9px] text-indigo-600">ON</span>
+                  </button>
+
+                  <div className="space-y-1">
+                    {([
+                      { icon: AudioLines, label: 'Waveform view', hint: 'Segment-aware' },
+                      { icon: Video, label: 'Video clip', hint: 'Synced to timeline' },
+                      { icon: Scissors, label: 'Segment controls', hint: 'Split · Trim · Join' },
+                      { icon: SlidersHorizontal, label: 'Formant tracker', hint: 'Praat-compatible' },
+                      { icon: Mic, label: 'Re-record utterance', hint: 'Overlay on segment' },
+                    ] as const).map(({ icon: Icon, label, hint }) => (
+                      <button key={label} className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-slate-50">
+                        <Icon className="h-3.5 w-3.5 text-slate-400 group-hover:text-indigo-600"/>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-[11px] font-medium text-slate-700 truncate">{label}</div>
+                          <div className="text-[9px] text-slate-400 truncate">{hint}</div>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* --- ANNOTATE: Tag filter + Save --- */}
+                <div className="border-b border-slate-100 p-4">
+                  <h4 className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                    <Filter className="h-3 w-3"/> Filter concepts
+                  </h4>
+                  <div className="space-y-1">
+                    {([
+                      ['all','All concepts','bg-slate-400'],
+                      ['untagged','Untagged','bg-slate-300'],
+                      ['review','Review needed','bg-amber-400'],
+                      ['confirmed','Confirmed','bg-emerald-500'],
+                      ['problematic','Problematic','bg-rose-500'],
+                    ] as const).map(([key,label,dot]) => (
+                      <button key={key} onClick={() => setTagFilter(key)}
+                        className={`flex w-full items-center gap-2 rounded-md px-2 py-1 text-[11px] transition ${tagFilter===key ? 'bg-indigo-50 font-semibold text-indigo-800' : 'text-slate-600 hover:bg-slate-50'}`}>
+                        <span className={`h-1.5 w-1.5 rounded-full ${dot}`}/>{label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="p-4">
+                  <button className="flex w-full items-center gap-2 rounded-md bg-emerald-600 px-2.5 py-1.5 text-[11px] font-semibold text-white hover:bg-emerald-700">
+                    <Save className="h-3 w-3"/> Save annotations
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -11,6 +11,15 @@ import {
   Pause, SkipBack, SkipForward, ZoomIn, ZoomOut, MessageSquare, Anchor,
   Sun, Moon
 } from 'lucide-react';
+import type { AnnotationInterval, AnnotationRecord, Tag as StoreTag } from './api/types';
+import { useChatSession, type UseChatSessionResult } from './hooks/useChatSession';
+import { useWaveSurfer } from './hooks/useWaveSurfer';
+import { useAnnotationStore } from './stores/annotationStore';
+import { useAnnotationSync } from './hooks/useAnnotationSync';
+import { useConfigStore } from './stores/configStore';
+import { usePlaybackStore } from './stores/playbackStore';
+import { useTagStore } from './stores/tagStore';
+import { useUIStore } from './stores/uiStore';
 
 type TagState = 'all' | 'untagged' | 'review' | 'confirmed' | 'problematic';
 type ConceptTag = 'untagged' | 'review' | 'confirmed' | 'problematic';
@@ -21,14 +30,17 @@ interface LingTag {
   id: string; name: string; color: string; dotClass: string; count: number;
 }
 
-interface Concept { id: number; name: string; tag: ConceptTag; }
+interface Concept {
+  id: number;
+  key: string;
+  name: string;
+  tag: ConceptTag;
+}
+
 interface SpeakerForm {
   speaker: string; ipa: string; utterances: number;
   arabicSim: number; persianSim: number;
   cognate: 'A' | 'B' | 'C' | '—'; flagged: boolean;
-}
-interface ChatMessage {
-  id: number; role: 'user' | 'ai'; content: string; streaming?: boolean;
 }
 
 const CONCEPTS: Concept[] = [
@@ -42,7 +54,9 @@ const CONCEPTS: Concept[] = [
   'sun','swim','tail','that','this','three','tongue','tooth','tree','two',
   'warm','water'
 ].map((name, i) => ({
-  id: i + 1, name,
+  id: i + 1,
+  key: String(i + 1),
+  name,
   tag: (['untagged','review','confirmed','problematic','untagged','confirmed'][i % 6]) as ConceptTag,
 }));
 
@@ -64,6 +78,48 @@ const simColor = (v: number) =>
   v >= 0.8 ? 'text-emerald-600' : v >= 0.5 ? 'text-amber-600' : 'text-slate-400';
 const simBar = (v: number) =>
   v >= 0.8 ? 'bg-emerald-500' : v >= 0.5 ? 'bg-amber-400' : 'bg-slate-300';
+
+const REVIEW_TAG_IDS = new Set(['review', 'review-needed']);
+
+function overlaps(a: AnnotationInterval, b: AnnotationInterval): boolean {
+  return a.start <= b.end && b.start <= a.end;
+}
+
+
+function conceptMatchesIntervalText(concept: Concept, text: string): boolean {
+  const normalizedText = text.trim().toLowerCase();
+  const normalizedName = concept.name.trim().toLowerCase();
+  const normalizedKey = concept.key.trim().toLowerCase();
+
+  return normalizedText === normalizedName
+    || normalizedText === normalizedKey
+    || normalizedText.includes(normalizedName);
+}
+
+function getConceptStatus(tags: StoreTag[]): ConceptTag {
+  if (tags.some((tag) => tag.id === 'problematic')) return 'problematic';
+  if (tags.some((tag) => tag.id === 'confirmed')) return 'confirmed';
+  if (tags.some((tag) => REVIEW_TAG_IDS.has(tag.id))) return 'review';
+  return 'untagged';
+}
+
+function findAnnotationForConcept(record: AnnotationRecord | null | undefined, concept: Concept) {
+  if (!record) {
+    return { conceptInterval: null, ipaInterval: null, orthoInterval: null };
+  }
+
+  const conceptIntervals = record.tiers.concept?.intervals ?? [];
+  const conceptInterval = conceptIntervals.find((interval) => conceptMatchesIntervalText(concept, interval.text)) ?? null;
+
+  if (!conceptInterval) {
+    return { conceptInterval: null, ipaInterval: null, orthoInterval: null };
+  }
+
+  const ipaInterval = (record.tiers.ipa?.intervals ?? []).find((interval) => overlaps(interval, conceptInterval)) ?? null;
+  const orthoInterval = (record.tiers.ortho?.intervals ?? []).find((interval) => overlaps(interval, conceptInterval)) ?? null;
+
+  return { conceptInterval, ipaInterval, orthoInterval };
+}
 
 const SimBar: React.FC<{ value: number }> = ({ value }) => (
   <div className="flex items-center gap-2">
@@ -100,8 +156,9 @@ interface AIChatProps {
   onResizeStart: (e: React.MouseEvent) => void;
   onMinimize: () => void;
   conceptName: string;
-  conceptId: number;
+  conceptId: number | string;
   speakerCount: number;
+  chatSession: UseChatSessionResult;
 }
 
 const QUICK_ACTIONS = [
@@ -112,10 +169,7 @@ const QUICK_ACTIONS = [
   'Compare IPA alignments',
 ];
 
-const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMinimize, conceptName, conceptId, speakerCount }) => {
-  const [messages, setMessages] = useState<ChatMessage[]>([
-    { id: 1, role: 'ai', content: `Hi — I'm looking at concept "${conceptName}" across ${speakerCount} speakers. Fail01 /ramaːd/ stands out from the Persian cluster with a 0.92 Arabic similarity. Want me to investigate it as a potential borrowing?` },
-  ]);
+const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMinimize, conceptName, conceptId, speakerCount, chatSession }) => {
   const [input, setInput] = useState('');
   const [collapsedInput, setCollapsedInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -124,25 +178,14 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
     if (!minimized) {
       scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
     }
-  }, [messages, minimized]);
+  }, [chatSession.messages, minimized]);
 
   const send = (text: string) => {
     const q = text.trim();
-    if (!q) return;
-    const uid = Date.now();
-    setMessages(m => [...m, { id: uid, role: 'user', content: q }]);
+    if (!q || chatSession.sending) return;
     setInput('');
     setCollapsedInput('');
-    const aid = uid + 1;
-    setMessages(m => [...m, { id: aid, role: 'ai', content: '', streaming: true }]);
-    const full = `Analyzing "${conceptName}" across the selected speakers. Based on current cognate groupings, I'd recommend splitting Fail01 and Tbr07 (Group A, /ramaːd/-type) from the Persian cluster (Group B, /xɑkestær/-type). The 0.92 Arabic similarity on Fail01 strongly suggests an Arabic borrowing rather than a cognate.`;
-    let i = 0;
-    const tick = () => {
-      i += 3;
-      setMessages(m => m.map(msg => msg.id === aid ? { ...msg, content: full.slice(0, i), streaming: i < full.length } : msg));
-      if (i < full.length) setTimeout(tick, 18);
-    };
-    setTimeout(tick, 250);
+    void chatSession.send(q);
   };
 
   // ---------- Collapsed: thin command bar ----------
@@ -216,18 +259,24 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
       {/* Messages */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-6 py-4">
         <div className="mx-auto max-w-3xl space-y-3">
-          {messages.map(m => (
-            <div key={m.id} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-              <div className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed ${
-                m.role === 'user'
-                  ? 'bg-slate-900 text-white'
-                  : 'bg-white text-slate-800 ring-1 ring-slate-200/70 shadow-sm'
-              }`}>
-                {m.content}
-                {m.streaming && <span className="ml-0.5 inline-block h-3.5 w-[2px] translate-y-0.5 animate-pulse bg-slate-500"/>}
+          {chatSession.messages.length === 0 && !chatSession.sending && (
+            <p className="py-6 text-center text-[12px] text-slate-400">Ask PARSE AI about <span className="font-semibold">{conceptName}</span>…</p>
+          )}
+          {chatSession.messages.map((m, i) => {
+            const isLastAi = i === chatSession.messages.length - 1 && m.role === 'assistant';
+            return (
+              <div key={`${m.timestamp}-${i}`} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed ${
+                  m.role === 'user'
+                    ? 'bg-slate-900 text-white'
+                    : 'bg-white text-slate-800 ring-1 ring-slate-200/70 shadow-sm'
+                }`}>
+                  {m.content}
+                  {isLastAi && chatSession.sending && <span className="ml-0.5 inline-block h-3.5 w-[2px] translate-y-0.5 animate-pulse bg-slate-500"/>}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
 
@@ -445,104 +494,59 @@ const ManageTagsView: React.FC<ManageTagsProps> = ({
 };
 
 // ---------- Annotate View ----------
-/**
- * AnnotateView — full-page annotation workspace.
- *
- * The waveform below is a styled mock that visually mimics wavesurfer.js v7.8.0.
- * To replace with the real implementation:
- *
- *   // TODO: Replace mock with real hook
- *   import { useWaveSurfer } from 'src/hooks/useWaveSurfer';
- *   const containerRef = useRef<HTMLDivElement>(null);
- *   const { wavesurfer, isPlaying, currentTime, duration, play, pause,
- *           loadAudio, addRegion, zoom } = useWaveSurfer(containerRef, {
- *     plugins: [RegionsPlugin, TimelinePlugin],
- *     waveColor: '#c7d2fe',
- *     progressColor: '#4f46e5',
- *     cursorColor: '#0f172a',
- *   });
- *
- * The real hook (src/hooks/useWaveSurfer.ts) mounts WaveSurfer into a plain
- * <div ref={containerRef}/> and wires up RegionsPlugin + TimelinePlugin.
- *
- * Spectrogram: the Spectrogram toggle below should later be wired to a worker-
- * backed overlay. See src/workers/spectrogram-worker.ts — plan is a dedicated
- * useSpectrogram(containerRef) hook that posts PCM windows to the worker and
- * draws an FFT heatmap on a sibling canvas.
- */
-
 interface AnnotateViewProps {
   concept: Concept;
   speaker: string;
   totalConcepts: number;
   onPrev: () => void;
   onNext: () => void;
+  audioUrl: string;
+  peaksUrl?: string;
 }
 
-// Deterministic pseudo-waveform (stable per render)
-const WAVE_BARS = Array.from({ length: 220 }, (_, i) => {
-  const x = i / 220;
-  const env = Math.sin(x * Math.PI); // rise-and-fall envelope
-  const noise = Math.abs(Math.sin(i * 1.9) + Math.sin(i * 0.37) * 0.8 + Math.sin(i * 7.1) * 0.4);
-  return Math.max(0.08, Math.min(1, env * 0.85 * noise));
-});
+const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConcepts, onPrev, onNext, audioUrl, peaksUrl }) => {
+  const record = useAnnotationStore(s => s.records[speaker] ?? null);
+  const saveSpeaker = useAnnotationStore(s => s.saveSpeaker);
 
-// Mock segmented regions on the virtual timeline
-const REGIONS = [
-  { id: 'r1', start: 0.08, end: 0.18, label: 'one',   color: 'rgba(99,102,241,0.25)',  ring: 'rgba(99,102,241,0.7)'  },
-  { id: 'r2', start: 0.26, end: 0.41, label: 'two',   color: 'rgba(16,185,129,0.22)',  ring: 'rgba(16,185,129,0.7)'  },
-  { id: 'r3', start: 0.52, end: 0.66, label: 'three', color: 'rgba(244,114,182,0.22)', ring: 'rgba(244,114,182,0.7)' },
-  { id: 'r4', start: 0.74, end: 0.88, label: 'four',  color: 'rgba(251,191,36,0.25)',  ring: 'rgba(251,191,36,0.7)'  },
-];
+  // Pre-populate IPA/ortho from store when concept or speaker changes
+  const { ipaInterval, orthoInterval } = useMemo(
+    () => findAnnotationForConcept(record, concept),
+    [record, concept]
+  );
+  const [ipa, setIpa] = useState(ipaInterval?.text ?? '');
+  const [ortho, setOrtho] = useState(orthoInterval?.text ?? '');
+  useEffect(() => {
+    setIpa(ipaInterval?.text ?? '');
+    setOrtho(orthoInterval?.text ?? '');
+  }, [ipaInterval, orthoInterval]);
 
-const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConcepts, onPrev, onNext }) => {
-  const [ipa, setIpa] = useState('');
-  const [ortho, setOrtho] = useState('');
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [playhead, setPlayhead] = useState(0.32); // 0..1 fraction
-  const [zoom, setZoom] = useState(1);
   const [spectroOn, setSpectroOn] = useState(false);
-  const [activeRegion, setActiveRegion] = useState<string | null>('r2');
-  const [hoverRegion, setHoverRegion] = useState<string | null>(null);
+  const [activeRegion] = useState<string | null>(null);
   const [lexAnchor, setLexAnchor] = useState<'word' | 'concept'>('concept');
-  const waveRef = useRef<HTMLDivElement>(null);
-  const draggingRef = useRef(false);
+  const [zoom, setZoom] = useState(10); // minPxPerSec
 
-  // Mock duration / current time derived from playhead
-  const duration = 4.82;
-  const currentTime = playhead * duration;
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Playback state (written by useWaveSurfer via callbacks)
+  const isPlaying = usePlaybackStore(s => s.isPlaying);
+  const currentTime = usePlaybackStore(s => s.currentTime);
+  const duration = usePlaybackStore(s => s.duration);
+
+  const { playPause, skip, setZoom: wsSetZoom, setRate } = useWaveSurfer({
+    containerRef,
+    audioUrl,
+    peaksUrl,
+    onTimeUpdate: t => usePlaybackStore.setState({ currentTime: t }),
+    onReady:      d => usePlaybackStore.setState({ duration: d }),
+    onPlayStateChange: p => usePlaybackStore.setState({ isPlaying: p }),
+    onRegionUpdate: (start, end) => usePlaybackStore.setState({ selectedRegion: { start, end } }),
+  });
 
   const fmt = (t: number) => {
     const m = Math.floor(t / 60).toString().padStart(2, '0');
     const s = Math.floor(t % 60).toString().padStart(2, '0');
     const ms = Math.floor((t * 100) % 100).toString().padStart(2, '0');
     return `${m}:${s}.${ms}`;
-  };
-
-  const handleSeek = (e: React.MouseEvent) => {
-    const rect = waveRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const x = (e.clientX - rect.left) / rect.width;
-    setPlayhead(Math.max(0, Math.min(1, x)));
-  };
-
-  const startDrag = (e: React.MouseEvent) => {
-    e.preventDefault();
-    draggingRef.current = true;
-    handleSeek(e);
-    const onMove = (ev: MouseEvent) => {
-      if (!draggingRef.current || !waveRef.current) return;
-      const rect = waveRef.current.getBoundingClientRect();
-      const x = (ev.clientX - rect.left) / rect.width;
-      setPlayhead(Math.max(0, Math.min(1, x)));
-    };
-    const onUp = () => {
-      draggingRef.current = false;
-      window.removeEventListener('mousemove', onMove);
-      window.removeEventListener('mouseup', onUp);
-    };
-    window.addEventListener('mousemove', onMove);
-    window.addEventListener('mouseup', onUp);
   };
 
   return (
@@ -559,11 +563,11 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
               <SkipForward className="h-3.5 w-3.5"/>
             </button>
             <div className="mx-2 h-5 w-px bg-slate-200"/>
-            <button onClick={() => setZoom(z => Math.max(0.5, z - 0.25))} title="Zoom out" className="grid h-7 w-7 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800">
+            <button onClick={() => { const z = Math.max(10, zoom - 20); setZoom(z); wsSetZoom(z); }} title="Zoom out" className="grid h-7 w-7 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800">
               <ZoomOut className="h-3.5 w-3.5"/>
             </button>
-            <div className="rounded bg-slate-100 px-2 py-0.5 font-mono text-[10px] text-slate-500">{zoom.toFixed(2)}×</div>
-            <button onClick={() => setZoom(z => Math.min(4, z + 0.25))} title="Zoom in" className="grid h-7 w-7 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800">
+            <div className="rounded bg-slate-100 px-2 py-0.5 font-mono text-[10px] text-slate-500">{zoom}px/s</div>
+            <button onClick={() => { const z = Math.min(500, zoom + 20); setZoom(z); wsSetZoom(z); }} title="Zoom in" className="grid h-7 w-7 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800">
               <ZoomIn className="h-3.5 w-3.5"/>
             </button>
             <div className="mx-2 h-5 w-px bg-slate-200"/>
@@ -587,86 +591,25 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
           </div>
         </div>
 
-        {/* Waveform container */}
+        {/* Waveform container — WaveSurfer owns this div */}
         <div className="relative px-5 pt-4 pb-2">
-          {/* TODO: Replace mock with real hook
-              const { wavesurfer, isPlaying, loadAudio, ... } = useWaveSurfer(containerRef, {
-                plugins: [RegionsPlugin, TimelinePlugin]
-              });
-              <div ref={containerRef} /> will be mounted by WaveSurfer. */}
-          <div
-            ref={waveRef}
-            onMouseDown={startDrag}
-            className="relative h-32 w-full cursor-crosshair select-none overflow-hidden rounded-lg bg-gradient-to-b from-slate-50 to-white ring-1 ring-slate-100"
-            style={{ backgroundImage: 'linear-gradient(to right, rgba(148,163,184,0.08) 1px, transparent 1px)', backgroundSize: `${100/20}% 100%` }}
-          >
-            {/* Optional spectrogram underlay placeholder */}
+          <div className="relative">
+            <div
+              ref={containerRef}
+              className="relative w-full overflow-hidden rounded-lg ring-1 ring-slate-100"
+              style={{ minHeight: 110 }}
+            />
+            {/* Spectrogram overlay — wire to src/workers/spectrogram-worker.ts (MC-297) */}
             {spectroOn && (
               <div
-                className="pointer-events-none absolute inset-0 opacity-70"
+                className="pointer-events-none absolute inset-0 rounded-lg opacity-60"
                 style={{
                   background: 'repeating-linear-gradient(90deg, rgba(79,70,229,0.35) 0 2px, rgba(236,72,153,0.25) 2px 4px, rgba(16,185,129,0.25) 4px 6px, transparent 6px 8px)',
                   mixBlendMode: 'multiply',
                 }}
-                title="Spectrogram placeholder — real FFT heatmap via spectrogram-worker.ts"
+                title="Spectrogram placeholder — real FFT heatmap coming via MC-297"
               />
             )}
-
-            {/* Regions overlay */}
-            {REGIONS.map(r => (
-              <div
-                key={r.id}
-                onMouseEnter={() => setHoverRegion(r.id)}
-                onMouseLeave={() => setHoverRegion(null)}
-                onClick={(e) => { e.stopPropagation(); setActiveRegion(r.id); }}
-                className="absolute inset-y-0 cursor-pointer transition-all"
-                style={{
-                  left: `${r.start * 100}%`,
-                  width: `${(r.end - r.start) * 100}%`,
-                  background: r.color,
-                  boxShadow: (activeRegion === r.id || hoverRegion === r.id) ? `inset 0 0 0 2px ${r.ring}` : `inset 0 0 0 1px ${r.ring}`,
-                }}
-              >
-                <div className="absolute left-1 top-1 rounded bg-white/90 px-1.5 py-0.5 font-mono text-[9px] font-semibold text-slate-700 shadow-sm">
-                  {r.label}
-                </div>
-              </div>
-            ))}
-
-            {/* Waveform bars */}
-            <div className="pointer-events-none absolute inset-0 flex items-center px-0.5">
-              {WAVE_BARS.map((h, i) => {
-                const frac = i / WAVE_BARS.length;
-                const played = frac <= playhead;
-                return (
-                  <div
-                    key={i}
-                    className="mx-[0.5px] flex-1 rounded-full"
-                    style={{
-                      height: `${h * 90}%`,
-                      background: played ? '#4f46e5' : '#c7d2fe',
-                    }}
-                  />
-                );
-              })}
-            </div>
-
-            {/* Playhead */}
-            <div
-              className="pointer-events-none absolute inset-y-0 w-[2px] bg-slate-900"
-              style={{ left: `calc(${playhead * 100}% - 1px)` }}
-            >
-              <div className="absolute -top-1 -left-1.5 h-3 w-3 rounded-full bg-slate-900 ring-2 ring-white shadow"/>
-            </div>
-          </div>
-
-          {/* Timeline ruler */}
-          <div className="relative mt-1 h-5 select-none font-mono text-[9px] text-slate-400">
-            {[0, 0.25, 0.5, 0.75, 1].map((f, i) => (
-              <span key={i} className="absolute -translate-x-1/2" style={{ left: `${f * 100}%` }}>
-                {fmt(f * duration)}
-              </span>
-            ))}
           </div>
         </div>
       </section>
@@ -730,7 +673,10 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
 
           {/* Action buttons */}
           <div className="flex items-center gap-3 pt-2">
-            <button className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700">
+            <button
+              onClick={() => { void saveSpeaker(speaker); }}
+              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
+            >
               <Save className="h-4 w-4"/> Save Annotation
             </button>
             <button className="inline-flex items-center gap-2 rounded-xl border border-rose-200 bg-white px-5 py-2.5 text-sm font-semibold text-rose-600 transition hover:bg-rose-50">
@@ -746,29 +692,29 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
       {/* ======= BOTTOM PLAYBACK BAR ======= */}
       <section className="sticky bottom-0 border-t border-slate-200 bg-white/95 backdrop-blur">
         <div className="mx-auto flex max-w-4xl items-center gap-3 px-8 py-3">
-          <button className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><SkipBack className="h-4 w-4"/></button>
-          <button onClick={() => setPlayhead(p => Math.max(0, p - 0.05))} className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><ChevronLeft className="h-4 w-4"/></button>
+          <button onClick={() => skip(-5)} title="-5s" className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><SkipBack className="h-4 w-4"/></button>
+          <button onClick={() => skip(-1)} title="-1s" className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><ChevronLeft className="h-4 w-4"/></button>
           <button
-            onClick={() => setIsPlaying(p => !p)}
+            onClick={() => playPause()}
             className="grid h-10 w-10 place-items-center rounded-full bg-slate-900 text-white shadow-sm hover:bg-slate-700"
           >
             {isPlaying ? <Pause className="h-4 w-4"/> : <Play className="h-4 w-4 translate-x-[1px]"/>}
           </button>
-          <button onClick={() => setPlayhead(p => Math.min(1, p + 0.05))} className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><ChevronRight className="h-4 w-4"/></button>
-          <button className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><SkipForward className="h-4 w-4"/></button>
+          <button onClick={() => skip(1)} title="+1s" className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><ChevronRight className="h-4 w-4"/></button>
+          <button onClick={() => skip(5)} title="+5s" className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><SkipForward className="h-4 w-4"/></button>
 
           <div className="ml-2 font-mono text-[11px] tabular-nums text-slate-500">
             {fmt(currentTime)} <span className="text-slate-300">/</span> {fmt(duration)}
           </div>
 
           <div className="ml-auto flex items-center gap-2">
-            <select className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-600 focus:border-indigo-300 focus:outline-none">
-              <option>0.5x</option>
-              <option>0.75x</option>
-              <option defaultValue="1">1.0x</option>
-              <option>1.25x</option>
-              <option>1.5x</option>
-              <option>2.0x</option>
+            <select defaultValue="1" onChange={e => setRate(Number(e.target.value))} className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-600 focus:border-indigo-300 focus:outline-none">
+              <option value="0.5">0.5x</option>
+              <option value="0.75">0.75x</option>
+              <option value="1">1.0x</option>
+              <option value="1.25">1.25x</option>
+              <option value="1.5">1.5x</option>
+              <option value="2">2.0x</option>
             </select>
             <button className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600 hover:bg-slate-50">
               <MessageSquare className="h-3 w-3"/> Chat
@@ -782,6 +728,25 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
 
 // ---------- Main Component ----------
 export function ParseUI() {
+  // — Stores —
+  const loadConfig       = useConfigStore(s => s.load);
+  const rawSpeakers      = useConfigStore(s => s.config?.speakers ?? []);
+  const rawConcepts      = useConfigStore(s => s.config?.concepts ?? []);
+  const storeTags        = useTagStore(s => s.tags);
+  const storeAddTag      = useTagStore(s => s.addTag);
+  const hydrateTagStore  = useTagStore(s => s.hydrate);
+  const getTagsForConcept = useTagStore(s => s.getTagsForConcept);
+  const setActiveSpeakerUI = useUIStore(s => s.setActiveSpeaker);
+  // — Chat session (one instance for the whole UI) —
+  const chatSession = useChatSession();
+  // — Annotation sync (auto-loads record when activeSpeaker changes) —
+  useAnnotationSync();
+  // — Bootstrap —
+  useEffect(() => {
+    loadConfig().catch(console.error);
+    hydrateTagStore();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const [query, setQuery] = useState('');
   const [sortMode, setSortMode] = useState<'az'|'1n'>('1n');
   const [tagFilter, setTagFilter] = useState<TagState>('all');
@@ -796,11 +761,7 @@ export function ParseUI() {
   const [currentMode, setCurrentMode] = useState<AppMode>('compare');
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
   const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
-  const [tagsList, setTagsList] = useState<LingTag[]>([
-    { id: 'review', name: 'Review needed', color: '#f59e0b', dotClass: 'bg-amber-400', count: 14 },
-    { id: 'confirmed', name: 'Confirmed', color: '#10b981', dotClass: 'bg-emerald-500', count: 23 },
-    { id: 'problematic', name: 'Problematic', color: '#f43f5e', dotClass: 'bg-rose-500', count: 6 },
-  ]);
+
   const [tagSearch, setTagSearch] = useState('');
   const [newTagName, setNewTagName] = useState('');
   const [newTagColor, setNewTagColor] = useState('#6366f1');
@@ -812,6 +773,26 @@ export function ParseUI() {
   useEffect(() => {
     document.documentElement.classList.toggle('dark', darkMode);
   }, [darkMode]);
+
+  // — Derived: real speakers (fallback to mock while config loads) —
+  const speakers = rawSpeakers.length > 0 ? rawSpeakers : SPEAKERS;
+
+  // — Derived: real concepts with live tag state —
+  const concepts = useMemo<Concept[]>(() => {
+    if (rawConcepts.length === 0) return CONCEPTS;
+    return rawConcepts.map((c, i) => ({
+      id: i + 1,
+      key: c.id,
+      name: c.label,
+      tag: getConceptStatus(getTagsForConcept(c.id)),
+    }));
+  }, [rawConcepts, getTagsForConcept]);
+
+  // — Derived: tags list from store —
+  const tagsList = useMemo<LingTag[]>(() =>
+    storeTags.map(t => ({ id: t.id, name: t.label, color: t.color, dotClass: '', count: t.concepts.length })),
+    [storeTags]
+  );
 
   // AI bottom panel
   const [aiHeight, setAiHeight] = useState(() => Math.round(window.innerHeight * 0.4));
@@ -845,7 +826,7 @@ export function ParseUI() {
   };
 
   const filtered = useMemo(() => {
-    let list = CONCEPTS.filter(c => c.name.toLowerCase().includes(query.toLowerCase()));
+    let list = concepts.filter(c => c.name.toLowerCase().includes(query.toLowerCase()));
     if (tagFilter !== 'all') list = list.filter(c => c.tag === tagFilter);
     if (modeTab === 'unreviewed') list = list.filter(c => c.tag === 'untagged' || c.tag === 'review');
     if (modeTab === 'flagged') list = list.filter(c => c.tag === 'problematic');
@@ -860,15 +841,17 @@ export function ParseUI() {
     return list;
   }, [query, tagFilter, sortMode, modeTab, currentMode, selectedSpeakers]);
 
-  const concept = CONCEPTS.find(c => c.id === conceptId) ?? CONCEPTS[0];
-  const reviewed = 0;
-  const total = CONCEPTS.length;
+  const concept = concepts.find(c => c.id === conceptId) ?? concepts[0] ?? { id: 1, name: '—', tag: 'untagged' as ConceptTag };
+  const reviewed = concepts.filter(c => c.tag === 'confirmed').length;
+  const total = concepts.length;
 
   const goPrev = () => setConceptId(id => Math.max(1, id - 1));
   const goNext = () => setConceptId(id => Math.min(total, id + 1));
   const toggleSpeaker = (s: string) => {
     if (currentMode === 'annotate') {
       setSelectedSpeakers([s]);
+      setActiveSpeakerUI(s);
+      usePlaybackStore.setState({ activeSpeaker: s });
       return;
     }
     setSelectedSpeakers(sel => sel.includes(s) ? sel.filter(x => x !== s) : [...sel, s]);
@@ -1042,11 +1025,7 @@ export function ParseUI() {
           <>
             <ManageTagsView
               tags={tagsList}
-              onCreateTag={(name, color) => {
-                if (!name.trim()) return;
-                setTagsList(t => [...t, { id: name.toLowerCase().replace(/\s+/g,'-'), name, color, dotClass: '', count: 0 }]);
-                setNewTagName('');
-              }}
+              onCreateTag={(name, color) => { if (!name.trim()) return; storeAddTag(name, color); setNewTagName(''); }}
               tagSearch={tagSearch}
               setTagSearch={setTagSearch}
               newTagName={newTagName}
@@ -1068,6 +1047,7 @@ export function ParseUI() {
               conceptName={concept.name}
               conceptId={concept.id}
               speakerCount={selectedSpeakers.length}
+              chatSession={chatSession}
             />
           </>
           ) : currentMode === 'annotate' ? (
@@ -1078,6 +1058,8 @@ export function ParseUI() {
               totalConcepts={total}
               onPrev={goPrev}
               onNext={goNext}
+              audioUrl={selectedSpeakers[0] ? `/audio/${selectedSpeakers[0]}.wav` : ''}
+              peaksUrl={selectedSpeakers[0] ? `/peaks/${selectedSpeakers[0]}.json` : undefined}
             />
             <AIChat
               height={aiHeight}
@@ -1087,6 +1069,7 @@ export function ParseUI() {
               conceptName={concept.name}
               conceptId={concept.id}
               speakerCount={selectedSpeakers.length}
+              chatSession={chatSession}
             />
           </>
           ) : (
@@ -1245,6 +1228,7 @@ export function ParseUI() {
             conceptName={concept.name}
             conceptId={concept.id}
             speakerCount={selectedSpeakers.length}
+            chatSession={chatSession}
           />
           </>
           )}
@@ -1297,7 +1281,7 @@ export function ParseUI() {
                   Speakers {currentMode === 'annotate' && <span className="ml-1 rounded bg-indigo-50 px-1 py-0.5 font-mono text-[8px] text-indigo-600">SINGLE</span>}
                 </h4>
                 <span className="text-[10px] text-slate-400">
-                  {currentMode === 'annotate' ? '1' : selectedSpeakers.length} / {SPEAKERS.length}
+                  {currentMode === 'annotate' ? '1' : selectedSpeakers.length} / {speakers.length}
                 </span>
               </div>
               <div className="mb-2 flex gap-1">
@@ -1308,7 +1292,7 @@ export function ParseUI() {
                     else setSpeakerPicker(e.target.value);
                   }}
                   className="flex-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] text-slate-700 focus:border-indigo-300 focus:outline-none">
-                  {SPEAKERS.map(s => <option key={s}>{s}</option>)}
+                  {speakers.map(s => <option key={s}>{s}</option>)}
                 </select>
                 {currentMode === 'compare' && (
                   <button onClick={addSpeaker} className="grid h-6 w-6 place-items-center rounded-md bg-slate-900 text-white hover:bg-slate-700">
@@ -1317,7 +1301,7 @@ export function ParseUI() {
                 )}
               </div>
               <div className="flex flex-wrap gap-1">
-                {SPEAKERS.map(s => {
+                {speakers.map(s => {
                   const active = currentMode === 'annotate' ? selectedSpeakers[0] === s : selectedSpeakers.includes(s);
                   return (
                     <button key={s} onClick={() => toggleSpeaker(s)}

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import {
   Search, ChevronLeft, ChevronRight, Check, Flag, Split, GitMerge,
-  RotateCw, Play, RefreshCw, Save, Upload, Sparkles,
+  RotateCw, Play, RefreshCw, Save, Upload,
   Layers, ChevronDown, ChevronUp, Plus, X, AlertCircle,
-  CheckCircle2, ArrowUpDown, Volume2, Filter, Send, Minus,
-  GripHorizontal, Bot, User, Database, Users as UsersIcon, Cpu,
+  CheckCircle2, ArrowUpDown, Volume2, Filter, Send,
+  Database, Users as UsersIcon, Cpu,
   PanelRightClose, Tag, Tags, Import, AudioLines, Type, Mic,
   Workflow, Network, Trash2, ChevronDown as CDown,
   Video, Scissors, Activity, SlidersHorizontal,

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary

Replaces the segmented `AnnotateMode`/`CompareMode` route architecture with a single unified React shell (`src/ParseUI.tsx`).

## What's in this PR

### MC-294 — New unified UI shell
- `src/ParseUI.tsx` — full-app layout covering Annotate, Compare, Tags, and AI Chat in one component
- `App.tsx` simplified to `<BrowserRouter><ParseUI /></BrowserRouter>`
- Dependencies added: `lucide-react`, `tailwindcss v3`, `postcss`, `autoprefixer`
- `tailwind.config.js`, `postcss.config.js`, `src/index.css` added

### MC-295 — Annotate wiring
- `useWaveSurfer` wired: real waveform container, play/pause, skip ±1/±5s, zoom, playback rate
- Mock bars/playhead/WAVE_BARS/REGIONS/startDrag removed — WaveSurfer owns the canvas
- IPA/ortho pre-populate from `annotationStore` via `findAnnotationForConcept` on concept/speaker change
- Save Annotation button → `saveSpeaker()`
- `useChatSession` wired to all 3 AIChat instances (real API, streaming cursor)
- Speakers/concepts from `useConfigStore`, tags from `useTagStore`
- `reviewed` count from real confirmed tag count
- `useAnnotationSync` on mount, config + tagStore hydration on mount

### MC-296 — Stale reference cleanup
- Unused imports removed
- `CONCEPTS`/`SPEAKERS` → derived `concepts`/`speakers` everywhere
- Stale JSDoc/TODO comment blocks deleted
- AIChat `useEffect` dep fixed

## Still TODO (follow-up PRs)
- MOCK_FORMS → real annotationStore data (compare speaker table)
- Spectrogram worker port (MC-297)
- server.py startup messaging (MC-298)
- Actions menu API wiring, cognate decisions, tag assignment

## Test
```
npm run check   # 0 errors
```

## Reviewer
@TrueNorth49