### PR TITLE
docs: fix PR #30 staleness — AGENTS.md, wiring-todo, contract mismatch table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
 # AGENTS.md — PARSE React + Vite Integration (2026)
 
-## Current State (updated 2026-05-14)
+## Current State (updated 2026-06-14)
 
-PARSE has already crossed the React pivot integration point on **`feat/parse-react-vite`**.
+PARSE has crossed the React pivot and the unified UI redesign is **merged to `main`**.
 
-- **UI Redesign complete** on `feat/annotate-ui-redesign` (MC-294):
-  - `src/ParseUI.tsx` — 1482-line unified shell (Annotate + Compare + Tags + AI Chat in one layout)
+- **UI Redesign landed** (MC-294, merged via multiple PRs through PR #31):
+  - `src/ParseUI.tsx` — unified shell (Annotate + Compare + Tags + AI Chat in one layout)
   - `App.tsx` simplified to `<BrowserRouter><ParseUI /></BrowserRouter>`
-  - Dependencies added: `lucide-react`, `tailwindcss v3`, `postcss`, `autoprefixer`
+  - Dependencies: `lucide-react`, `tailwindcss v3`, `postcss`, `autoprefixer`
   - Wired: `useWaveSurfer`, `useChatSession`, `useConfigStore`, `useTagStore`, `usePlaybackStore`, `useUIStore`, `useAnnotationSync`
-  - tsc: clean compile · pending PR merge to `main`
-  - TODO next: MOCK_FORMS → real store, Save Annotation intervals, spectrogram Worker, Cognate compute
+  - Spectrogram Worker TS port + `useSpectrogram` hook (MC-297, PR #31)
+  - Annotate prefill/save/mark/badge, compare real data, import modal, notes, compute basics, decisions basics, tags bulk-selection — all landed
 - **Phase C1–C4 complete** on integration branch:
   - Track merge (`feat/annotate-react` + `feat/compare-react`)
   - Cross-mode navigation (Annotate ↔ Compare)
@@ -22,6 +22,17 @@ PARSE has already crossed the React pivot integration point on **`feat/parse-rea
   - Server endpoints:
     - `POST /api/compute/contact-lexemes`
     - `GET /api/contact-lexemes/coverage`
+
+## Known Client/Server Contract Gaps
+
+These exist in `src/api/client.ts` without matching routes in `python/server.py`:
+
+| Client helper | Endpoint | Server status |
+|---|---|---|
+| `startNormalize()` | `POST /api/normalize` | ❌ No route in `server.py` — planned in MC-271 but never implemented |
+| *(raw fetch in `SpeakerImport.tsx`)* | `POST /api/onboard/speaker` | ❌ No route in `server.py` dispatch — component bypasses typed client |
+
+**Rule:** Do not build more UI on top of these until the server routes are implemented or the client helpers are removed.
 
 ## Release Gates (hard)
 
@@ -41,16 +52,15 @@ Do not start C7 early.
   - This uppercase clone currently follows archival/worktree history and may not match `origin/main`.
   - Do not use it as branch truth without an explicit fetch/prune check.
 
-### Canonical worktrees
-- Historical React pivot worktrees remain useful for traceability:
-  - Integration root: `/home/lucas/gh/ArdeleanLucas/PARSE` → `feat/parse-react-vite`
-  - Annotate lane: `/home/lucas/gh/worktrees/PARSE/annotate-react` → `feat/annotate-react`
-  - Compare lane: `/home/lucas/gh/worktrees/PARSE/compare-react` → `feat/compare-react`
-- These worktrees describe migration history; they are not automatically the current runtime source of truth.
+### Historical worktrees (traceability only)
+- Integration root: `/home/lucas/gh/ArdeleanLucas/PARSE` → `feat/parse-react-vite`
+- Annotate lane: `/home/lucas/gh/worktrees/PARSE/annotate-react` → `feat/annotate-react`
+- Compare lane: `/home/lucas/gh/worktrees/PARSE/compare-react` → `feat/compare-react`
+- These worktrees describe migration history; they are not the current runtime source of truth.
 
 ### Active development rule
 - **New work should branch from `origin/main` in `/home/lucas/gh/ardeleanlucas/parse` unless Lucas explicitly changes repo policy.**
-- `feat/annotate-react`, `feat/compare-react`, and `feat/parse-react-vite` are historical pivot lanes, not default bases for new work.
+- `feat/annotate-react`, `feat/compare-react`, `feat/parse-react-vite`, and `feat/annotate-ui-redesign` are historical pivot lanes, not default bases for new work.
 - Do not assume stale track branches or archival clones reflect current `main`.
 
 ## Ownership + Coordination
@@ -90,7 +100,7 @@ npm run test -- --run
 ./node_modules/.bin/tsc --noEmit
 ```
 
-Expected floor: **>=102 passing tests** and clean TypeScript compile.
+Expected floor: **>=119 passing tests** and clean TypeScript compile.
 
 ## Baseline Architecture
 

--- a/docs/plans/parseui-current-state-plan.md
+++ b/docs/plans/parseui-current-state-plan.md
@@ -11,7 +11,7 @@ Do not execute `docs/plans/parseui-wiring-todo.md` literally anymore. Most of it
 
 ## Live sources of truth
 
-1. `AGENTS.md` — branch policy and release gates
+1. `AGENTS.md` — branch policy, release gates, and known contract gaps
 2. `docs/plans/parsebuilder-todo.md` — high-level current status / blocked gate
 3. `src/ParseUI.tsx` — implemented UI state and current affordances
 4. `src/ParseUI.test.tsx` — regression coverage for landed ParseUI slices
@@ -38,25 +38,35 @@ These are no longer open execution tasks:
 
 ## What is genuinely still open
 
-### 1. Reconcile the Actions menu with the **live** contract
+### 1. Fix known client/server contract mismatches
 
-The next implementation work is not “add raw fetch calls from the old TODO.” It is:
+Before any more UI wiring, resolve these concrete gaps between `src/api/client.ts` and `python/server.py`:
 
-- verify which actions are fully backed by `python/server.py` today
+| Client surface | Endpoint | Server status | Action needed |
+|---|---|---|---|
+| `startNormalize(speaker)` in `client.ts` | `POST /api/normalize` | ❌ **No route** in `server.py` — planned in MC-271 but never implemented | Either implement the server route or remove the dead client helper |
+| Raw `fetch()` in `SpeakerImport.tsx` | `POST /api/onboard/speaker` | ❌ **No route** in `server.py` dispatch table (README documents it, but dispatch doesn't handle it) | Either add the route to `server.py` or formalize through the typed `client.ts` layer with a working endpoint |
+| `startSTT()` in `client.ts` | `POST /api/stt` | ✅ Route exists | No action — verified |
+| `startCompute()` in `client.ts` | `POST /api/compute/{type}` | ✅ Route exists (dynamic dispatch) | No action — verified |
+| `getLingPyExport()` in `client.ts` | `GET /api/export/lingpy` | ✅ Route exists | No action — verified |
+| `getNEXUSExport()` in `client.ts` | `GET /api/export/nexus` | ✅ Route exists | No action — verified |
+| `pollSTT()` in `client.ts` | `POST /api/stt/status` | ✅ Route exists | No action — verified |
+
+**Rule:** Do not build more Actions-menu UI on top of a client helper that 404s. Fix the gap first.
+
+### 2. Reconcile the Actions menu with the **live** contract
+
+The next implementation work is not "add raw fetch calls from the old TODO." It is:
+
+- verify which actions are fully backed by `python/server.py` today (see table above — most verified, two broken)
 - normalize ParseUI action handlers to the typed client surface where possible
 - avoid creating a second ad hoc API path in `ParseUI.tsx`
 
-#### Specific audit points
-- `SpeakerImport` currently uses its own upload flow (`/api/onboard/speaker`) instead of a typed client helper; decide whether to keep that component-owned path or formalize it in `src/api/client.ts`
-- `src/api/client.ts` currently exposes helpers such as `startSTT()`, `startNormalize()`, `startCompute()`, and `getLingPyExport()`
-- before adding more UI wiring, confirm each corresponding server route exists in `python/server.py`
-- if a client helper exists without a server route, fix that mismatch first instead of building more UI on top of it
-
-### 2. Finish Actions menu job behavior, not just button clicks
+### 3. Finish Actions menu job behavior, not just button clicks
 
 The remaining Actions work is about **progress, polling, and explicit success/error handling**:
 
-- Audio normalization
+- Audio normalization (⚠️ blocked on `/api/normalize` server route)
 - Orthographic STT
 - IPA transcription / pipeline step
 - Full pipeline orchestration
@@ -69,7 +79,7 @@ The remaining Actions work is about **progress, polling, and explicit success/er
 - no silent background trigger with console-only failure reporting
 - action handlers grounded in the current contract, not the historical TODO doc
 
-### 3. Unify the decisions story
+### 4. Unify the decisions story
 
 Decisions are partially wired, but the plan now needs to answer:
 
@@ -82,7 +92,7 @@ Decisions are partially wired, but the plan now needs to answer:
 - inspect any existing `parse-decisions` localStorage readers/writers elsewhere in the app
 - pick one canonical format and document it before more UI changes
 
-### 4. Verify compute-mode semantics against the server
+### 5. Verify compute-mode semantics against the server
 
 `useComputeJob` is already mounted in ParseUI, so the remaining work is to verify:
 
@@ -90,7 +100,7 @@ Decisions are partially wired, but the plan now needs to answer:
 - whether additional payload is needed (speaker subset / concept scope)
 - whether refresh semantics should reload enrichments only or also re-run compute
 
-### 5. C5 / C6 evidence after contract reconciliation
+### 6. C5 / C6 evidence after contract reconciliation
 
 Once the Actions / compute / decisions contract is coherent, the next gate is evidence:
 
@@ -101,11 +111,12 @@ Once the Actions / compute / decisions contract is coherent, the next gate is ev
 ## Execution order
 
 1. **Do not** reopen completed annotate/compare wiring tasks from the historical TODO.
-2. Audit `src/ParseUI.tsx`, `src/api/client.ts`, and `python/server.py` together.
-3. Resolve client/server mismatches for Actions flows first.
-4. Unify decision persistence/load-save behavior.
-5. Re-run targeted tests and full test suite.
-6. Collect C5/C6 evidence.
+2. **Fix the two known contract gaps** (`/api/normalize`, `/api/onboard/speaker`) before building more UI.
+3. Audit `src/ParseUI.tsx`, `src/api/client.ts`, and `python/server.py` together.
+4. Resolve remaining client/server mismatches for Actions flows.
+5. Unify decision persistence/load-save behavior.
+6. Re-run targeted tests and full test suite.
+7. Collect C5/C6 evidence.
 
 ## Explicit non-goals for the next slice
 
@@ -117,4 +128,4 @@ Once the Actions / compute / decisions contract is coherent, the next gate is ev
 
 If starting the next code slice now, the brief should be:
 
-> Audit and reconcile ParseUI Actions menu handlers against the live typed client/server contract, then unify decisions persistence/load-save behavior, and only after that proceed to C5/C6 browser evidence.
+> Fix the two broken contract gaps (`POST /api/normalize` route in server.py; `POST /api/onboard/speaker` route in server.py or migration to typed client), then audit remaining ParseUI Actions menu handlers against the live contract, unify decisions persistence, and proceed to C5/C6 browser evidence.

--- a/docs/plans/parseui-wiring-todo.md
+++ b/docs/plans/parseui-wiring-todo.md
@@ -3,272 +3,57 @@
 > **Status:** Historical plan only — do **not** use this file as the live execution guide.
 > **Original branch context:** `feat/annotate-ui-redesign`
 > **Why archived:** this file predates the current `origin/main` state, the strict branch policy in `AGENTS.md`, and multiple merged ParseUI wiring slices.
-> **Already landed since this plan was written:** annotate prefill/save/mark/badge, compare real speaker forms/reference/reviewed count, import modal, notes persistence, compute run/refresh basic wiring, and decisions load/save basics.
+> **Already landed since this plan was written:** annotate prefill/save/mark/badge, compare real speaker forms/reference/reviewed count, import modal, notes persistence, compute run/refresh basic wiring, decisions load/save basics, manage tags bulk-selection, spectrogram worker TS port (MC-297).
 > **Current source of truth:** `docs/plans/parseui-current-state-plan.md`
 > **Rule:** For new work, start from `origin/main` and use the live client/server contract (`src/api/client.ts`, `python/server.py`) rather than the raw endpoint suggestions below.
 
 ---
 
+<details>
+<summary>Original task checklist (collapsed — all items either landed or superseded)</summary>
+
 ## Priority 1 — Core Annotation Workflow (thesis-critical)
 
-### TASK 1 — Fix stale `CONCEPTS` / `SPEAKERS` references
-**File:** `src/ParseUI.tsx`
-
-- [ ] Line 863: `const concept = CONCEPTS.find(...)` → change to `concepts.find(...)`
-- [ ] Line 865: `const total = CONCEPTS.length` → change to `concepts.length`
-- [ ] Line 1300: `{SPEAKERS.length}` → `{speakers.length}`
-
-These three were missed in the initial wiring pass. `concepts` and `speakers` are already derived from `useConfigStore` — just the references need updating.
-
----
-
-### TASK 2 — Load IPA/ortho from `annotationStore` on concept/speaker change
-**File:** `src/ParseUI.tsx` — `AnnotateView` component (line ~498)
-
-Currently `ipa` and `ortho` are plain local `useState('')`. They need to pre-populate from the stored annotation when the concept or speaker changes.
-
-- [ ] Import `useAnnotationStore` at the top of the file
-- [ ] Inside `AnnotateView`, subscribe to `annotationStore.records[speaker]`
-- [ ] On mount and when `concept` or `speaker` changes, find the interval in `tiers.ipa` and `tiers.ortho` whose text matches the current concept (look up by concept name in `tiers.concept` intervals — find the interval whose `text` contains `concept.name`, then get the corresponding IPA/ortho interval at the same time range)
-- [ ] Pre-populate `ipa` and `ortho` state with that text (empty string if not found)
-
-**Relevant store shape:**
-```typescript
-// annotationStore.records[speaker].tiers.ipa.intervals[]
-// each interval: { start: number, end: number, text: string }
-// annotationStore.records[speaker].tiers.concept.intervals[]
-// find concept interval where text includes concept.name, use its start/end to match ipa/ortho
-```
-
----
-
-### TASK 3 — Wire "Save Annotation" button
-**File:** `src/ParseUI.tsx` — `AnnotateView`, line ~733
-
-Currently renders with no `onClick`.
-
-- [ ] Import `useAnnotationStore` (if not already done from Task 2)
-- [ ] Get `selectedRegion` from `usePlaybackStore` (has `start` and `end` from the active WaveSurfer region)
-- [ ] On save: call `annotationStore.setInterval(speaker, 'ipa', { start, end, text: ipa })` and `annotationStore.setInterval(speaker, 'ortho', { start, end, text: ortho })`
-- [ ] Also write a `concept` tier interval: `annotationStore.setInterval(speaker, 'concept', { start, end, text: concept.name })`
-- [ ] Then call `annotationStore.saveSpeaker(speaker)` to persist
-
-Check `src/stores/annotationStore.ts` for the exact method signatures before implementing.
-
----
-
-### TASK 4 — Wire "Mark Done" button
-**File:** `src/ParseUI.tsx` — `AnnotateView`, line ~736
-
-- [ ] On click: call `tagStore.tagConcept('confirmed', concept.id.toString())`
-- [ ] Visually: the concept dot in the sidebar will update automatically since `concepts` is derived from `getTagsForConcept`
-
----
-
-### TASK 5 — Fix "Missing" badge — make it reactive
-**File:** `src/ParseUI.tsx` — `AnnotateView`, line 690–692
-
-Currently hardcoded `Missing` badge always shows.
-
-- [ ] Check `annotationStore.records[speaker]?.tiers.ipa.intervals` — if there is at least one interval whose time range overlaps with a concept tier interval for `concept.name`, consider it annotated
-- [ ] If annotated: show a green "Annotated" or "Done" badge instead
-- [ ] If not annotated: keep the rose "Missing" badge
-
----
-
-### TASK 6 — Stale comment cleanup in `AnnotateView`
-**File:** `src/ParseUI.tsx`
-
-- [ ] Lines 451–468: delete the entire JSDoc block that says `The waveform below is a styled mock...` — the hook is already wired
-- [ ] Lines 592–595: delete the `{/* TODO: Replace mock... */}` comment block — already done
-- [ ] Line 127 (inside `AIChat` `useEffect`): change `[messages, minimized]` dependency to `[chatSession.messages, minimized]`
-
----
+- ~~TASK 1 — Fix stale CONCEPTS / SPEAKERS references~~ → landed
+- ~~TASK 2 — Load IPA/ortho from annotationStore~~ → landed
+- ~~TASK 3 — Wire Save Annotation button~~ → landed
+- ~~TASK 4 — Wire Mark Done button~~ → landed
+- ~~TASK 5 — Fix Missing badge reactivity~~ → landed
+- ~~TASK 6 — Stale comment cleanup~~ → landed
 
 ## Priority 2 — Compare Mode Real Data
 
-### TASK 7 — Replace `MOCK_FORMS` with real annotation data
-**File:** `src/ParseUI.tsx` — Compare mode, line ~1158
-
-`MOCK_FORMS` is a hardcoded array of 5 speaker forms. It needs to be derived from `annotationStore`.
-
-- [ ] Inside `ParseUI`, after stores are set up, build `speakerForms` with `useMemo`:
-  - For each speaker in `selectedSpeakers`:
-    - Get `annotationStore.records[speaker]`
-    - Find IPA interval(s) for the current concept (match via concept tier)
-    - Count utterance intervals for that concept
-    - Get `arabicSim` and `persianSim` from `enrichmentStore` (check `src/stores/enrichmentStore.ts` for shape)
-    - Get cognate group from enrichments (if available, else `'—'`)
-    - Get `flagged` from tagStore — is the concept tagged `problematic`?
-  - Return `SpeakerForm[]`
-- [ ] Replace `MOCK_FORMS.filter(f => selectedSpeakers.includes(f.speaker)).map(...)` at line 1158 with `speakerForms.map(...)`
-- [ ] If enrichment data isn't available for a speaker+concept, show `0.00` similarity and `'—'` cognate — do not crash
-
----
-
-### TASK 8 — Wire Reference forms from `enrichmentStore`
-**File:** `src/ParseUI.tsx` — Compare mode, lines 1122–1140
-
-Currently hardcoded Arabic رماد and Persian خاکستر.
-
-- [ ] Check `src/stores/enrichmentStore.ts` for what data is available per concept
-- [ ] Get enrichments for the current `concept.name` from the store
-- [ ] Replace the hardcoded Arabic script + IPA with real values from enrichments
-- [ ] Replace the hardcoded Persian script + IPA with real values from enrichments
-- [ ] If enrichments not available for this concept: show a "No reference data" placeholder — do not crash
-- [ ] Wire the `Volume2` audio play buttons to play a reference audio file if one exists in enrichments (or leave as no-op with a `title="Reference audio not available"` if not)
-
----
-
-### TASK 9 — Wire Accept / Flag concept buttons
-**File:** `src/ParseUI.tsx` — Compare mode, lines 1113–1118
-
-- [ ] **Flag button** (line 1113): `onClick={() => tagStore.tagConcept('problematic', concept.id.toString())}`
-- [ ] **Accept concept button** (line 1116): `onClick={() => tagStore.tagConcept('confirmed', concept.id.toString())}`
-- [ ] Make the buttons visually reflect current state — if already confirmed, show filled/active state; same for flagged
-
----
-
-### TASK 10 — Wire Notes field persistence
-**File:** `src/ParseUI.tsx` — Compare mode, line ~1220
-
-Currently `notes` is local `useState`. It needs to persist.
-
-- [ ] On blur (or debounced onChange): write to `annotationStore` — either as a dedicated `notes` tier interval or as metadata on the record
-- [ ] On concept/speaker change: load the saved note for that concept (empty string if none)
-- [ ] Check whether `annotationStore` has a mechanism for free-form notes — if not, store in `localStorage` keyed by `concept.id` as a minimal interim solution
-
----
-
-### TASK 11 — Wire per-speaker Flag toggle in Compare table
-**File:** `src/ParseUI.tsx` — Compare mode, line ~1176
-
-Currently the flag button renders `f.flagged` from `MOCK_FORMS` with no `onClick`.
-
-- [ ] After TASK 7, `f.flagged` comes from `tagStore`. Wire the button `onClick` to toggle:
-  - If flagged: `tagStore.untagConcept('problematic', concept.id.toString())`
-  - If not: `tagStore.tagConcept('problematic', concept.id.toString())`
-
----
-
-### TASK 12 — Wire `reviewed` count
-**File:** `src/ParseUI.tsx` — line 864
-
-Currently `const reviewed = 0`.
-
-- [ ] Compute: count how many concepts in the current concept list have at least one confirmed tag (`tagStore.getTagsForConcept(c.id.toString()).some(t => t.id === 'confirmed')`)
-- [ ] Use that as `reviewed`
-
----
+- ~~TASK 7 — Replace MOCK_FORMS with real annotation data~~ → landed
+- ~~TASK 8 — Wire Reference forms from enrichmentStore~~ → landed
+- ~~TASK 9 — Wire Accept / Flag concept buttons~~ → landed
+- ~~TASK 10 — Wire Notes field persistence~~ → landed
+- ~~TASK 11 — Wire per-speaker Flag toggle~~ → landed
+- ~~TASK 12 — Wire reviewed count~~ → landed
 
 ## Priority 3 — Actions Menu (Pipeline Triggers)
 
-### TASK 13 — Wire Actions menu items to real API endpoints
-**File:** `src/ParseUI.tsx` — lines 966–988
-
-All items currently just call `setActionsMenuOpen(false)`.
-
-Wire each to its real endpoint using `fetch` + poll pattern (same as used in legacy `parse.html`):
-
-| Label | Endpoint | Notes |
-|---|---|---|
-| Import Speaker Data… | Open onboarding modal or `POST /api/import/upload` | Can be a modal trigger for now |
-| Run Audio Normalization | `POST /api/normalize` + poll `GET /api/normalize/status/<jobId>` | Show progress in topbar |
-| Run Orthographic STT | `POST /api/stt` with `{ model: 'razhan' }` + poll | Show progress |
-| Run IPA Transcription | `POST /api/pipeline/run` with `{ ipa_only: true }` + poll | Show progress |
-| Run Full Pipeline | Sequential: normalize → STT → IPA | Client-side orchestration |
-| Run Cross-Speaker Match | `POST /api/compute/contact-lexemes` | Uses `useComputeJob` |
-| Load Decisions | File input → parse JSON → merge into stores | |
-| Save Decisions | `GET /api/export/lingpy` → download TSV | |
-| Reset Project | Confirmation modal → clear all stores + localStorage | |
-
-- [ ] Add a `runningAction` local state to show inline progress in the topbar area
-- [ ] Each action should: close the dropdown → show progress → complete/error
-
----
+- ~~TASK 13 — Wire Actions menu items~~ → partially landed (import modal done; normalize/STT/pipeline still need server route verification per `parseui-current-state-plan.md`)
 
 ## Priority 4 — Compare Compute
 
-### TASK 14 — Wire Compute panel Run + Refresh buttons
-**File:** `src/ParseUI.tsx` — right panel, lines 1351–1357
-
-- [ ] Import `useComputeJob` from `src/hooks/useComputeJob.ts`
-- [ ] **Run button**: call `useComputeJob` to `POST /api/compute/contact-lexemes` for current selectedSpeakers + concept
-- [ ] **Refresh button**: re-fetch enrichments from store
-- [ ] Show a loading spinner or disabled state while job is running
-
----
-
-### TASK 15 — Wire Cognate decision buttons
-**File:** `src/ParseUI.tsx` — lines 1189–1201
-
-Accept / Split / Merge / Cycle — these modify cognate groupings in the compute result.
-
-- [ ] Check what API endpoints exist for cognate decisions (look in `python/server.py` for `/api/decisions` or similar)
-- [ ] Wire Accept: save current grouping as a decision
-- [ ] Wire Split / Merge / Cycle: mutate cognate groupings locally and persist to decisions JSON
-- [ ] If no backend endpoint exists yet: write to `localStorage` keyed by `concept.id` as interim
-
----
+- ~~TASK 14 — Wire Compute panel Run + Refresh~~ → landed (basic wiring)
+- TASK 15 — Wire Cognate decision buttons → open (decisions story needs unification, see current-state plan §3)
 
 ## Priority 5 — Tags Mode
 
-### TASK 16 — Wire concept checkboxes in ManageTagsView
-**File:** `src/ParseUI.tsx` — `ManageTagsView` component, line ~433
+- ~~TASK 16 — Wire concept checkboxes in ManageTagsView~~ → landed
 
-- [ ] Add local `checkedConcepts: Set<string>` state inside `ManageTagsView`
-- [ ] `onChange` on each checkbox: toggle that concept's id in `checkedConcepts`
-- [ ] Pre-check concepts that already have `selectedTag` applied: check if `selectedTag.id` is in `tagStore.getTagsForConcept(c.id.toString()).map(t => t.id)`
-- [ ] **Apply to selected button** (line 411): for each id in `checkedConcepts`, call `tagConcept(selectedTag.id, conceptId)` — pass `tagConcept` + `untagConcept` as props from `ParseUI`
-- [ ] **Clear selection button** (line 408): reset `checkedConcepts` to empty Set
+## Priority 6 — Spectrogram
 
----
+- ~~TASK 17 — Port spectrogram worker to TypeScript~~ → landed (MC-297, PR #31)
 
-## Priority 6 — Spectrogram (post-thesis, low urgency)
+## Right rail Save buttons
 
-### TASK 17 — Port spectrogram worker to TypeScript
-**Files:** New: `src/workers/spectrogram-worker.ts`, `src/hooks/useSpectrogram.ts`
+- ~~TASK 18 — Wire right rail Save buttons~~ → partially landed (annotate save done; compare decisions save depends on TASK 15)
 
-The legacy worker lives at `parse/js/shared/spectrogram-worker.js` (273 lines, STFT/FFT pipeline).
-
-- [ ] Copy logic to `src/workers/spectrogram-worker.ts` — add TypeScript types
-- [ ] Create `src/hooks/useSpectrogram.ts` — manages the Worker lifecycle, posts PCM data, receives `Uint8ClampedArray` image data
-- [ ] In `AnnotateView`: when `spectroOn` is true, get the decoded audio buffer from WaveSurfer (`wsRef.current?.getDecodedData()`), post it to the worker, draw result on a `<canvas>` overlay inside the waveform container
-- [ ] Replace the CSS gradient placeholder with the real canvas
+</details>
 
 ---
 
-## Right rail Save buttons (Annotate + Compare)
-
-### TASK 18 — Wire right rail Save buttons
-**File:** `src/ParseUI.tsx`
-
-- [ ] **Annotate mode right rail "Save annotations"** (line ~1471): same as TASK 3 — call `annotationStore.saveSpeaker(speaker)`
-- [ ] **Compare mode right rail "Save decisions"** (line ~1407): same as TASK 15 — persist decisions JSON
-- [ ] **Compare mode right rail "Load decisions"** (line ~1405): same as TASK 13 Load Decisions
-
----
-
-## Verification checklist after all tasks done
-
-```bash
-# In /home/lucas/gh/ardeleanlucas/parse
-npm run check          # must be 0 errors
-npm run test -- --run  # must be >=102 passing
-```
-
-Then open in browser at `http://localhost:5173`:
-- [ ] Switch to Annotate mode → select a speaker → waveform loads real audio
-- [ ] IPA field pre-populates if annotation exists
-- [ ] Type IPA → Save → reload → IPA still there
-- [ ] Mark Done → concept dot turns green in sidebar
-- [ ] Switch to Compare mode → speaker forms table shows real IPA (not ash/bark placeholder data)
-- [ ] Accept concept → confirmed badge updates
-- [ ] Tags mode → check a concept → Apply to selected → concept dot updates
-- [ ] Actions menu → Run Audio Normalization → progress shows in topbar
-
----
-
-> **parse-gpt:** Work task by task. Do not batch multiple tasks into one commit.
-> Commit message format: `feat(parseui): wire <task name> (#<task number>)`
-> Open a PR to `feat/annotate-ui-redesign` — do not merge to `main`.
+> **parse-gpt / ParseBuilder:** Do not reopen completed tasks from this file.
+> Follow `docs/plans/parseui-current-state-plan.md` for remaining work.


### PR DESCRIPTION
## What this fixes

Post-merge review of PR #30 found three docs issues. This PR resolves all of them.

### 1. AGENTS.md was stale (HIGH)
- Removed references to `feat/annotate-ui-redesign` as if it were the active branch
- Removed "pending PR merge to `main`" — the redesign already merged
- Removed stale TODO list (MOCK_FORMS, spectrogram Worker, etc. — all landed)
- Added **Known Client/Server Contract Gaps** section documenting:
  - `startNormalize()` → `POST /api/normalize` — no server route
  - `SpeakerImport.tsx` raw `fetch()` → `POST /api/onboard/speaker` — no server route
- Bumped test floor from >=102 to >=119

### 2. parseui-wiring-todo.md kept full stale checklist (MEDIUM)
- Collapsed the entire unchecked task list into a `<details>` block
- Each task marked as landed or superseded with strikethrough
- Archive banner preserved and expanded

### 3. parseui-current-state-plan.md lacked concrete mismatches (MEDIUM)
- Replaced vague "reconcile contract" with a concrete audit table:
  - Each `client.ts` helper mapped to its endpoint + server route status
  - Two broken (❌ no route) and five verified (✅)
- Reordered execution: fix the two gaps *before* building more UI
- Updated suggested next implementation brief to lead with gap fixes

## Files changed
- `AGENTS.md`
- `docs/plans/parseui-wiring-todo.md`
- `docs/plans/parseui-current-state-plan.md`

## Notes
- Docs-only PR, no tests required
- Addresses all findings from the PR #30 post-merge audit