### PR TITLE
fix: harden ParseUI action job follow-up flow

### DIFF
--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { AnnotationRecord, AnnotationInterval, ProjectConfig, Tag } from "./api/types";
 
@@ -218,7 +218,10 @@ beforeEach(() => {
   mockConfigSetState.mockClear();
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe("ParseUI", () => {
   it("loads config and tag hydration on mount and computes reviewed count from confirmed tags", () => {
@@ -401,13 +404,32 @@ describe("Actions menu job lifecycle", () => {
     expect(screen.getByText("Run Cross-Speaker Match")).toBeTruthy();
   });
 
-  it("action buttons show running label while job is in progress", async () => {
+  it("shows topbar normalize progress and disables the button while running", async () => {
+    vi.useFakeTimers();
+    vi.mocked(apiClient.startNormalize).mockResolvedValue({ job_id: "normalize-1" });
+    vi.mocked(apiClient.pollNormalize).mockResolvedValue({ status: "running", progress: 25, segments: [] });
+
     render(<ParseUI />);
 
     fireEvent.click(screen.getByRole("button", { name: "Actions" }));
-    fireEvent.click(screen.getByRole("button", { name: "Run Audio Normalization" }));
 
-    await waitFor(() => expect(apiClient.startNormalize).toHaveBeenCalledWith("Fail01"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Run Audio Normalization" }));
+      await Promise.resolve();
+    });
+
+    expect(apiClient.startNormalize).toHaveBeenCalledWith("Fail01");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(screen.getByTestId("topbar-action-statuses")).toBeTruthy();
+    expect(screen.getByText("Normalizing audio…")).toBeTruthy();
+    expect(screen.getByText("25%")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    expect((screen.getByRole("button", { name: "Normalizing…" }) as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("action buttons have disabled class when applicable", () => {
@@ -420,14 +442,56 @@ describe("Actions menu job lifecycle", () => {
     expect(normalizeButton.className).toContain("disabled:cursor-not-allowed");
   });
 
-  it("Reset Project clears action job states", () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  it("shows retry for action errors and reruns the job", async () => {
+    vi.useFakeTimers();
+    vi.mocked(apiClient.startNormalize)
+      .mockResolvedValueOnce({ job_id: "normalize-error-1" })
+      .mockResolvedValueOnce({ job_id: "normalize-error-2" });
+    vi.mocked(apiClient.pollNormalize)
+      .mockResolvedValueOnce({ status: "error", progress: 40, segments: [], message: "Normalize failed" } as unknown as Awaited<ReturnType<typeof apiClient.pollNormalize>>)
+      .mockResolvedValue({ status: "running", progress: 60, segments: [] });
 
     render(<ParseUI />);
 
     fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Run Audio Normalization" }));
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(screen.getByText("Normalize failed")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      await Promise.resolve();
+    });
+
+    expect(apiClient.startNormalize).toHaveBeenCalledTimes(2);
+  });
+
+  it("Reset Project clears action job states", async () => {
+    vi.useFakeTimers();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(apiClient.startNormalize).mockResolvedValue({ job_id: "normalize-reset" });
+    vi.mocked(apiClient.pollNormalize).mockResolvedValue({ status: "running", progress: 10, segments: [] });
+
+    render(<ParseUI />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run Audio Normalization" }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(screen.getByTestId("topbar-action-statuses")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Actions" }));
     fireEvent.click(screen.getByRole("button", { name: "Reset Project" }));
 
+    expect(screen.queryByTestId("topbar-action-statuses")).toBeNull();
     expect(confirmSpy).toHaveBeenCalled();
     expect(mockAnnotationSetState).toHaveBeenCalledWith({ records: {}, dirty: {}, loading: {} });
     expect(mockEnrichmentSetState).toHaveBeenCalledWith({ data: {}, loading: false });

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1235,35 +1235,46 @@ export function ParseUI() {
   const [selectedSpeakers, setSelectedSpeakers] = useState<string[]>(['Fail01','Kzn03','Shz05','Tbr07','Isf09']);
   const [speakerPicker, setSpeakerPicker] = useState('Fail02');
   const [computeMode, setComputeMode] = useState('cognates');
-  const { start: startComputeJob, state: computeJobState } = useComputeJob(computeMode);
+  const { start: startComputeJob, state: computeJobState, reset: resetComputeJob } = useComputeJob(computeMode);
   const [notes, setNotes] = useState('');
   const [borrowingsOpen, setBorrowingsOpen] = useState(true);
   const [panelOpen, setPanelOpen] = useState(true);
   const [currentMode, setCurrentMode] = useState<AppMode>('compare');
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
   const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
-  const speaker = selectedSpeakers[0];
+  const activeActionSpeaker = selectedSpeakers[0] ?? null;
   const loadSpeaker = useAnnotationStore((s) => s.loadSpeaker);
   const loadEnrichments = useEnrichmentStore((s) => s.load);
 
+  const reloadSpeakerAnnotation = async (speakerId: string | null) => {
+    if (!speakerId) {
+      return;
+    }
+
+    useAnnotationStore.setState((store: { dirty: Record<string, boolean> }) => ({
+      dirty: { ...store.dirty, [speakerId]: true },
+    }));
+    await loadSpeaker(speakerId);
+  };
+
   const normalizeJob = useActionJob({
     start: () => {
-      if (!speaker) return Promise.reject(new Error('No speaker selected'));
-      return startNormalize(speaker);
+      if (!activeActionSpeaker) return Promise.reject(new Error('No speaker selected'));
+      return startNormalize(activeActionSpeaker);
     },
     poll: (id) => pollNormalize(id) as Promise<PollResult>,
     label: 'Normalizing audio…',
-    onComplete: () => { if (speaker) loadSpeaker(speaker); },
+    onComplete: () => reloadSpeakerAnnotation(activeActionSpeaker),
   });
 
   const sttJob = useActionJob({
     start: () => {
-      if (!speaker) return Promise.reject(new Error('No speaker selected'));
-      return startSTT(speaker, `${speaker}.wav`, 'ckb');
+      if (!activeActionSpeaker) return Promise.reject(new Error('No speaker selected'));
+      return startSTT(activeActionSpeaker, `${activeActionSpeaker}.wav`, 'ckb');
     },
     poll: (id) => pollSTT(id) as Promise<PollResult>,
     label: 'Running STT…',
-    onComplete: () => { if (speaker) loadSpeaker(speaker); },
+    onComplete: () => reloadSpeakerAnnotation(activeActionSpeaker),
   });
 
   const ipaJob = useActionJob({
@@ -1292,6 +1303,18 @@ export function ParseUI() {
 
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
+
+  const resetProject = () => {
+    setActionsMenuOpen(false);
+    if (!window.confirm('Reset project? This will clear all in-memory store state. Saved files on disk are not affected.')) return;
+    useAnnotationStore.setState({ records: {}, dirty: {}, loading: {} });
+    useEnrichmentStore.setState({ data: {}, loading: false });
+    useTagStore.setState({ tags: [] });
+    usePlaybackStore.setState({ activeSpeaker: null, currentTime: 0 });
+    useConfigStore.setState({ config: null, loading: false });
+    allJobs.forEach(j => j.reset());
+    resetComputeJob();
+  };
 
   const handleExportLingPy = async () => {
     setExporting(true);
@@ -1554,7 +1577,7 @@ export function ParseUI() {
                     </button>
                     <button
                       onClick={() => { setActionsMenuOpen(false); void normalizeJob.run(); }}
-                      disabled={normalizeJob.state.status === 'running'}
+                      disabled={!activeActionSpeaker || normalizeJob.state.status === 'running'}
                       className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <AudioLines className="h-3.5 w-3.5 text-slate-400"/>
@@ -1562,7 +1585,7 @@ export function ParseUI() {
                     </button>
                     <button
                       onClick={() => { setActionsMenuOpen(false); void sttJob.run(); }}
-                      disabled={sttJob.state.status === 'running'}
+                      disabled={!activeActionSpeaker || sttJob.state.status === 'running'}
                       className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Mic className="h-3.5 w-3.5 text-slate-400"/>
@@ -1612,16 +1635,7 @@ export function ParseUI() {
                     </button>
                     <div className="my-1 border-t border-slate-100"/>
                     <button
-                      onClick={() => {
-                        setActionsMenuOpen(false);
-                        if (!window.confirm('Reset project? This will clear all in-memory store state. Saved files on disk are not affected.')) return;
-                        useAnnotationStore.setState({ records: {}, dirty: {}, loading: {} });
-                        useEnrichmentStore.setState({ data: {}, loading: false });
-                        useTagStore.setState({ tags: [] });
-                        usePlaybackStore.setState({ activeSpeaker: null, currentTime: 0 });
-                        useConfigStore.setState({ config: null, loading: false });
-                        allJobs.forEach(j => j.reset());
-                      }}
+                      onClick={resetProject}
                       className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-rose-600 hover:bg-rose-50"
                     >
                       <Trash2 className="h-3.5 w-3.5"/> Reset Project
@@ -1632,7 +1646,7 @@ export function ParseUI() {
             </div>
 
             {activeJobs.length > 0 && (
-              <div className="ml-2 flex flex-col gap-1">
+              <div className="ml-2 flex flex-col gap-1" data-testid="topbar-action-statuses">
                 {activeJobs.map((job, i) => (
                   <div key={i} className="flex items-center gap-2 text-[11px]">
                     {job.state.status === 'running' && (
@@ -1658,6 +1672,12 @@ export function ParseUI() {
                       <>
                         <XCircle className="h-3 w-3 text-rose-500" />
                         <span className="max-w-[200px] truncate text-rose-600">{job.state.error}</span>
+                        <button
+                          onClick={() => { void job.run(); }}
+                          className="text-[10px] text-rose-600 underline hover:text-rose-700"
+                        >
+                          Retry
+                        </button>
                         <button
                           onClick={job.reset}
                           className="text-[10px] text-slate-500 underline hover:text-slate-700"

--- a/src/hooks/__tests__/useActionJob.test.ts
+++ b/src/hooks/__tests__/useActionJob.test.ts
@@ -223,4 +223,60 @@ describe("useActionJob", () => {
     expect(start).toHaveBeenCalledTimes(1);
     expect(result.current.state.status).toBe("running");
   });
+
+  it("ignores concurrent run() calls while start() is still resolving", async () => {
+    let releaseStart: (() => void) | null = null;
+    const start = vi.fn(
+      () =>
+        new Promise<{ job_id: string }>((resolve) => {
+          releaseStart = () => resolve({ job_id: "j9" });
+        }),
+    );
+    const poll = vi.fn().mockResolvedValue({ status: "running", progress: 0.2 });
+
+    const { result } = renderHook(() =>
+      useActionJob({
+        start,
+        poll,
+        label: "Running action…",
+      }),
+    );
+
+    await act(async () => {
+      const firstRun = result.current.run();
+      const secondRun = result.current.run();
+      expect(start).toHaveBeenCalledTimes(1);
+      releaseStart?.();
+      await firstRun;
+      await secondRun;
+    });
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(result.current.state.status).toBe("running");
+  });
+
+  it("surfaces start failures immediately without polling", async () => {
+    const start = vi.fn().mockRejectedValue(new Error("Start failed"));
+    const poll = vi.fn();
+
+    const { result } = renderHook(() =>
+      useActionJob({
+        start,
+        poll,
+        label: "Running action…",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run();
+    });
+
+    expect(result.current.state).toEqual({
+      status: "error",
+      progress: 0,
+      error: "Start failed",
+      label: "Running action…",
+    });
+    expect(poll).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useActionJob.ts
+++ b/src/hooks/useActionJob.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback, useEffect, type SetStateAction } from "react";
 
 export interface PollResult {
   status: string;
@@ -56,12 +56,38 @@ function normalizeProgress(progress: number): number {
   return Math.min(1, progress);
 }
 
+function isCompleteStatus(status: string): boolean {
+  return status === "complete" || status === "done" || status === "success" || status === "succeeded";
+}
+
+function isErrorStatus(status: string): boolean {
+  return status === "error" || status === "failed" || status === "failure";
+}
+
 export function useActionJob(config: ActionJobConfig): ActionJobHandle {
   const [state, setState] = useState<ActionJobState>(IDLE_STATE);
+  const stateRef = useRef<ActionJobState>(IDLE_STATE);
+  const mountedRef = useRef(true);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const inFlightRef = useRef(false);
+  const pollInFlightRef = useRef(false);
+  const startInFlightRef = useRef(false);
   const jobIdRef = useRef<string | null>(null);
   const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeRunIdRef = useRef(0);
+
+  const setStateIfMounted = useCallback((nextState: SetStateAction<ActionJobState>) => {
+    if (!mountedRef.current) {
+      return;
+    }
+
+    setState((previousState) => {
+      const resolvedState = typeof nextState === "function"
+        ? nextState(previousState)
+        : nextState;
+      stateRef.current = resolvedState;
+      return resolvedState;
+    });
+  }, []);
 
   const stopPolling = useCallback(() => {
     if (intervalRef.current !== null) {
@@ -72,30 +98,55 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
       clearTimeout(dismissTimeoutRef.current);
       dismissTimeoutRef.current = null;
     }
-    inFlightRef.current = false;
+    pollInFlightRef.current = false;
     jobIdRef.current = null;
   }, []);
 
   const reset = useCallback(() => {
+    activeRunIdRef.current += 1;
+    startInFlightRef.current = false;
     stopPolling();
-    setState(IDLE_STATE);
-  }, [stopPolling]);
+    stateRef.current = IDLE_STATE;
+    setStateIfMounted(IDLE_STATE);
+  }, [setStateIfMounted, stopPolling]);
 
-  const pollOnce = useCallback(async () => {
-    if (inFlightRef.current || !jobIdRef.current) {
+  const pollOnce = useCallback(async (runId: number) => {
+    if (pollInFlightRef.current || !jobIdRef.current || activeRunIdRef.current !== runId) {
       return;
     }
 
-    inFlightRef.current = true;
+    pollInFlightRef.current = true;
     try {
       const poll = await config.poll(jobIdRef.current);
+      if (activeRunIdRef.current !== runId) {
+        return;
+      }
+
       const progress = normalizeProgress(Number(poll.progress ?? 0));
       const status = String(poll.status || "running").toLowerCase();
 
-      if (status === "complete" || status === "done") {
+      if (isCompleteStatus(status)) {
         stopPolling();
-        await config.onComplete?.();
-        setState({
+        try {
+          await config.onComplete?.();
+        } catch (error) {
+          if (activeRunIdRef.current !== runId) {
+            return;
+          }
+          setStateIfMounted({
+            status: "error",
+            progress,
+            error: toErrorMessage(error, `${config.label} follow-up failed`),
+            label: config.label,
+          });
+          return;
+        }
+
+        if (activeRunIdRef.current !== runId) {
+          return;
+        }
+
+        setStateIfMounted({
           status: "complete",
           progress: 1,
           error: null,
@@ -104,16 +155,17 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
 
         if (config.autoDismissMs !== 0) {
           dismissTimeoutRef.current = setTimeout(() => {
-            setState(IDLE_STATE);
+            stateRef.current = IDLE_STATE;
+            setStateIfMounted(IDLE_STATE);
             dismissTimeoutRef.current = null;
           }, config.autoDismissMs ?? 3000);
         }
         return;
       }
 
-      if (status === "error" || status === "failed") {
+      if (isErrorStatus(status)) {
         stopPolling();
-        setState({
+        setStateIfMounted({
           status: "error",
           progress,
           error: poll.message ?? poll.error ?? "Job failed",
@@ -122,34 +174,45 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
         return;
       }
 
-      setState((prev) => ({
+      setStateIfMounted((prev) => ({
         ...prev,
         status: "running",
         progress,
       }));
     } catch (error) {
+      if (activeRunIdRef.current !== runId) {
+        return;
+      }
       stopPolling();
-      setState({
+      setStateIfMounted({
         status: "error",
         progress: 0,
         error: toErrorMessage(error, "Job polling failed"),
         label: config.label,
       });
     } finally {
-      inFlightRef.current = false;
+      pollInFlightRef.current = false;
     }
-  }, [config, stopPolling]);
+  }, [config, setStateIfMounted, stopPolling]);
 
   const run = useCallback(async (): Promise<void> => {
-    if (state.status === "running") {
+    if (startInFlightRef.current || stateRef.current.status === "running") {
       return;
     }
 
+    activeRunIdRef.current += 1;
+    const runId = activeRunIdRef.current;
+
+    startInFlightRef.current = true;
     stopPolling();
-    setState({ status: "running", progress: 0, error: null, label: config.label });
+    setStateIfMounted({ status: "running", progress: 0, error: null, label: config.label });
 
     try {
       const job = await config.start();
+      if (activeRunIdRef.current !== runId) {
+        return;
+      }
+
       const resolvedJobId = String(job.job_id || "").trim();
       if (!resolvedJobId) {
         throw new Error("Missing action job id");
@@ -157,21 +220,32 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
 
       jobIdRef.current = resolvedJobId;
       intervalRef.current = setInterval(() => {
-        void pollOnce();
+        void pollOnce(runId);
       }, config.pollIntervalMs ?? 1000);
     } catch (error) {
+      if (activeRunIdRef.current !== runId) {
+        return;
+      }
       stopPolling();
-      setState({
+      setStateIfMounted({
         status: "error",
         progress: 0,
         error: toErrorMessage(error, "Job start failed"),
         label: config.label,
       });
+    } finally {
+      if (activeRunIdRef.current === runId) {
+        startInFlightRef.current = false;
+      }
     }
-  }, [config.label, config.pollIntervalMs, config.start, pollOnce, state.status, stopPolling]);
+  }, [config.label, config.pollIntervalMs, config.start, pollOnce, setStateIfMounted, stopPolling]);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
+      mountedRef.current = false;
+      startInFlightRef.current = false;
+      activeRunIdRef.current += 1;
       stopPolling();
     };
   }, [stopPolling]);


### PR DESCRIPTION
## Summary
- harden `useActionJob` against concurrent start races and stale async updates
- force speaker annotation reload after Normalize/STT by marking the record dirty before reload
- tighten ParseUI action UX with retry support, safer speaker-dependent disables, status test ids, and dedicated reset wiring
- expand regression coverage for topbar progress, retry flow, reset clearing, and hook start-failure/double-start cases

## Context
PR #38 is already merged; this is a follow-up hardening pass on top of the landed Actions lifecycle work, opened from the correct code branch (`feat/parseui-unified-shell`).

## Test Plan
- `npm run test -- --run`
- `./node_modules/.bin/tsc --noEmit`

## Evidence
- full test suite: 135 passing
- targeted follow-up suites: `src/hooks/__tests__/useActionJob.test.ts`, `src/ParseUI.test.tsx` green
