### PR TITLE
feat(MC-297): wire spectrogram worker + hook into AnnotateView

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -14,6 +14,7 @@ import {
 import type { AnnotationInterval, AnnotationRecord, Tag as StoreTag } from './api/types';
 import { getLingPyExport, saveApiKey, startSTT, startCompute, startNormalize } from './api/client';
 import { useChatSession, type UseChatSessionResult } from './hooks/useChatSession';
+import { useSpectrogram } from './hooks/useSpectrogram';
 import { useWaveSurfer } from './hooks/useWaveSurfer';
 import { useAnnotationStore } from './stores/annotationStore';
 import { useAnnotationSync } from './hooks/useAnnotationSync';
@@ -952,11 +953,13 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
   }, [speaker, concept.key, ipaInterval, orthoInterval]);
 
   const [spectroOn, setSpectroOn] = useState(false);
+  const [audioReady, setAudioReady] = useState(false);
   const [activeRegion] = useState<string | null>(null);
   const [lexAnchor, setLexAnchor] = useState<'word' | 'concept'>('concept');
   const [zoom, setZoom] = useState(10); // minPxPerSec
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const spectroCanvasRef = useRef<HTMLCanvasElement | null>(null);
 
   const isPlaying = usePlaybackStore(s => s.isPlaying);
   const currentTime = usePlaybackStore(s => s.currentTime);
@@ -964,15 +967,17 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
   const selectedRegion = usePlaybackStore(s => s.selectedRegion);
   const annotated = Boolean(conceptInterval && ipaInterval);
 
-  const { playPause, skip, setZoom: wsSetZoom, setRate } = useWaveSurfer({
+  const { playPause, skip, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
     containerRef,
     audioUrl,
     peaksUrl,
     onTimeUpdate: t => usePlaybackStore.setState({ currentTime: t }),
-    onReady:      d => usePlaybackStore.setState({ duration: d }),
+    onReady: d => { usePlaybackStore.setState({ duration: d }); setAudioReady(true); },
     onPlayStateChange: p => usePlaybackStore.setState({ isPlaying: p }),
     onRegionUpdate: (start, end) => usePlaybackStore.setState({ selectedRegion: { start, end } }),
   });
+
+  useSpectrogram({ enabled: spectroOn && audioReady, wsRef, canvasRef: spectroCanvasRef });
 
   const fmt = (t: number) => {
     const m = Math.floor(t / 60).toString().padStart(2, '0');
@@ -1038,10 +1043,9 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
           </div>
 
           <div className="flex items-center gap-1.5">
-            {/* Spectrogram toggle — wire to src/workers/spectrogram-worker.ts later */}
             <button
               onClick={() => setSpectroOn(v => !v)}
-              title="Toggle spectrogram (worker-backed, coming soon)"
+              title="Toggle spectrogram"
               className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-semibold transition ${spectroOn ? 'bg-indigo-600 text-white' : 'border border-slate-200 bg-white text-slate-600 hover:bg-slate-50'}`}
             >
               <Activity className="h-3 w-3"/> Spectrogram
@@ -1057,15 +1061,11 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
               className="relative w-full overflow-hidden rounded-lg ring-1 ring-slate-100"
               style={{ minHeight: 110 }}
             />
-            {/* Spectrogram overlay — wire to src/workers/spectrogram-worker.ts (MC-297) */}
             {spectroOn && (
-              <div
-                className="pointer-events-none absolute inset-0 rounded-lg opacity-60"
-                style={{
-                  background: 'repeating-linear-gradient(90deg, rgba(79,70,229,0.35) 0 2px, rgba(236,72,153,0.25) 2px 4px, rgba(16,185,129,0.25) 4px 6px, transparent 6px 8px)',
-                  mixBlendMode: 'multiply',
-                }}
-                title="Spectrogram placeholder — real FFT heatmap coming via MC-297"
+              <canvas
+                ref={spectroCanvasRef}
+                className="pointer-events-none absolute inset-0 rounded-lg"
+                style={{ width: '100%', height: '100%', opacity: 0.6, mixBlendMode: 'multiply' }}
               />
             )}
           </div>

--- a/src/hooks/__tests__/useSpectrogram.test.ts
+++ b/src/hooks/__tests__/useSpectrogram.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useSpectrogram } from "../useSpectrogram";
+
+type MockWorker = {
+  postMessage: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+  onmessage: ((evt: MessageEvent) => void) | null;
+  onerror: ((evt: ErrorEvent) => void) | null;
+};
+
+function makeAudioBufferLike() {
+  return {
+    numberOfChannels: 1,
+    length: 4410,
+    sampleRate: 44100,
+    duration: 0.1,
+    getChannelData: () => new Float32Array(4410),
+  };
+}
+
+describe("useSpectrogram", () => {
+  let clearRect: ReturnType<typeof vi.fn>;
+  let drawImage: ReturnType<typeof vi.fn>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let getContextSpy: any;
+  let workerInstances: MockWorker[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let WorkerMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    clearRect = vi.fn();
+    drawImage = vi.fn();
+    workerInstances = [];
+
+    getContextSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, "getContext")
+      .mockImplementation((contextId: string) => {
+        if (contextId === "2d") {
+          return {
+            clearRect,
+            drawImage,
+          } as unknown as CanvasRenderingContext2D;
+        }
+        return null;
+      });
+
+    WorkerMock = vi.fn(() => {
+      const worker: MockWorker = {
+        postMessage: vi.fn(),
+        terminate: vi.fn(),
+        onmessage: null,
+        onerror: null,
+      };
+      workerInstances.push(worker);
+      return worker;
+    });
+
+    vi.stubGlobal("Worker", WorkerMock);
+  });
+
+  it("when enabled=false, does not create worker and clears canvas", () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 640;
+    canvas.height = 120;
+
+    const wsRef = { current: null };
+    const canvasRef = { current: canvas };
+
+    renderHook(() =>
+      useSpectrogram({
+        enabled: false,
+        wsRef: wsRef as never,
+        canvasRef: canvasRef as never,
+      }),
+    );
+
+    expect(WorkerMock).not.toHaveBeenCalled();
+    expect(getContextSpy).toHaveBeenCalledWith("2d");
+    expect(clearRect).toHaveBeenCalledWith(0, 0, 640, 120);
+  });
+
+  it("when enabled=true, creates worker and posts compute payload", () => {
+    const canvas = document.createElement("canvas");
+    const wsMock = {
+      getDecodedData: vi.fn(() => makeAudioBufferLike()),
+    };
+
+    const wsRef = { current: wsMock };
+    const canvasRef = { current: canvas };
+
+    renderHook(() =>
+      useSpectrogram({
+        enabled: true,
+        wsRef: wsRef as never,
+        canvasRef: canvasRef as never,
+        windowSize: 256,
+      }),
+    );
+
+    expect(WorkerMock).toHaveBeenCalledTimes(1);
+    expect(wsMock.getDecodedData).toHaveBeenCalledTimes(1);
+
+    const worker = workerInstances[0];
+    expect(worker.postMessage).toHaveBeenCalledTimes(1);
+
+    const [payload] = vi.mocked(worker.postMessage).mock.calls[0] as [
+      {
+        type: string;
+        audioData: Float32Array;
+        sampleRate: number;
+        windowSize: number;
+        startSec: number;
+        endSec: number;
+      },
+      Transferable[]
+    ];
+
+    expect(payload.type).toBe("compute");
+    expect(payload.audioData).toBeInstanceOf(Float32Array);
+    expect(payload.audioData.length).toBe(4410);
+    expect(payload.sampleRate).toBe(44100);
+    expect(payload.windowSize).toBe(256);
+    expect(payload.startSec).toBe(0);
+    expect(payload.endSec).toBe(0.1);
+  });
+
+  it("transfers audioData buffer in postMessage second argument", () => {
+    const canvas = document.createElement("canvas");
+    const wsRef = {
+      current: {
+        getDecodedData: vi.fn(() => makeAudioBufferLike()),
+      },
+    };
+    const canvasRef = { current: canvas };
+
+    renderHook(() =>
+      useSpectrogram({
+        enabled: true,
+        wsRef: wsRef as never,
+        canvasRef: canvasRef as never,
+      }),
+    );
+
+    const worker = workerInstances[0];
+    const [payload, transfer] = vi.mocked(worker.postMessage).mock.calls[0] as [
+      { audioData: Float32Array },
+      Transferable[]
+    ];
+
+    expect(Array.isArray(transfer)).toBe(true);
+    expect(transfer).toHaveLength(1);
+    expect(transfer[0]).toBe(payload.audioData.buffer);
+  });
+
+  it("terminates worker when enabled flips from true to false", () => {
+    const canvas = document.createElement("canvas");
+    const wsRef = {
+      current: {
+        getDecodedData: vi.fn(() => makeAudioBufferLike()),
+      },
+    };
+    const canvasRef = { current: canvas };
+
+    const { rerender } = renderHook(
+      (enabled: boolean) =>
+        useSpectrogram({
+          enabled,
+          wsRef: wsRef as never,
+          canvasRef: canvasRef as never,
+        }),
+      { initialProps: true },
+    );
+
+    const worker = workerInstances[0];
+    rerender(false);
+
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("terminates worker on unmount", () => {
+    const canvas = document.createElement("canvas");
+    const wsRef = {
+      current: {
+        getDecodedData: vi.fn(() => makeAudioBufferLike()),
+      },
+    };
+    const canvasRef = { current: canvas };
+
+    const { unmount } = renderHook(() =>
+      useSpectrogram({
+        enabled: true,
+        wsRef: wsRef as never,
+        canvasRef: canvasRef as never,
+      }),
+    );
+
+    const worker = workerInstances[0];
+    unmount();
+
+    expect(worker.terminate).toHaveBeenCalled();
+  });
+});

--- a/src/workers/spectrogram-worker.ts
+++ b/src/workers/spectrogram-worker.ts
@@ -168,6 +168,7 @@ function computeSTFT(
   const maxBin      = Math.min(totalBins - 1, Math.floor((freqCeiling * fftSize) / sampleRate));
   const numBins     = maxBin + 1;
 
+  // Enough left-aligned windows to cover the tail with zero-padding.
   const numFrames = Math.max(1, Math.ceil((samples.length - windowSize) / hopSize) + 1);
 
   const re = new Float64Array(fftSize);


### PR DESCRIPTION
## Summary

Wire the existing spectrogram STFT worker and `useSpectrogram` hook into the AnnotateView canvas overlay.

### What changed

| File | Change |
|---|---|
| `src/ParseUI.tsx` | Import `useSpectrogram`, add `audioReady` state (gated on `onReady`), add `spectroCanvasRef`, destructure `wsRef` from `useWaveSurfer`, call `useSpectrogram()`, replace placeholder gradient div with real `<canvas>`, remove 'coming soon' copy |
| `src/workers/spectrogram-worker.ts` | Add clarifying frame-count comment (review NIT from `reviews/spectrogram_worker_review.md`) |
| `src/hooks/__tests__/useSpectrogram.test.ts` | **New** — 5 unit tests: disabled state, compute payload, buffer transfer, terminate on disable, terminate on unmount |

### Data flow

```
Spectrogram button → spectroOn
                        ↓
onReady callback → audioReady
                        ↓
useSpectrogram({ enabled: spectroOn && audioReady, wsRef, canvasRef })
   → getDecodedData() → mono mixdown → Worker.postMessage (transferred)
   → Worker: Hann → STFT → dB → normalize → grayscale Uint8ClampedArray
   → onmessage: grayscale → RGBA → offscreen canvas → drawImage to <canvas>
```

### Pre-existing on `main` (not new in this PR)
- `src/workers/spectrogram-worker.ts` — full TS port with all review fixes (30s cap, floor bin clipping, timestamp validation)
- `src/hooks/useSpectrogram.ts` — complete hook (mono mixdown, Vite module worker, offscreen→display scaling, cleanup)

### Gate results
- `npx tsc --noEmit`: **clean** ✅
- `npm run test -- --run`: **119 tests passing** (23 files, floor: 102) ✅

### Notes
- Vite 5 handles `new Worker(new URL(...), { type: 'module' })` natively — no config needed
- Canvas uses `opacity: 0.6` + `mix-blend-mode: multiply` for waveform overlay compositing
- Worker buffer is transferred (zero-copy) via `postMessage` second arg