### PR TITLE
docs: sync AGENTS.md + plan after contract gaps resolved (PR #33)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,16 +23,21 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
     - `POST /api/compute/contact-lexemes`
     - `GET /api/contact-lexemes/coverage`
 
-## Known Client/Server Contract Gaps
+## Client/Server Contract Surface
 
-These exist in `src/api/client.ts` without matching routes in `python/server.py`:
+All `src/api/client.ts` helpers have matching routes in `python/server.py`:
 
 | Client helper | Endpoint | Server status |
 |---|---|---|
-| `startNormalize()` | `POST /api/normalize` | ❌ No route in `server.py` — planned in MC-271 but never implemented |
-| *(raw fetch in `SpeakerImport.tsx`)* | `POST /api/onboard/speaker` | ❌ No route in `server.py` dispatch — component bypasses typed client |
+| `onboardSpeaker()` | `POST /api/onboard/speaker` | ✅ Multipart upload, background job |
+| `pollOnboardSpeaker()` | `POST /api/onboard/speaker/status` | ✅ Job poll |
+| `startNormalize()` | `POST /api/normalize` | ✅ ffmpeg loudnorm pipeline |
+| `pollNormalize()` | `POST /api/normalize/status` | ✅ Job poll |
+| `startSTT()` | `POST /api/stt` | ✅ |
+| `startCompute()` | `POST /api/compute/{type}` | ✅ Dynamic dispatch |
+| `getLingPyExport()` | `GET /api/export/lingpy` | ✅ |
 
-**Rule:** Do not build more UI on top of these until the server routes are implemented or the client helpers are removed.
+**Rule:** Keep this table current. Every new client helper must have a matching server route before merge.
 
 ## Release Gates (hard)
 

--- a/docs/plans/parseui-current-state-plan.md
+++ b/docs/plans/parseui-current-state-plan.md
@@ -38,35 +38,35 @@ These are no longer open execution tasks:
 
 ## What is genuinely still open
 
-### 1. Fix known client/server contract mismatches
+### 1. ~~Fix known client/server contract mismatches~~ ✅ DONE
 
-Before any more UI wiring, resolve these concrete gaps between `src/api/client.ts` and `python/server.py`:
+All contract gaps have been resolved (PR #33):
 
-| Client surface | Endpoint | Server status | Action needed |
-|---|---|---|---|
-| `startNormalize(speaker)` in `client.ts` | `POST /api/normalize` | ❌ **No route** in `server.py` — planned in MC-271 but never implemented | Either implement the server route or remove the dead client helper |
-| Raw `fetch()` in `SpeakerImport.tsx` | `POST /api/onboard/speaker` | ❌ **No route** in `server.py` dispatch table (README documents it, but dispatch doesn't handle it) | Either add the route to `server.py` or formalize through the typed `client.ts` layer with a working endpoint |
-| `startSTT()` in `client.ts` | `POST /api/stt` | ✅ Route exists | No action — verified |
-| `startCompute()` in `client.ts` | `POST /api/compute/{type}` | ✅ Route exists (dynamic dispatch) | No action — verified |
-| `getLingPyExport()` in `client.ts` | `GET /api/export/lingpy` | ✅ Route exists | No action — verified |
-| `getNEXUSExport()` in `client.ts` | `GET /api/export/nexus` | ✅ Route exists | No action — verified |
-| `pollSTT()` in `client.ts` | `POST /api/stt/status` | ✅ Route exists | No action — verified |
+| Client surface | Endpoint | Server status |
+|---|---|---|
+| `onboardSpeaker()` in `client.ts` | `POST /api/onboard/speaker` | ✅ Implemented — multipart upload, background job |
+| `pollOnboardSpeaker()` in `client.ts` | `POST /api/onboard/speaker/status` | ✅ Implemented — job poll |
+| `startNormalize()` in `client.ts` | `POST /api/normalize` | ✅ Implemented — ffmpeg loudnorm |
+| `pollNormalize()` in `client.ts` | `POST /api/normalize/status` | ✅ Implemented — job poll |
+| `startSTT()` in `client.ts` | `POST /api/stt` | ✅ Existing |
+| `startCompute()` in `client.ts` | `POST /api/compute/{type}` | ✅ Existing |
+| `getLingPyExport()` in `client.ts` | `GET /api/export/lingpy` | ✅ Existing |
 
-**Rule:** Do not build more Actions-menu UI on top of a client helper that 404s. Fix the gap first.
+`SpeakerImport.tsx` now uses the typed client (`onboardSpeaker` + `pollOnboardSpeaker`) instead of raw `fetch()`.
 
 ### 2. Reconcile the Actions menu with the **live** contract
 
 The next implementation work is not "add raw fetch calls from the old TODO." It is:
 
-- verify which actions are fully backed by `python/server.py` today (see table above — most verified, two broken)
-- normalize ParseUI action handlers to the typed client surface where possible
+- all actions are now backed by `python/server.py` (see table above — zero gaps)
+- normalize remaining ParseUI action handlers to the typed client surface where possible
 - avoid creating a second ad hoc API path in `ParseUI.tsx`
 
 ### 3. Finish Actions menu job behavior, not just button clicks
 
 The remaining Actions work is about **progress, polling, and explicit success/error handling**:
 
-- Audio normalization (⚠️ blocked on `/api/normalize` server route)
+- Audio normalization
 - Orthographic STT
 - IPA transcription / pipeline step
 - Full pipeline orchestration
@@ -110,10 +110,10 @@ Once the Actions / compute / decisions contract is coherent, the next gate is ev
 
 ## Execution order
 
-1. **Do not** reopen completed annotate/compare wiring tasks from the historical TODO.
-2. **Fix the two known contract gaps** (`/api/normalize`, `/api/onboard/speaker`) before building more UI.
+1. ~~**Fix the two known contract gaps** (`/api/normalize`, `/api/onboard/speaker`)~~ ✅ Done (PR #33)
+2. **Do not** reopen completed annotate/compare wiring tasks from the historical TODO.
 3. Audit `src/ParseUI.tsx`, `src/api/client.ts`, and `python/server.py` together.
-4. Resolve remaining client/server mismatches for Actions flows.
+4. Wire remaining Actions menu handlers to the typed client surface.
 5. Unify decision persistence/load-save behavior.
 6. Re-run targeted tests and full test suite.
 7. Collect C5/C6 evidence.
@@ -128,4 +128,4 @@ Once the Actions / compute / decisions contract is coherent, the next gate is ev
 
 If starting the next code slice now, the brief should be:
 
-> Fix the two broken contract gaps (`POST /api/normalize` route in server.py; `POST /api/onboard/speaker` route in server.py or migration to typed client), then audit remaining ParseUI Actions menu handlers against the live contract, unify decisions persistence, and proceed to C5/C6 browser evidence.
+> Contract gaps are fixed. Audit remaining ParseUI Actions menu handlers against the live typed client/server contract, wire progress/error UI for in-flight jobs, unify decisions persistence/load-save behavior, and proceed to C5/C6 browser evidence.


### PR DESCRIPTION
## Summary

PR #32 (merged without reviewer — my mistake) documented two contract gaps as ❌ broken. PR #33 (merged) fixed them with real server routes. This PR syncs the docs to reflect the resolved state.

### Changes

**AGENTS.md**
- Renamed 'Known Client/Server Contract Gaps' → 'Client/Server Contract Surface'
- Updated table: all 7 client helpers now show ✅ with matching server routes
- Added new entries: `onboardSpeaker()`, `pollOnboardSpeaker()`, `pollNormalize()`
- Updated rule: 'keep this table current' instead of 'do not build on gaps'

**docs/plans/parseui-current-state-plan.md**
- Marked §1 (contract fix) as ✅ DONE with PR #33 reference
- Replaced ❌ audit table with ✅ verified table
- Removed 'blocked on /api/normalize' warning from Actions menu section
- Updated execution order: step 1 done, remaining steps renumbered
- Updated suggested next brief

### Notes
- Docs-only PR, no code changes, no tests needed
- Fixes the staleness left by PR #32 merging before PR #33 landed