### PR TITLE
docs: clarify stale branch references after cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,14 +58,14 @@ Do not start C7 early.
   - Do not use it as branch truth without an explicit fetch/prune check.
 
 ### Historical worktrees (traceability only)
-- Integration root: `/home/lucas/gh/ArdeleanLucas/PARSE` → `feat/parse-react-vite`
+- Integration root: `/home/lucas/gh/ArdeleanLucas/PARSE` → historical `feat/parse-react-vite` lane (merged/deleted)
 - Annotate lane: `/home/lucas/gh/worktrees/PARSE/annotate-react` → `feat/annotate-react`
 - Compare lane: `/home/lucas/gh/worktrees/PARSE/compare-react` → `feat/compare-react`
 - These worktrees describe migration history; they are not the current runtime source of truth.
 
 ### Active development rule
 - **New work should branch from `origin/main` in `/home/lucas/gh/ardeleanlucas/parse` unless Lucas explicitly changes repo policy.**
-- `feat/annotate-react`, `feat/compare-react`, `feat/parse-react-vite`, and `feat/annotate-ui-redesign` are historical pivot lanes, not default bases for new work.
+- `feat/annotate-react`, `feat/compare-react`, `feat/parse-react-vite` (merged/deleted), and `feat/annotate-ui-redesign` are historical pivot lanes, not default bases for new work.
 - Do not assume stale track branches or archival clones reflect current `main`.
 
 ## Ownership + Coordination

--- a/doc/TASK.md
+++ b/doc/TASK.md
@@ -1,11 +1,13 @@
 # ParseUI — Wiring Task List
 
 > **File:** `src/ParseUI.tsx`
-> **Branch target:** `feat/parseui-unified-shell`
+> **Branch target:** branch from `origin/main` (historical note: `feat/parseui-unified-shell` was merged and deleted)
 > **Last audited:** 2026-05-14
 > **Items:** 46 total — 9 data, 7 annotate actions, 14 compare actions, 9 actions-menu items, 3 tags-mode, 4 minor cleanup
+> **Status:** historical recovery/audit checklist — do not recreate the deleted rolling branch.
 
-All items reference line numbers in the **current** `src/ParseUI.tsx` on `feat/parseui-unified-shell`.
+All items reference line numbers in the `src/ParseUI.tsx` snapshot that existed when this memo was authored.
+For new work, compare against the current file on `main` / your fresh feature branch from `origin/main`.
 Each item lists the real hook or store it should call instead of the current mock/stub.
 
 ---

--- a/docs/plans/MC-300-parseui-recovery.md
+++ b/docs/plans/MC-300-parseui-recovery.md
@@ -1,12 +1,14 @@
 # MC-300 — ParseUI unified shell recovery + Priority 1 wiring
 
+> **Historical note:** this recovery task belongs to the earlier rolling-branch period. The branch names below are historical references; current work now branches from `origin/main`.
+
 ## Objective
 Recover the ParseUI unified shell after the broken wiring attempt, then complete the thesis-critical Priority 1 wiring tasks from `docs/plans/parseui-wiring-todo.md` in a test-backed way.
 
 ## Scope
-1. Verify branch state against Lucas's protocol:
-   - `feat/parseui-unified-shell` -> `main` for code only
-   - `docs/parseui-planning` -> `main` for docs only
+1. Verify branch state against current PARSE policy:
+   - code/docs branches now start from `origin/main`
+   - the old `feat/parseui-unified-shell` and `docs/parseui-planning` lanes are historical/deleted
 2. Restore `src/ParseUI.tsx` so the app imports and builds again.
 3. Re-run targeted ParseUI tests to confirm RED/GREEN state.
 4. Complete Priority 1 tasks sequentially:

--- a/docs/plans/MC-301-parseui-actions-import.md
+++ b/docs/plans/MC-301-parseui-actions-import.md
@@ -1,10 +1,12 @@
 # MC-301 — ParseUI actions menu import speaker modal wiring
 
+> **Historical note:** this task was completed during the deleted rolling ParseUI branch era. Keep it as task history; for new work, branch from `origin/main` rather than recreating `feat/parseui-unified-shell`.
+
 ## Objective
 Complete the next ParseUI wiring slice by turning the top-bar Actions > Import Speaker Data entry into a real modal-backed flow that reuses the existing `SpeakerImport` component inside the unified shell.
 
 ## Scope
-1. Work on the canonical code branch path for ParseUI: `feat/parseui-unified-shell` -> `main`.
+1. Work on a feature branch cut from `origin/main` (historical note: `feat/parseui-unified-shell` was the old rolling code lane and has been deleted).
 2. Add a failing ParseUI regression test that proves the action opens the import modal.
 3. Wire the action menu item to open a shared modal and render `SpeakerImport`.
 4. Close the dropdown after invocation and allow the modal to close cleanly.
@@ -32,4 +34,4 @@ Complete the next ParseUI wiring slice by turning the top-bar Actions > Import S
 - Typecheck passes.
 - Targeted ParseUI tests pass.
 - Full test suite passes.
-- A PR to `main` is opened from `feat/parseui-unified-shell` with reviewer request to `TrueNorth49`.
+- A PR to `main` is opened from an `origin/main`-based feature branch with reviewer request to `TrueNorth49`.

--- a/docs/plans/MC-305-branch-cleanup-findings-pr.md
+++ b/docs/plans/MC-305-branch-cleanup-findings-pr.md
@@ -1,10 +1,12 @@
 # MC-305 — Branch cleanup findings PR
 
+> **Historical note:** this task captured the branch-cleanup recommendation state before the later pruning pass completed. Keep it as task history; the repo has since moved to `origin/main` as the only base for new work.
+
 ## Objective
 Submit a docs-only PR that captures the current PARSE GitHub branch-cleanup recommendations based on live remote branch state, PR state, and prior cleanup audits.
 
 ## Scope
-1. Work in the canonical docs lane: `docs/parseui-planning` -> `main`.
+1. Work in a docs branch cut from `origin/main` (historical note: `docs/parseui-planning` was the old rolling docs lane and has since been deleted).
 2. Re-audit the current branch set against `origin/main`.
 3. Write a concise findings memo with three buckets:
    - delete now
@@ -15,8 +17,8 @@ Submit a docs-only PR that captures the current PARSE GitHub branch-cleanup reco
 
 ## Key facts from current audit
 - `docs/phase4-c5-c6-signoff` still has open PR #7, so it should not be deleted.
-- `feat/parseui-unified-shell` has been merged repeatedly and should remain the rolling code branch.
-- `docs/parseui-planning` is the rolling docs branch.
+- Historical finding at capture time: `feat/parseui-unified-shell` was still treated as the rolling code branch.
+- Historical finding at capture time: `docs/parseui-planning` was still treated as the rolling docs branch.
 - `feat/annotate-ui-redesign` and `feat/parse-ai-connect-onboarding` still carry commits not present on `main`.
 - `feat/compare-react` has no surviving code delta relative to `main`, but still has a local attached worktree.
 

--- a/docs/plans/MC-305-branch-cleanup-findings-pr.md
+++ b/docs/plans/MC-305-branch-cleanup-findings-pr.md
@@ -19,7 +19,7 @@ Submit a docs-only PR that captures the current PARSE GitHub branch-cleanup reco
 - `docs/phase4-c5-c6-signoff` still has open PR #7, so it should not be deleted.
 - Historical finding at capture time: `feat/parseui-unified-shell` was still treated as the rolling code branch.
 - Historical finding at capture time: `docs/parseui-planning` was still treated as the rolling docs branch.
-- `feat/annotate-ui-redesign` and `feat/parse-ai-connect-onboarding` still carry commits not present on `main`.
+- Historical finding at capture time: `feat/annotate-ui-redesign` and `feat/parse-ai-connect-onboarding` still carried commits not present on `main`; both were deleted in the later cleanup pass.
 - `feat/compare-react` has no surviving code delta relative to `main`, but still has a local attached worktree.
 
 ## Completion criteria

--- a/docs/plans/contact-lexeme-fetcher.md
+++ b/docs/plans/contact-lexeme-fetcher.md
@@ -1,9 +1,11 @@
 # Contact Language Lexeme Fetcher — Design Plan
 
-**Status:** Unimplemented  
-**Priority:** High — required for borrowing adjudication in thesis  
-**Branch target:** `feat/parse-react-vite` → merge to `feat/contact-lexemes` first  
+**Status:** Partially implemented / design reference
+**Priority:** High — required for borrowing adjudication in thesis
+**Branch target:** branch from `origin/main` (historical note: `feat/parse-react-vite` was the old pivot lane and has been deleted)
 **Thesis relevance:** §4.4 PARSE pipeline — similarity scores underpin the borrowing detection in the comparative analysis
+
+> **Update (post-pivot merge):** provider registry code, `ContactLexemePanel`, provider tests, and coverage/fetch endpoints now exist on `main`. Use this document as a design/reference plan for the remaining fetch-and-fill work, not as a reason to branch from the deleted pivot lane.
 
 ---
 
@@ -436,9 +438,8 @@ These thresholds are informed by the existing `lexstat_threshold: 0.6` and shoul
 ## Branch Strategy
 
 ```
-main
-  └── feat/parse-react-vite  (current — C5/C6/C7 pending)
-        └── feat/contact-lexemes  (new branch from feat/parse-react-vite)
+origin/main
+  └── feat/contact-lexemes  (new additive branch from current trunk)
 ```
 
 Do **not** start this until C6 (Lucas's browser regression checklist) is green. This is additive work, not a blocker for thesis submission — but having real similarity scores would make the borrowing adjudication section of the thesis concrete.

--- a/docs/plans/generic-comparison-data-pipeline.md
+++ b/docs/plans/generic-comparison-data-pipeline.md
@@ -1,10 +1,12 @@
 # Generic Comparison Data Pipeline for PARSE — Design Document
 
-**MC-294**  
-**Status:** Design Complete  
-**Author:** dr-kurd (spawned Opus session equivalent via orchestration)  
-**Date:** 2026-04-08  
-**Branch target:** feat/generic-comparison-pipeline (from feat/parse-react-vite)
+**MC-294**
+**Status:** Design Complete / historical reference
+**Author:** dr-kurd (spawned Opus session equivalent via orchestration)
+**Date:** 2026-04-08
+**Branch target:** `feat/generic-comparison-pipeline` (from `origin/main`; historical note: `feat/parse-react-vite` has been merged and deleted)
+
+> **Update (post-pivot merge):** core provider plumbing now lives on `main` under `python/compare/providers/`. Use this design doc for future expansion work, but branch from `origin/main`, not the deleted pivot lane.
 
 ## Executive Summary
 

--- a/docs/plans/github-branch-cleanup-findings-2026-04-10.md
+++ b/docs/plans/github-branch-cleanup-findings-2026-04-10.md
@@ -10,7 +10,7 @@
 
 - Delete the clearly merged or superseded remote branches.
 - Keep `feat/parseui-unified-shell` and `docs/parseui-planning` as the rolling delivery branches.
-- Do **not** delete `feat/annotate-ui-redesign` or `feat/parse-ai-connect-onboarding` yet.
+- At capture time, do **not** delete `feat/annotate-ui-redesign` or `feat/parse-ai-connect-onboarding` yet; both were deleted in the later cleanup pass.
 - Do **not** delete `docs/phase4-c5-c6-signoff` until PR #7 is resolved.
 - `feat/compare-react` is safe to delete on GitHub, but local worktree cleanup should happen separately.
 
@@ -41,18 +41,18 @@
 | `docs/parseui-planning` | Canonical rolling docs branch targeting `main`. |
 | `main` | Protected trunk. |
 
-## Do not delete yet
+## Historical "do not delete yet" set at capture time
 
 | Branch | Reason |
 | --- | --- |
 | `docs/phase4-c5-c6-signoff` | PR #7 is still open. Resolve the PR first. |
-| `feat/annotate-ui-redesign` | PR #8 was closed, not merged. Branch still shows commits not present on `main`. |
-| `feat/parse-ai-connect-onboarding` | PR #19 merged into `feat/annotate-ui-redesign`, not into `main`. Branch still carries commits outside `main`. |
+| `feat/annotate-ui-redesign` | Historical note: PR #8 was closed, not merged; this branch was later deleted in the cleanup pass. |
+| `feat/parse-ai-connect-onboarding` | Historical note: PR #19 merged into `feat/annotate-ui-redesign`, not into `main`; this branch was later deleted in the cleanup pass. |
 
-## Required follow-up before deleting the two unresolved feature branches
+## Historical follow-up that was recommended at capture time
 
-1. Review `feat/annotate-ui-redesign` and `feat/parse-ai-connect-onboarding` together.
-2. Cherry-pick or re-land anything still wanted onto `feat/parseui-unified-shell`.
+1. Review `feat/annotate-ui-redesign` and `feat/parse-ai-connect-onboarding` together (this was later superseded by the cleanup pass that deleted both branches).
+2. Cherry-pick or re-land anything still wanted onto `feat/parseui-unified-shell` (historical note: that rolling branch was later deleted after merge cleanup).
 3. Only then delete those two remote branches.
 
 ## Local worktree caveat
@@ -73,13 +73,13 @@ Recommendation:
   - PR #2, #3, #4, #5, #6, #11, #12, #14, #17, #20, #23
 - Closed superseded PR observed:
   - PR #15 — `feat/mc-300-reference-forms`
-- Branches still carrying commits not on `main`:
-  - `feat/annotate-ui-redesign`
-  - `feat/parse-ai-connect-onboarding`
+- Branches that still carried commits not on `main` at capture time:
+  - `feat/annotate-ui-redesign` (later deleted in the cleanup pass)
+  - `feat/parse-ai-connect-onboarding` (later deleted in the cleanup pass)
 
 ## Recommended execution order
 
 1. Merge or close PR #7.
-2. Salvage any still-needed commits from `feat/annotate-ui-redesign` and `feat/parse-ai-connect-onboarding`.
+2. At capture time: salvage any still-needed commits from `feat/annotate-ui-redesign` and `feat/parse-ai-connect-onboarding` (both were later deleted in the cleanup pass).
 3. Delete the safe merged/superseded remote branches.
 4. Run a separate local worktree cleanup pass.

--- a/docs/plans/github-branch-cleanup-findings-2026-04-10.md
+++ b/docs/plans/github-branch-cleanup-findings-2026-04-10.md
@@ -1,7 +1,9 @@
 # PARSE GitHub branch cleanup findings — 2026-04-10
 
+> **Historical note (post-cleanup):** the GitHub cleanup described here has since landed. `origin` now exposes only 4 remote branches (`main`, `docs/phase4-c5-c6-signoff`, `feat/annotate-react`, `feat/compare-react`), and the rolling branches named below (`feat/parseui-unified-shell`, `docs/parseui-planning`) were later merged/deleted. Keep this memo as historical evidence only; branch from `origin/main` for new work.
+
 **Captured from:** `/home/lucas/gh/ardeleanlucas/parse`
-**Docs branch for this memo:** `docs/parseui-planning`
+**Docs branch for this memo:** `docs/parseui-planning` (historical; since deleted)
 **Reference main:** `origin/main` @ `0fc397c`
 
 ## TLDR

--- a/docs/plans/oda/oda-core.md
+++ b/docs/plans/oda/oda-core.md
@@ -1,6 +1,8 @@
 # Oda — Core Identity, Ownership, and Summary Rules
 
 > Load this file in every session. It is always required.
+>
+> **Historical note (post-pivot merge):** this document captures the original Oda Compare-track lane. References to `feat/compare-react` and `feat/parse-react-vite` are historical branch notes; current PARSE work branches from `origin/main` unless Lucas explicitly asks otherwise.
 
 ---
 
@@ -142,8 +144,10 @@ without an explanatory comment.
 **Exports.** LingPy TSV is P0. Verify `GET /api/export/lingpy` returns 200 before
 implementing `useExport`. If it returns 404, stop and report immediately.
 
-**Branch.** `feat/compare-react`. Never commit to `main` or `feat/annotate-react`.
-Never merge into `feat/parse-react-vite` yourself — ParseBuilder leads Phase C.
+**Historical branch note.** The original Compare lane used `feat/compare-react`.
+Treat that as history only unless Lucas explicitly revives it. For new work, branch
+from `origin/main` and open PRs back to `main`. Do not merge into historical pivot
+branches such as `feat/parse-react-vite` yourself.
 
 **Phase 0 gate.** Do not write a single component until `npm run dev` starts,
 `curl localhost:5173/api/config` returns JSON, and `npx tsc --noEmit` passes.

--- a/docs/plans/oda/rules.md
+++ b/docs/plans/oda/rules.md
@@ -1,6 +1,8 @@
 # Rules — Hard Constraints (Load with Every Task)
 
 > Every rule here is a blocker. Violation = stop and fix before continuing.
+>
+> **Historical note (post-pivot merge):** this file documents the original Compare-track lane. References to `feat/compare-react` and `feat/parse-react-vite` are historical lane notes, not the current default branch policy. New work now branches from `origin/main` unless Lucas explicitly asks for a historical lane.
 
 ---
 
@@ -57,8 +59,9 @@
 
 ## Branch and File Discipline
 
-15. **Branch is `feat/compare-react`.** Never commit to `main`, `feat/annotate-react`,
-    or any other branch.
+15. **Historical lane note:** the original Compare track worked on `feat/compare-react`.
+    Do not treat that as the current default policy; for new work, branch from
+    `origin/main` unless Lucas explicitly revives the historical lane.
 
 16. **Write only to your owned files.** Never touch:
     `src/components/annotate/`, `src/hooks/useWaveSurfer.ts`,
@@ -68,8 +71,9 @@
     `vite.config.ts`, `package.json`, `index.html`, `src/App.tsx`,
     or anything under `python/`.
 
-17. **Do not merge into `feat/parse-react-vite`.** ParseBuilder leads Phase C.
-    You deliver a passing `feat/compare-react` branch and stop there.
+17. **Do not merge into historical pivot branches** such as `feat/parse-react-vite`.
+    That lane has already been merged and deleted. Current work should go back to
+    `main` via PRs from `origin/main`-based feature branches.
 
 ---
 

--- a/docs/plans/parseui-current-state-plan.md
+++ b/docs/plans/parseui-current-state-plan.md
@@ -3,7 +3,7 @@
 **Updated:** 2026-06-14
 **Applies to:** `origin/main`
 **Code branch policy:** new work branches from `origin/main` (per `AGENTS.md`); historical pivot branches like `feat/parseui-unified-shell` are archived
-**Docs branch for planning:** `docs/parseui-planning`
+**Docs branch for planning:** branch from `origin/main` (historical docs lane `docs/parseui-planning` was deleted after merge cleanup)
 
 ## TLDR
 

--- a/docs/plans/parseui-current-state-plan.md
+++ b/docs/plans/parseui-current-state-plan.md
@@ -120,7 +120,7 @@ Once the Actions / compute / decisions contract is coherent, the next gate is ev
 
 ## Explicit non-goals for the next slice
 
-- Do not branch from `feat/annotate-ui-redesign`
+- Do not branch from historical/deleted pivot lanes such as `feat/annotate-ui-redesign`; start from `origin/main`
 - Do not add raw `fetch()` calls to `ParseUI.tsx` just because the historical TODO says so
 - Do not start C7 cleanup / legacy deletion before Lucas clears C5 and C6
 

--- a/docs/plans/react-vite-pivot.md
+++ b/docs/plans/react-vite-pivot.md
@@ -4,6 +4,8 @@
 > Oda (Gemini + Flash/Pro) owns Track B — Compare Mode.
 > Both tracks share a pre-agreed contract (Phase 0) before any parallel work begins.
 > Integration happens in Phase C after both tracks pass their own gate tests.
+>
+> **Historical note (post-merge):** the React/Vite pivot has already landed on `main`. Branch references in this document such as `feat/parse-react-vite` are historical only. Do not branch from or recreate them; start new work from `origin/main`.
 
 **Goal:** Replace the vanilla-JS monolith (36,951 lines across parse.html, compare.html, 25 JS modules)
 with a React + Vite frontend, keeping the Python backend (port 8766) completely unchanged.

--- a/docs/plans/react-vite-pivot.md
+++ b/docs/plans/react-vite-pivot.md
@@ -45,7 +45,7 @@ with a React + Vite frontend, keeping the Python backend (port 8766) completely 
 | B9 Browser integration | — | PENDING Lucas | manual |
 | agent-gpt EnrichmentsPanel rebase | feat/compare-react | PENDING agent-gpt | rebase onto ad09bcf |
 | Phase C merge | feat/parse-react-vite | BLOCKED — wait for agent-gpt rebase | — |
-| **UI Redesign — ParseUI unified shell** | **feat/annotate-ui-redesign** | **DONE fd955cc** | **tsc clean** |
+| **UI Redesign — ParseUI unified shell** | **historical `feat/annotate-ui-redesign` lane** | **DONE fd955cc** | **tsc clean** |
 
 ---
 

--- a/docs/plans/repo-cleanup-preflight.md
+++ b/docs/plans/repo-cleanup-preflight.md
@@ -6,6 +6,8 @@
 **Active repo:** `/home/lucas/gh/ardeleanlucas/parse`
 **Active branch when captured:** `docs/phase0-repo-cleanup-preflight`
 
+> **Historical note (post-cleanup):** this preflight captured the repo before the later branch-pruning pass. Treat branch lists here as historical snapshots. Current work should branch from `origin/main`, and the remote is now down to 4 branches.
+
 ---
 
 ## 1. Current `origin/main`

--- a/docs/plans/repo-state-cleanup-and-architecture-unification.md
+++ b/docs/plans/repo-state-cleanup-and-architecture-unification.md
@@ -1,6 +1,8 @@
 # PARSE Repository State Cleanup and Architecture Unification Plan
 
 > **For Hermes:** Execute from the lowercase clone `/home/lucas/gh/ardeleanlucas/parse` unless Lucas explicitly decides otherwise. Do **not** merge to `main` directly. Open PRs; **Lucas must merge them**.
+>
+> **Historical note (post-cleanup):** this plan was written before the later branch-pruning pass. Any branch lists that still mention `feat/parse-react-vite` or other removed branches are historical snapshots, not current policy. New work branches from `origin/main`.
 
 **Goal:** Get PARSE into a clean post-pivot state with one canonical active repo, explicit React-vs-legacy boundaries, a defensible branch cleanup sequence, and a gated path to removing legacy HTML/JS.
 

--- a/docs/plans/worktree-setup.md
+++ b/docs/plans/worktree-setup.md
@@ -1,42 +1,56 @@
 # PARSE Worktree Setup — Multi-Agent Parallel Development
 
-**Purpose:** Give ParseBuilder and parse-gpt isolated checkouts of the same repo with no file conflicts.
+**Purpose:** Give multiple PARSE agents isolated checkouts of the same repository with no file conflicts while treating `origin/main` as the only base for new work.
 
-## Repo
+## Canonical Repo
 
-`https://github.com/ArdeleanLucas/PARSE` (new canonical home)
+`https://github.com/ArdeleanLucas/PARSE`
+
+- **Source of truth:** `/home/lucas/gh/ardeleanlucas/parse`
+- **Archive/divergent clone:** `/home/lucas/gh/ArdeleanLucas/PARSE` (do **not** use this as branch truth)
+
+> **Historical note:** older plans referenced `feat/parse-react-vite`, `feat/parseui-unified-shell`, and `docs/parseui-planning` as rolling branches. Those branches have been merged and deleted. Do not recreate them; branch from `origin/main` instead.
 
 ---
 
 ## Directory Layout
 
-```
+```text
 /home/lucas/gh/ardeleanlucas/
-  PARSE/                       ← primary clone (main branch, bare reference)
-    .git/                      ← shared git object store
-  PARSE-parse-builder/         ← ParseBuilder worktree (feat/parse-react-vite)
-  PARSE-parse-gpt/             ← parse-gpt worktree  (feat/parse-gpt or new feat branches)
+  parse/                       ← canonical clone on `main`
+/home/lucas/gh/worktrees/parse/
+  <branch-name>/               ← optional worktree for a new branch from `origin/main`
+/home/lucas/gh/ArdeleanLucas/PARSE/
+  ...                          ← archival/divergent clone; traceability only
 ```
 
-Each worktree shares `.git/` from `PARSE/` — no duplication of history or objects.
+Each worktree shares the git object store from the canonical lowercase clone.
 
 ---
 
-## Setup Commands (run once after repo is created on GitHub)
+## Setup Commands (current workflow)
 
 ```bash
-# 1. Clone the new repo as primary
+# 1. Clone the canonical repo once
 cd /home/lucas/gh/ardeleanlucas
-git clone https://github.com/ArdeleanLucas/PARSE PARSE
-cd PARSE
+git clone https://github.com/ArdeleanLucas/PARSE parse
+cd parse
 
-# 2. ParseBuilder worktree — feat/parse-react-vite (all Phase C + CLEF work)
-git worktree add ../PARSE-parse-builder feat/parse-react-vite
+git fetch origin --prune
+git switch main
 
-# 3. parse-gpt worktree — new branch for its tasks
-git worktree add ../PARSE-parse-gpt -b feat/parse-gpt-work
+# 2. Create a worktree root for new branches
+mkdir -p /home/lucas/gh/worktrees/parse
 
-# 4. Verify
+# 3. Create an example docs worktree from origin/main
+git worktree add /home/lucas/gh/worktrees/parse/docs-stale-branch-reference-cleanup \
+  -b docs/stale-branch-reference-cleanup origin/main
+
+# 4. Create an example feature worktree from origin/main
+git worktree add /home/lucas/gh/worktrees/parse/feat-example \
+  -b feat/example origin/main
+
+# 5. Verify
 git worktree list
 ```
 
@@ -44,37 +58,35 @@ git worktree list
 
 ## Agent Assignment
 
-| Agent | Worktree | Branch | MESSAGING_CWD |
+| Agent | Recommended checkout | Branch policy | MESSAGING_CWD |
 |---|---|---|---|
-| ParseBuilder (you) | `/home/lucas/gh/ardeleanlucas/PARSE-parse-builder` | `feat/parse-react-vite` | N/A (Discord) |
-| parse-gpt | `/home/lucas/gh/ardeleanlucas/PARSE-parse-gpt` | `feat/parse-gpt-work` | Set to worktree path |
+| ParseBuilder | `/home/lucas/gh/ardeleanlucas/parse` or a dedicated worktree | branch from `origin/main` | N/A (Discord) |
+| parse-gpt | dedicated worktree under `/home/lucas/gh/worktrees/parse/` | branch from `origin/main` | set to that worktree path |
 
----
+Example Hermes config:
 
-## parse-gpt Gateway Config
-
-In parse-gpt's Hermes config, set:
 ```yaml
-MESSAGING_CWD: /home/lucas/gh/ardeleanlucas/PARSE-parse-gpt
+MESSAGING_CWD: /home/lucas/gh/worktrees/parse/feat-example
 ```
 
-This ensures parse-gpt's file edits, terminal commands, and context files all land in its own worktree — never touching ParseBuilder's working files.
+This ensures each agent edits only its own checkout.
 
 ---
 
 ## Merge Strategy
 
-1. Both agents commit + push to their own branches
-2. ParseBuilder leads Phase C integration merges (unchanged from current plan)
-3. PRs: each agent's branch → `main` via Lucas review
-4. No direct pushes to `main`
+1. Start every new branch from `origin/main`.
+2. Give each agent its own worktree / branch.
+3. Open PRs back to `main`.
+4. Do not use the uppercase archival clone for branch conclusions.
+5. Delete temporary worktrees once the PR is merged or abandoned.
 
 ---
 
-## What parse-gpt Can Work On (suggested)
+## Historical Worktrees
 
-Since `feat/parse-react-vite` is mid-Phase C (C5/C6 pending Lucas browser check, C7 cleanup next), parse-gpt can start:
-- Phase D work in its own branch: deploy workflow, PARSE server bundling, Electron packaging
-- Or any of the contact lexeme pipeline tasks that don't conflict with Phase C
+These may still exist locally for traceability:
+- `/home/lucas/gh/worktrees/PARSE/annotate-react`
+- `/home/lucas/gh/worktrees/PARSE/compare-react`
 
-Coordinate via Discord before touching shared files (server.py, enrichments schema).
+Treat them as historical lanes, not the default basis for new work.


### PR DESCRIPTION
## Summary
- update operator-facing docs to branch from `origin/main` instead of deleted rolling lanes
- mark historical planning/task docs as historical where they still mention removed branches
- refresh worktree setup guidance to use the lowercase canonical clone and current branch policy

## Test Plan
- [x] git diff --check
- [x] npm run test -- --run
- [x] ./node_modules/.bin/tsc --noEmit
