### PR TITLE
[MC-301] ParseUI actions menu: open speaker import modal

### DIFF
--- a/docs/plans/MC-301-parseui-actions-import.md
+++ b/docs/plans/MC-301-parseui-actions-import.md
@@ -1,0 +1,35 @@
+# MC-301 — ParseUI actions menu import speaker modal wiring
+
+## Objective
+Complete the next ParseUI wiring slice by turning the top-bar Actions > Import Speaker Data entry into a real modal-backed flow that reuses the existing `SpeakerImport` component inside the unified shell.
+
+## Scope
+1. Work on the canonical code branch path for ParseUI: `feat/parseui-unified-shell` -> `main`.
+2. Add a failing ParseUI regression test that proves the action opens the import modal.
+3. Wire the action menu item to open a shared modal and render `SpeakerImport`.
+4. Close the dropdown after invocation and allow the modal to close cleanly.
+5. Run `npm run check`, targeted ParseUI tests, then the full Vitest suite.
+6. Open/update the PR and request review from `TrueNorth49`.
+
+## Academic / product considerations
+- This is operational infrastructure for fieldwork onboarding, so the UI must expose a recoverable import path without breaking Annotate/Compare state.
+- The shell should reuse existing PARSE primitives rather than create a second import implementation.
+- No emoji in any UI labels.
+
+## Files in scope
+- `src/ParseUI.tsx`
+- `src/ParseUI.test.tsx`
+- `docs/plans/MC-301-parseui-actions-import.md`
+
+## Test strategy
+- RED: add a ParseUI test that clicks `Actions` -> `Import Speaker Data…` and expects the import modal content to appear.
+- GREEN: implement the minimal modal state and rendering needed to satisfy the test.
+- REFACTOR: keep the modal wiring local and avoid premature endpoint orchestration until the import trigger is stable.
+
+## Completion criteria
+- Actions menu import item opens a real modal containing `SpeakerImport`.
+- The menu closes after the click.
+- Typecheck passes.
+- Targeted ParseUI tests pass.
+- Full test suite passes.
+- A PR to `main` is opened from `feat/parseui-unified-shell` with reviewer request to `TrueNorth49`.

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -316,6 +316,15 @@ describe("ParseUI", () => {
     expect(mockUntagConcept).toHaveBeenCalledWith("problematic", "1");
   });
 
+  it("opens the speaker import modal from the Actions menu", async () => {
+    render(<ParseUI />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Import Speaker Data…" }));
+
+    expect(await screen.findByTestId("speaker-import")).toBeTruthy();
+  });
+
   it("persists compare notes per concept via localStorage on blur", () => {
     const { unmount } = render(<ParseUI />);
     const notesField = screen.getByPlaceholderText(/Add observations, etymological notes, or questions for review/i);

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -22,6 +22,8 @@ import { useEnrichmentStore } from './stores/enrichmentStore';
 import { usePlaybackStore } from './stores/playbackStore';
 import { useTagStore } from './stores/tagStore';
 import { useUIStore } from './stores/uiStore';
+import { Modal } from './components/shared/Modal';
+import { SpeakerImport } from './components/compare/SpeakerImport';
 
 type TagState = 'all' | 'untagged' | 'review' | 'confirmed' | 'problematic';
 type ConceptTag = 'untagged' | 'review' | 'confirmed' | 'problematic';
@@ -865,6 +867,7 @@ export function ParseUI() {
   const [currentMode, setCurrentMode] = useState<AppMode>('compare');
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
   const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
+  const [importModalOpen, setImportModalOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
 
   const handleExportLingPy = async () => {
@@ -1008,6 +1011,22 @@ export function ParseUI() {
   const addSpeaker = () => {
     if (!selectedSpeakers.includes(speakerPicker)) setSelectedSpeakers([...selectedSpeakers, speakerPicker]);
   };
+  const openImportModal = () => {
+    setActionsMenuOpen(false);
+    setImportModalOpen(true);
+  };
+  const handleImportComplete = (speakerId: string) => {
+    setImportModalOpen(false);
+    if (!speakerId) return;
+    setSpeakerPicker(speakerId);
+    if (currentMode === 'annotate') {
+      setSelectedSpeakers([speakerId]);
+      setActiveSpeakerUI(speakerId);
+      usePlaybackStore.setState({ activeSpeaker: speakerId });
+      return;
+    }
+    setSelectedSpeakers((existing) => existing.includes(speakerId) ? existing : [...existing, speakerId]);
+  };
 
   const modeTabs: { key: ModeTab; label: string }[] = [
     { key: 'all', label: 'All' },
@@ -1095,8 +1114,13 @@ export function ParseUI() {
                 <>
                   <div className="fixed inset-0 z-30" onClick={() => setActionsMenuOpen(false)}/>
                   <div className="absolute right-0 z-[60] mt-1.5 w-60 overflow-hidden rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
+                    <button
+                      onClick={openImportModal}
+                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50"
+                    >
+                      <Import className="h-3.5 w-3.5 text-slate-400"/> Import Speaker Data…
+                    </button>
                     {([
-                      ['Import Speaker Data…', Import],
                       ['Run Audio Normalization', AudioLines],
                       ['Run Orthographic STT', Mic],
                       ['Run IPA Transcription', Type],
@@ -1662,6 +1686,10 @@ export function ParseUI() {
           </div>
         </aside>
       </div>
+
+      <Modal open={importModalOpen} onClose={() => setImportModalOpen(false)} title="Import Speaker">
+        <SpeakerImport onImportComplete={handleImportComplete} />
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a failing ParseUI regression test for Actions > Import Speaker Data
- wire the unified shell action to open a real Modal + SpeakerImport flow
- keep selected-speaker state in sync when the import completes

## Verification
- npm run test -- src/ParseUI.test.tsx --run
- npm run check
- npm run test -- --run