### PR TITLE
fix: server crash on Windows — Unicode checkmarks in startup banner

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -3095,7 +3095,7 @@ def main() -> None:
         print("    Annotate: http://{0}:{1}/parse.html".format(ip, PORT))
         print("    Compare : http://{0}:{1}/compare.html".format(ip, PORT))
     print()
-    print("  Features: Range requests ✓  CORS ✓  Threaded ✓  API ✓")
+    print("  Features: Range requests [x]  CORS [x]  Threaded [x]  API [x]")
     print("  Press Ctrl+C to stop.")
     print("=" * 60)
 


### PR DESCRIPTION
The server startup banner used `✓` (U+2713) which crashes on Windows cp1252 console:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2713' in position 27
```

This prevented `parse-run` from starting the server at all on WSL.

**Fix:** Replace `✓` with `[x]` in the single print statement.

One-line change. Already patched in the deploy clone (`parse_v2`) — this PR syncs it to main.