### PR TITLE
[MC-306] Add current-state ParseUI execution plan

### DIFF
--- a/docs/plans/MC-306-parseui-current-state-plan.md
+++ b/docs/plans/MC-306-parseui-current-state-plan.md
@@ -1,0 +1,22 @@
+# MC-306 — Replace stale ParseUI wiring plan with a current-state execution plan
+
+## Objective
+Retire `docs/plans/parseui-wiring-todo.md` as a live execution guide and replace it with one current-state ParseUI plan grounded in `origin/main`, the implemented UI, and the live client/server contract.
+
+## Scope
+1. Audit the current `main` code and tests for what is already done in ParseUI.
+2. Mark `parseui-wiring-todo.md` as historical/stale rather than deleting it.
+3. Create a new plan with only the genuinely open work.
+4. Point `parsebuilder-todo.md` at the new plan.
+5. Submit a docs-only PR and request review from `TrueNorth49`.
+
+## Working assumptions
+- Branch policy comes from `AGENTS.md`: new work starts from `origin/main`; old pivot branches are historical.
+- `parseui-wiring-todo.md` is useful as an archive, but no longer safe to execute literally.
+- The next open work is not the old annotate/compare wiring list; it is contract reconciliation and verification around actions, compute, decisions, and C5/C6 evidence.
+
+## Completion criteria
+- `parseui-wiring-todo.md` clearly labeled historical.
+- New `parseui-current-state-plan.md` added.
+- `parsebuilder-todo.md` updated to reference the new plan.
+- Docs branch committed, pushed, and in PR.

--- a/docs/plans/parsebuilder-todo.md
+++ b/docs/plans/parsebuilder-todo.md
@@ -6,6 +6,14 @@
 
 ---
 
+## Current execution plan
+
+- Live execution guide: `docs/plans/parseui-current-state-plan.md`
+- Historical archive only: `docs/plans/parseui-wiring-todo.md`
+- Short version: most early ParseUI wiring tasks are already done; the remaining work is contract reconciliation around Actions / compute / decisions, followed by C5/C6 evidence.
+
+---
+
 ## 🔒 Blocked
 
 ### MC-299 — C6 Browser Regression Checklist

--- a/docs/plans/parsebuilder-todo.md
+++ b/docs/plans/parsebuilder-todo.md
@@ -2,7 +2,7 @@
 
 > **Owner:** ParseBuilder (@parse-builder)
 > **Domain:** Annotate mode + shared platform (waveform, spectrogram, phonetic tools)
-> **Updated:** 2026-04-10
+> **Updated:** 2026-06-14
 
 ---
 
@@ -42,7 +42,7 @@ When Lucas signals C5 cleared:
 - [x] **MC-299 prep** — ParseUI integration tests, 111/111 passing · PR #12 (2026-04-10)
 - [x] **Compare notes** — localStorage persistence per concept · PR #12 (2026-04-10)
 - [x] **Compare real data** — MOCK_FORMS → `buildSpeakerForm` from `annotationRecords` · PR #12 (2026-04-10)
-- [x] **MC-297** — `spectrogram-worker.ts` (TS port) + `useSpectrogram` hook + AnnotateView canvas · PR #11 (2026-04-10)
+- [x] **MC-297** — `spectrogram-worker.ts` (TS port) + `useSpectrogram` hook + AnnotateView canvas · PR #11 (2026-04-10), UI wiring PR #31 (2026-06-14)
 - [x] **MC-298** — `server.py` startup messaging — React `:5173` + legacy fallback labels · main `b930b1b`
 - [x] **MC-296** — ParseUI stale reference cleanup · PR #9
 - [x] **MC-295** — Annotate wiring: IPA/ortho pre-populate, Save (setInterval × 3 tiers + saveSpeaker), Mark Done (tagConcept), Annotated/Missing badge · PR #9 + #11
@@ -53,7 +53,7 @@ When Lucas signals C5 cleared:
 ## Test baseline (main, 2026-04-10)
 
 ```
-npm run test -- --run   →  111 / 111 passing
+npm run test -- --run   →  119 / 119 passing (23 files)
 tsc --noEmit            →  0 errors
 ```
 
@@ -65,4 +65,4 @@ tsc --noEmit            →  0 errors
 
 ## Status
 
-AI login wired and deployed. **MC-299 activates on Lucas's C5 signal.**
+AI login wired and deployed. MC-297 spectrogram UI wired (PR #31). **MC-299 activates on Lucas's C5 signal.**

--- a/docs/plans/parseui-current-state-plan.md
+++ b/docs/plans/parseui-current-state-plan.md
@@ -1,0 +1,119 @@
+# ParseUI current-state execution plan
+
+**Updated:** 2026-04-10
+**Applies to:** `origin/main`
+**Code branch for implementation:** `feat/parseui-unified-shell`
+**Docs branch for planning:** `docs/parseui-planning`
+
+## TLDR
+
+Do not execute `docs/plans/parseui-wiring-todo.md` literally anymore. Most of its early wiring tasks have already landed. The remaining ParseUI work is now mostly **contract reconciliation and verification** around Actions menu flows, compute/decisions persistence, and C5/C6 evidence.
+
+## Live sources of truth
+
+1. `AGENTS.md` — branch policy and release gates
+2. `docs/plans/parsebuilder-todo.md` — high-level current status / blocked gate
+3. `src/ParseUI.tsx` — implemented UI state and current affordances
+4. `src/ParseUI.test.tsx` — regression coverage for landed ParseUI slices
+5. `src/api/client.ts` + `python/server.py` — authoritative client/server integration surface
+
+## Already landed on the current line
+
+These are no longer open execution tasks:
+
+- Annotate prefill from stored annotations
+- Save Annotation wiring
+- Mark Done wiring
+- Annotated/Missing badge logic
+- Reviewed count from tags
+- Compare speaker forms from annotation data
+- Reference forms from enrichments
+- Compare Accept / Flag concept actions
+- Compare notes persistence
+- Actions > Import Speaker Data modal
+- Compute panel basic Run / Refresh wiring
+- Decisions basic load/save wiring in the unified shell
+- Manage Tags bulk-selection wiring
+
+## What is genuinely still open
+
+### 1. Reconcile the Actions menu with the **live** contract
+
+The next implementation work is not “add raw fetch calls from the old TODO.” It is:
+
+- verify which actions are fully backed by `python/server.py` today
+- normalize ParseUI action handlers to the typed client surface where possible
+- avoid creating a second ad hoc API path in `ParseUI.tsx`
+
+#### Specific audit points
+- `SpeakerImport` currently uses its own upload flow (`/api/onboard/speaker`) instead of a typed client helper; decide whether to keep that component-owned path or formalize it in `src/api/client.ts`
+- `src/api/client.ts` currently exposes helpers such as `startSTT()`, `startNormalize()`, `startCompute()`, and `getLingPyExport()`
+- before adding more UI wiring, confirm each corresponding server route exists in `python/server.py`
+- if a client helper exists without a server route, fix that mismatch first instead of building more UI on top of it
+
+### 2. Finish Actions menu job behavior, not just button clicks
+
+The remaining Actions work is about **progress, polling, and explicit success/error handling**:
+
+- Audio normalization
+- Orthographic STT
+- IPA transcription / pipeline step
+- Full pipeline orchestration
+- Cross-speaker match feedback
+- Reset Project confirmation + state reset review
+
+#### Desired outcome
+- one action state model for in-flight jobs
+- explicit progress/error UI
+- no silent background trigger with console-only failure reporting
+- action handlers grounded in the current contract, not the historical TODO doc
+
+### 3. Unify the decisions story
+
+Decisions are partially wired, but the plan now needs to answer:
+
+- what is the canonical persisted decisions format?
+- are decisions stored in enrichments, in `parse-decisions` localStorage, or both?
+- do Actions-menu decision load/save and right-rail decision load/save operate on the same structure?
+
+#### Required follow-up
+- inspect current decision writes in `src/ParseUI.tsx`
+- inspect any existing `parse-decisions` localStorage readers/writers elsewhere in the app
+- pick one canonical format and document it before more UI changes
+
+### 4. Verify compute-mode semantics against the server
+
+`useComputeJob` is already mounted in ParseUI, so the remaining work is to verify:
+
+- that each selected `computeMode` maps to a real supported server compute type
+- whether additional payload is needed (speaker subset / concept scope)
+- whether refresh semantics should reload enrichments only or also re-run compute
+
+### 5. C5 / C6 evidence after contract reconciliation
+
+Once the Actions / compute / decisions contract is coherent, the next gate is evidence:
+
+- use `docs/plans/phase4-c5-c6-signoff-checklist.md`
+- verify LingPy TSV export in the browser (C5)
+- verify full Annotate/Compare regression in the browser (C6)
+
+## Execution order
+
+1. **Do not** reopen completed annotate/compare wiring tasks from the historical TODO.
+2. Audit `src/ParseUI.tsx`, `src/api/client.ts`, and `python/server.py` together.
+3. Resolve client/server mismatches for Actions flows first.
+4. Unify decision persistence/load-save behavior.
+5. Re-run targeted tests and full test suite.
+6. Collect C5/C6 evidence.
+
+## Explicit non-goals for the next slice
+
+- Do not branch from `feat/annotate-ui-redesign`
+- Do not add raw `fetch()` calls to `ParseUI.tsx` just because the historical TODO says so
+- Do not start C7 cleanup / legacy deletion before Lucas clears C5 and C6
+
+## Suggested next implementation brief
+
+If starting the next code slice now, the brief should be:
+
+> Audit and reconcile ParseUI Actions menu handlers against the live typed client/server contract, then unify decisions persistence/load-save behavior, and only after that proceed to C5/C6 browser evidence.

--- a/docs/plans/parseui-current-state-plan.md
+++ b/docs/plans/parseui-current-state-plan.md
@@ -1,8 +1,8 @@
 # ParseUI current-state execution plan
 
-**Updated:** 2026-04-10
+**Updated:** 2026-06-14
 **Applies to:** `origin/main`
-**Code branch for implementation:** `feat/parseui-unified-shell`
+**Code branch policy:** new work branches from `origin/main` (per `AGENTS.md`); historical pivot branches like `feat/parseui-unified-shell` are archived
 **Docs branch for planning:** `docs/parseui-planning`
 
 ## TLDR
@@ -34,6 +34,7 @@ These are no longer open execution tasks:
 - Compute panel basic Run / Refresh wiring
 - Decisions basic load/save wiring in the unified shell
 - Manage Tags bulk-selection wiring
+- Spectrogram Worker — TS port (`src/workers/spectrogram-worker.ts`), `useSpectrogram` hook, AnnotateView `<canvas>` overlay wired (MC-297, PR #31)
 
 ## What is genuinely still open
 

--- a/docs/plans/parseui-wiring-todo.md
+++ b/docs/plans/parseui-wiring-todo.md
@@ -1,9 +1,11 @@
-# ParseUI Wiring TODO — for parse-gpt
+# ParseUI Wiring TODO — historical archive
 
-> **Branch:** `feat/annotate-ui-redesign`
-> **File:** `src/ParseUI.tsx`
-> **Status:** UI shell complete, hooks/stores partially wired. Work through this list top to bottom — priority order.
-> **Rule:** Run `npm run check` (tsc --noEmit) after every task. Do not proceed if it errors.
+> **Status:** Historical plan only — do **not** use this file as the live execution guide.
+> **Original branch context:** `feat/annotate-ui-redesign`
+> **Why archived:** this file predates the current `origin/main` state, the strict branch policy in `AGENTS.md`, and multiple merged ParseUI wiring slices.
+> **Already landed since this plan was written:** annotate prefill/save/mark/badge, compare real speaker forms/reference/reviewed count, import modal, notes persistence, compute run/refresh basic wiring, and decisions load/save basics.
+> **Current source of truth:** `docs/plans/parseui-current-state-plan.md`
+> **Rule:** For new work, start from `origin/main` and use the live client/server contract (`src/api/client.ts`, `python/server.py`) rather than the raw endpoint suggestions below.
 
 ---
 


### PR DESCRIPTION
## Summary
- mark `docs/plans/parseui-wiring-todo.md` as historical rather than a live execution guide
- add a new current-state ParseUI plan grounded in `origin/main` and the live client/server surface
- point `parsebuilder-todo.md` at the new source of truth

## Files
- docs/plans/parseui-current-state-plan.md
- docs/plans/parseui-wiring-todo.md
- docs/plans/parsebuilder-todo.md
- docs/plans/MC-306-parseui-current-state-plan.md

## Notes
- docs-only PR
- no tests required