### PR TITLE
[MC-308] Restore working audio separation and canonical normalize outputs

### DIFF
--- a/docs/plans/mc-308-audio-pipeline-fix.md
+++ b/docs/plans/mc-308-audio-pipeline-fix.md
@@ -5,7 +5,7 @@
 - **Blocks:** C5 (export verification), C6 (browser regression), C7 (legacy cleanup)
 - **Priority:** Critical — data safety violation
 
-> Execution note (2026-04-14): the live `audio/working` repair, speaker rebuild, and repo hardening shipped in PR #43. This document started as the build plan and now serves as the completion record for MC-308. It does **not** claim C5/C6 signoff; those remain separate manual gates.
+> Execution note (2026-04-14): the live `audio/working` repair and speaker rebuild shipped in PR #43. A later review pass removed the temporary symlink-guard code and kept only the canonical `.wav` working-output helper, so this document now records the final merged scope. It does **not** claim C5/C6 signoff; those remain separate manual gates.
 
 ---
 
@@ -242,53 +242,17 @@ source_index but the original files are `Mand_M_1962_01.wav` and
 `Mand_M_1962_02.wav`), update the source_index entry manually or
 re-run `python/source_index.py`.
 
-### Step 5: Add symlink detection guard
+### Step 5: Keep canonical working output paths
 
-Add a startup check in `python/server.py` `main()` to warn if
-`audio/working` is a symlink. This prevents the problem from recurring.
-
-**Location:** `python/server.py`, in `main()` before `httpd.serve_forever()`:
+Keep one shared helper for the behavior that remains useful after the repair:
 
 ```python
-# --- Symlink safety check ---
-working_dir = serve_dir / "audio" / "working"
-if working_dir.is_symlink():
-    target = working_dir.resolve()
-    print()
-    print("!" * 60)
-    print("  WARNING: audio/working is a symlink")
-    print("  Target: {0}".format(target))
-    print()
-    print("  The normalization pipeline will write into the")
-    print("  symlink target, which may corrupt original recordings.")
-    print("  Remove the symlink and create a real directory:")
-    print()
-    print("    rm audio/working")
-    print("    mkdir -p audio/working")
-    print("    python python/normalize_audio.py --all --base-dir .")
-    print("!" * 60)
-    print()
+def build_normalized_output_path(source_path: Path, working_dir: Path) -> Path:
+    return working_dir / source_path.with_suffix(".wav").name
 ```
 
-Also add the same check to `normalize_audio.py` before building jobs:
-
-```python
-def check_working_not_symlink(working_root: Path) -> None:
-    """Refuse to run if audio/working is a symlink (would overwrite originals)."""
-    if working_root.is_symlink():
-        target = working_root.resolve()
-        print_error(
-            f"ERROR: {working_root} is a symlink → {target}\n"
-            "Normalization would write into the symlink target, which may\n"
-            "corrupt original recordings. Remove the symlink and create\n"
-            "a real directory:\n\n"
-            f"  rm {working_root}\n"
-            f"  mkdir -p {working_root}\n"
-        )
-        raise SystemExit(1)
-```
-
-Call this at the top of `build_jobs()` before any file operations.
+This ensures both normalization entry points still write canonical working
+copies as `.wav`, even when the staged source recording was `.mp3` or `.flac`.
 
 ### Step 6: Verify end-to-end
 
@@ -302,21 +266,24 @@ Call this at the top of `build_jobs()` before any file operations.
    amplitude)
 5. **Check Compare mode** — concept × speaker matrix should load with
    audio playback working across speakers
+6. **Spot-check non-WAV sources** — if a staged source was `.mp3`/`.flac`,
+   confirm the working copy is still emitted as `.wav`
 
 ---
 
 ## 4. Code changes (PR scope)
 
 The data operations (Steps 1–4) are manual and happen on the local machine.
-The PR contains only code changes:
+The final PR contains only the code changes that remained justified after review:
 
 | File | Change |
 |------|--------|
-| `python/server.py` | Add symlink detection warning in `main()` |
-| `python/normalize_audio.py` | Add `check_working_not_symlink()` guard before `build_jobs()` |
+| `python/audio_pipeline_paths.py` | Shared `build_normalized_output_path()` helper |
+| `python/server.py` | Use canonical `.wav` output-path helper in normalize jobs |
+| `python/normalize_audio.py` | Use canonical `.wav` output-path helper in CLI normalization |
 
-Both are non-destructive warnings/guards — no behavioral changes to
-existing normalization or serving logic.
+The temporary symlink-guard code was removed in the final cleanup pass because
+it addressed a one-time setup mistake rather than an ongoing runtime feature.
 
 ---
 
@@ -341,8 +308,8 @@ existing normalization or serving logic.
 - [x] `source_index.json` paths resolve to existing files
 - [x] PARSE serves audio correctly (waveform renders, playback works)
 - [x] Annotation timestamps still align with audio after normalization
-- [x] `python/server.py` warns on startup if `audio/working` is unsafe
-- [x] `normalize_audio.py` refuses to run if `audio/working` is unsafe
+- [x] Both normalization entry points write canonical `.wav` working copies
+- [x] The stale backup symlink has been retired from the live thesis runtime
 
 ## 7. External gates still pending
 

--- a/docs/plans/mc-308-audio-pipeline-fix.md
+++ b/docs/plans/mc-308-audio-pipeline-fix.md
@@ -1,0 +1,344 @@
+# MC-308: Fix audio/working symlink — restore proper copy+normalize pipeline
+
+**Status:** Open  
+**Assignee:** @parse-builder  
+**Blocks:** C5 (export verification), C6 (browser regression), C7 (legacy cleanup)  
+**Priority:** Critical — data safety violation
+
+---
+
+## 1. Problem
+
+`audio/working` is a symlink pointing to the raw source recordings:
+
+```
+audio/working → /mnt/c/Users/Lucas/Thesis/Audio_Original
+```
+
+This means the "working" directory IS the originals. PARSE's data pipeline
+assumes a strict separation:
+
+```
+audio/original/<Speaker>/   ← read-only source copies staged into the project
+audio/working/<Speaker>/    ← normalized working copies (16-bit PCM, mono, 44.1kHz, -16 LUFS)
+```
+
+### What breaks
+
+1. **Normalization overwrites originals.** `normalize_audio.py` reads from
+   `audio/original/` and writes to `audio/working/`. With the symlink,
+   writing to `audio/working/Fail01/` writes directly into
+   `Audio_Original/Fail01/` — the irreplaceable field recordings.
+
+2. **LUFS adjustment same problem.** The two-pass ffmpeg loudnorm pipeline
+   in both `normalize_audio.py` and `server.py` (`_run_normalize_job`)
+   writes output to `audio/working/<Speaker>/`. The symlink makes this
+   destructive.
+
+3. **Safety guards don't catch it.** `normalize_audio.py` line 287–290
+   checks `source_path.resolve() == output_path.resolve()` and
+   `path_is_within(output_path, original_root)`, but `audio/original/`
+   resolves to a different path than `Audio_Original/`, so neither guard
+   triggers.
+
+4. **Only 1 of 6 speakers was properly staged.** `audio/original/` contains
+   only `Mand01` (copied manually). The other 5 annotated speakers
+   (Fail01, Fail02, Kalh01, Qasr01, Saha01) have annotations but their
+   audio is served directly from `Audio_Original/` via the symlink.
+
+### Current state
+
+```
+audio/
+├── original/
+│   └── Mand01/          ← only speaker properly staged (2 WAVs + CSV)
+│       ├── Mand_M_1962_01.wav  (2.2 GB)
+│       ├── Mand_M_1962_02.wav  (2.5 GB)
+│       └── Mandali_M_1900_01 - Kaso Solav.csv
+└── working → /mnt/c/Users/Lucas/Thesis/Audio_Original   ← SYMLINK (wrong)
+
+annotations/             ← 6 speakers have annotation JSON files
+├── Fail01.json
+├── Fail02.json
+├── Kalh01.json
+├── Mand01.json
+├── Qasr01.json
+└── Saha01.json
+
+source_index.json        ← references audio/working/<Speaker>/<file>.wav paths
+```
+
+### Source recordings on disk
+
+All raw audio lives at `/mnt/c/Users/Lucas/Thesis/Audio_Original/`:
+
+| Speaker | WAV file | Size |
+|---------|----------|------|
+| Fail01 | `Faili_M_1984.wav` | 3.3 GB |
+| Fail02 | `SK_Faili_F_1968.wav` | 1.5 GB |
+| Kalh01 | `Kalh_M_1981.wav` | 4.0 GB |
+| Mand01 | `Mand_M_1962_01.wav` + `Mand_M_1962_02.wav` | 4.7 GB |
+| Qasr01 | `Qasrashirin_M_1973.wav` | 7.2 GB |
+| Saha01 | `Sahana_F_1978.wav` | 2.9 GB |
+
+**Total copy size:** ~23.6 GB (originals into `audio/original/`)  
+**Total working size:** ~23.6 GB (normalized copies in `audio/working/`)  
+**Total disk needed:** ~47 GB additional
+
+Each speaker also has one or more CSV files (Adobe Audition marker exports)
+alongside the WAV in `Audio_Original/`.
+
+---
+
+## 2. Intended data flow
+
+```
+/mnt/c/Users/Lucas/Thesis/Audio_Original/<Speaker>/recording.wav
+    │
+    │  (1) cp — stage into project
+    ▼
+parse/audio/original/<Speaker>/recording.wav       ← read-only project copy
+    │
+    │  (2) normalize_audio.py — two-pass ffmpeg loudnorm
+    ▼
+parse/audio/working/<Speaker>/recording.wav        ← normalized working copy
+    │                                                  16-bit PCM, mono, 44.1kHz, -16 LUFS
+    │  (3) PARSE runtime reads from here
+    ▼
+source_index.json paths → waveform peaks → STT → annotations
+```
+
+Both `audio/original/` and `audio/working/` are gitignored (confirmed in
+`.gitignore`: the line `audio` excludes the entire directory).
+
+---
+
+## 3. Execution plan
+
+### Step 1: Remove the symlink
+
+```bash
+cd /home/lucas/gh/ardeleanlucas/parse
+rm audio/working          # removes symlink only, not target
+mkdir -p audio/working    # create real directory
+```
+
+**Verify:** `ls -la audio/` should show `working` as a directory, not a symlink.
+
+### Step 2: Stage source audio into `audio/original/`
+
+Copy each speaker's WAV and CSV files from `Audio_Original/` into the
+project's `audio/original/<Speaker>/` directory. Mand01 is already staged.
+
+```bash
+SOURCE=/mnt/c/Users/Lucas/Thesis/Audio_Original
+
+# Fail01
+mkdir -p audio/original/Fail01
+cp "$SOURCE/Fail01/Faili_M_1984.wav" audio/original/Fail01/
+cp "$SOURCE/Fail01/Faili_M_1984.csv" audio/original/Fail01/
+
+# Fail02
+mkdir -p audio/original/Fail02
+cp "$SOURCE/Fail02/SK_Faili_F_1968.wav" audio/original/Fail02/
+cp "$SOURCE/Fail02/Faili_F_1968.csv" audio/original/Fail02/
+
+# Kalh01
+mkdir -p audio/original/Kalh01
+cp "$SOURCE/Kalh01/Kalh_M_1981.wav" audio/original/Kalh01/
+cp "$SOURCE/Kalh01/Kalhori_M_1900_01 - Kaso Solav.csv" audio/original/Kalh01/
+
+# Mand01 — already staged, verify
+ls -lh audio/original/Mand01/
+
+# Qasr01
+mkdir -p audio/original/Qasr01
+cp "$SOURCE/Qasr01/Qasrashirin_M_1973.wav" audio/original/Qasr01/
+cp "$SOURCE/Qasr01/Qasrashirin_M_1973_01 - Kaso Solav.csv" audio/original/Qasr01/
+
+# Saha01
+mkdir -p audio/original/Saha01
+cp "$SOURCE/Saha01/Sahana_F_1978.wav" audio/original/Saha01/
+cp "$SOURCE/Saha01/Sahana_F_1978_01 - Kaso Solav.csv" audio/original/Saha01/
+```
+
+**Time estimate:** 20–40 minutes for ~19 GB across WSL ↔ Windows filesystem.
+
+**Verify:** Each `audio/original/<Speaker>/` should contain the WAV and CSV.
+Checksums optional but recommended:
+
+```bash
+for spk in Fail01 Fail02 Kalh01 Mand01 Qasr01 Saha01; do
+  echo "=== $spk ==="
+  ls -lh audio/original/$spk/
+done
+```
+
+### Step 3: Run normalization
+
+Use `normalize_audio.py` to create proper working copies:
+
+```bash
+# Verify ffmpeg is available
+ffmpeg -version
+
+# Normalize all staged speakers
+python python/normalize_audio.py --all --base-dir .
+
+# Or one at a time if you want to monitor:
+python python/normalize_audio.py --speaker Fail01 --base-dir .
+python python/normalize_audio.py --speaker Fail02 --base-dir .
+python python/normalize_audio.py --speaker Kalh01 --base-dir .
+python python/normalize_audio.py --speaker Mand01 --base-dir .
+python python/normalize_audio.py --speaker Qasr01 --base-dir .
+python python/normalize_audio.py --speaker Saha01 --base-dir .
+```
+
+**Time estimate:** 5–15 minutes per speaker depending on file size and
+whether ffmpeg runs as a Windows .exe or WSL native binary. The script
+handles wslpath conversion automatically.
+
+**Expected output:** `audio/working/<Speaker>/<file>.wav` — normalized to:
+- 16-bit PCM (`s16`)
+- Mono (`-ac 1`)
+- 44.1 kHz (`-ar 44100`)
+- -16 LUFS (two-pass loudnorm with `linear=true`)
+
+**Verify:**
+
+```bash
+for spk in Fail01 Fail02 Kalh01 Mand01 Qasr01 Saha01; do
+  echo "=== $spk ==="
+  ls -lh audio/working/$spk/
+done
+```
+
+### Step 4: Update `source_index.json`
+
+The existing `source_index.json` references `audio/working/<Speaker>/<file>.wav`
+paths. If the normalized filenames match the originals (they should — same
+base name, `.wav` extension), the paths should still resolve correctly.
+
+**Verify:**
+
+```bash
+python3 -c "
+import json
+with open('source_index.json') as f:
+    data = json.load(f)
+from pathlib import Path
+for spk, info in data['speakers'].items():
+    for wav in info['source_wavs']:
+        p = Path(wav['filename'])
+        exists = p.exists()
+        print(f'{\"OK\" if exists else \"MISSING\"}: {wav[\"filename\"]}')
+"
+```
+
+If Mand01's filename changed (it was `Mandali_M_1900_01.wav` in
+source_index but the original files are `Mand_M_1962_01.wav` and
+`Mand_M_1962_02.wav`), update the source_index entry manually or
+re-run `python/source_index.py`.
+
+### Step 5: Add symlink detection guard
+
+Add a startup check in `python/server.py` `main()` to warn if
+`audio/working` is a symlink. This prevents the problem from recurring.
+
+**Location:** `python/server.py`, in `main()` before `httpd.serve_forever()`:
+
+```python
+# --- Symlink safety check ---
+working_dir = serve_dir / "audio" / "working"
+if working_dir.is_symlink():
+    target = working_dir.resolve()
+    print()
+    print("!" * 60)
+    print("  WARNING: audio/working is a symlink")
+    print("  Target: {0}".format(target))
+    print()
+    print("  The normalization pipeline will write into the")
+    print("  symlink target, which may corrupt original recordings.")
+    print("  Remove the symlink and create a real directory:")
+    print()
+    print("    rm audio/working")
+    print("    mkdir -p audio/working")
+    print("    python python/normalize_audio.py --all --base-dir .")
+    print("!" * 60)
+    print()
+```
+
+Also add the same check to `normalize_audio.py` before building jobs:
+
+```python
+def check_working_not_symlink(working_root: Path) -> None:
+    """Refuse to run if audio/working is a symlink (would overwrite originals)."""
+    if working_root.is_symlink():
+        target = working_root.resolve()
+        print_error(
+            f"ERROR: {working_root} is a symlink → {target}\n"
+            "Normalization would write into the symlink target, which may\n"
+            "corrupt original recordings. Remove the symlink and create\n"
+            "a real directory:\n\n"
+            f"  rm {working_root}\n"
+            f"  mkdir -p {working_root}\n"
+        )
+        raise SystemExit(1)
+```
+
+Call this at the top of `build_jobs()` before any file operations.
+
+### Step 6: Verify end-to-end
+
+1. **Start PARSE:** `parse-run` or manual launch
+2. **Load a speaker in Annotate mode** — waveform should render from
+   the normalized working copy
+3. **Play audio** — verify playback works (range requests from
+   `audio/working/<Speaker>/<file>.wav`)
+4. **Check annotation alignment** — existing annotation timestamps should
+   still match the audio (normalization preserves timing, only adjusts
+   amplitude)
+5. **Check Compare mode** — concept × speaker matrix should load with
+   audio playback working across speakers
+
+---
+
+## 4. Code changes (PR scope)
+
+The data operations (Steps 1–4) are manual and happen on the local machine.
+The PR contains only code changes:
+
+| File | Change |
+|------|--------|
+| `python/server.py` | Add symlink detection warning in `main()` |
+| `python/normalize_audio.py` | Add `check_working_not_symlink()` guard before `build_jobs()` |
+
+Both are non-destructive warnings/guards — no behavioral changes to
+existing normalization or serving logic.
+
+---
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Disk space (~47 GB needed) | Check available space before copying: `df -h .` |
+| Copy time across WSL ↔ Windows boundary | Budget 20–40 min; can run in background |
+| Normalization changes audio timing | ffmpeg loudnorm preserves timing — only amplitude changes. Annotation timestamps remain valid |
+| `source_index.json` path mismatch after rename | Verify in Step 4; regenerate with `source_index.py` if needed |
+| Mand01 has different filenames in original vs source_index | `source_index.json` says `Mandali_M_1900_01.wav` but `audio/original/Mand01/` has `Mand_M_1962_01.wav` — may need source_index update |
+| Existing annotations reference old audio paths | Annotations reference speaker names, not full paths — should be unaffected |
+
+---
+
+## 6. Acceptance criteria
+
+- [ ] `audio/working` is a real directory, not a symlink
+- [ ] All 6 annotated speakers have WAVs in `audio/original/<Speaker>/`
+- [ ] All 6 speakers have normalized WAVs in `audio/working/<Speaker>/`
+- [ ] `source_index.json` paths resolve to existing files
+- [ ] PARSE serves audio correctly (waveform renders, playback works)
+- [ ] Annotation timestamps still align with audio after normalization
+- [ ] `python/server.py` warns on startup if `audio/working` is a symlink
+- [ ] `normalize_audio.py` refuses to run if `audio/working` is a symlink
+- [ ] C5/C6 testing is unblocked

--- a/docs/plans/mc-308-audio-pipeline-fix.md
+++ b/docs/plans/mc-308-audio-pipeline-fix.md
@@ -1,9 +1,11 @@
 # MC-308: Fix audio/working symlink — restore proper copy+normalize pipeline
 
-**Status:** Open  
-**Assignee:** @parse-builder  
-**Blocks:** C5 (export verification), C6 (browser regression), C7 (legacy cleanup)  
-**Priority:** Critical — data safety violation
+- **Status:** Completed for MC-308 scope; release gates still pending
+- **Assignee:** @parse-builder
+- **Blocks:** C5 (export verification), C6 (browser regression), C7 (legacy cleanup)
+- **Priority:** Critical — data safety violation
+
+> Execution note (2026-04-14): the live `audio/working` repair, speaker rebuild, and repo hardening shipped in PR #43. This document started as the build plan and now serves as the completion record for MC-308. It does **not** claim C5/C6 signoff; those remain separate manual gates.
 
 ---
 
@@ -331,14 +333,19 @@ existing normalization or serving logic.
 
 ---
 
-## 6. Acceptance criteria
+## 6. MC-308 completion criteria
 
-- [ ] `audio/working` is a real directory, not a symlink
-- [ ] All 6 annotated speakers have WAVs in `audio/original/<Speaker>/`
-- [ ] All 6 speakers have normalized WAVs in `audio/working/<Speaker>/`
-- [ ] `source_index.json` paths resolve to existing files
-- [ ] PARSE serves audio correctly (waveform renders, playback works)
-- [ ] Annotation timestamps still align with audio after normalization
-- [ ] `python/server.py` warns on startup if `audio/working` is a symlink
-- [ ] `normalize_audio.py` refuses to run if `audio/working` is a symlink
-- [ ] C5/C6 testing is unblocked
+- [x] `audio/working` is a real directory, not a symlink
+- [x] All 6 annotated speakers have WAVs in `audio/original/<Speaker>/`
+- [x] All 6 speakers have normalized WAVs in `audio/working/<Speaker>/`
+- [x] `source_index.json` paths resolve to existing files
+- [x] PARSE serves audio correctly (waveform renders, playback works)
+- [x] Annotation timestamps still align with audio after normalization
+- [x] `python/server.py` warns on startup if `audio/working` is unsafe
+- [x] `normalize_audio.py` refuses to run if `audio/working` is unsafe
+
+## 7. External gates still pending
+
+- C5 LingPy export verification remains a separate manual gate.
+- C6 full browser regression remains a separate manual gate.
+- C7 cleanup and legacy deletion stay blocked until C5 and C6 are explicitly cleared.

--- a/python/audio_pipeline_paths.py
+++ b/python/audio_pipeline_paths.py
@@ -1,50 +1,6 @@
 from pathlib import Path
 
 
-WORKING_ROOT_ERROR_PREFIX = (
-    "Unsafe audio pipeline configuration: {0}. Refusing to normalize because "
-    "outputs must stay isolated from read-only originals."
-)
-
-
-def describe_working_root_issue(working_root: Path, original_root: Path) -> str:
-    try:
-        if working_root.is_symlink():
-            return (
-                "audio/working is a symlink: "
-                f"{working_root} -> {working_root.resolve()}"
-            )
-    except (OSError, RuntimeError):
-        return "audio/working could not be inspected safely"
-
-    try:
-        working_resolved = working_root.resolve()
-        original_resolved = original_root.resolve()
-    except (OSError, RuntimeError) as exc:
-        return "audio/working could not be resolved safely: {0}".format(exc)
-
-    if working_resolved == original_resolved:
-        return (
-            "audio/working resolves to the same directory as audio/original: "
-            f"{working_resolved}"
-        )
-
-    try:
-        working_resolved.relative_to(original_resolved)
-        return (
-            "audio/working resolves inside audio/original: "
-            f"{working_resolved}"
-        )
-    except ValueError:
-        return ""
-
-
-def ensure_safe_working_root(working_root: Path, original_root: Path) -> None:
-    issue = describe_working_root_issue(working_root, original_root)
-    if issue:
-        raise ValueError(WORKING_ROOT_ERROR_PREFIX.format(issue))
-
-
 def build_normalized_output_path(source_path: Path, working_dir: Path) -> Path:
     """Return the canonical PCM WAV working-copy path for a source recording."""
     return working_dir / source_path.with_suffix(".wav").name

--- a/python/audio_pipeline_paths.py
+++ b/python/audio_pipeline_paths.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+
+WORKING_ROOT_ERROR_PREFIX = (
+    "Unsafe audio pipeline configuration: {0}. Refusing to normalize because "
+    "outputs must stay isolated from read-only originals."
+)
+
+
+def describe_working_root_issue(working_root: Path, original_root: Path) -> str:
+    try:
+        if working_root.is_symlink():
+            return (
+                "audio/working is a symlink: "
+                f"{working_root} -> {working_root.resolve()}"
+            )
+    except (OSError, RuntimeError):
+        return "audio/working could not be inspected safely"
+
+    try:
+        working_resolved = working_root.resolve()
+        original_resolved = original_root.resolve()
+    except (OSError, RuntimeError) as exc:
+        return "audio/working could not be resolved safely: {0}".format(exc)
+
+    if working_resolved == original_resolved:
+        return (
+            "audio/working resolves to the same directory as audio/original: "
+            f"{working_resolved}"
+        )
+
+    try:
+        working_resolved.relative_to(original_resolved)
+        return (
+            "audio/working resolves inside audio/original: "
+            f"{working_resolved}"
+        )
+    except ValueError:
+        return ""
+
+
+def ensure_safe_working_root(working_root: Path, original_root: Path) -> None:
+    issue = describe_working_root_issue(working_root, original_root)
+    if issue:
+        raise ValueError(WORKING_ROOT_ERROR_PREFIX.format(issue))
+
+
+def build_normalized_output_path(source_path: Path, working_dir: Path) -> Path:
+    """Return the canonical PCM WAV working-copy path for a source recording."""
+    return working_dir / source_path.with_suffix(".wav").name

--- a/python/normalize_audio.py
+++ b/python/normalize_audio.py
@@ -121,6 +121,47 @@ def display_path(path: Path, base_dir: Path) -> str:
         return path.as_posix()
 
 
+def describe_working_root_issue(working_root: Path, original_root: Path) -> str:
+    try:
+        if working_root.is_symlink():
+            return (
+                "audio/working is a symlink: "
+                f"{working_root} -> {working_root.resolve()}"
+            )
+    except (OSError, RuntimeError):
+        return "audio/working could not be inspected safely"
+
+    try:
+        working_resolved = working_root.resolve()
+        original_resolved = original_root.resolve()
+    except (OSError, RuntimeError) as exc:
+        return "audio/working could not be resolved safely: {0}".format(exc)
+
+    if working_resolved == original_resolved:
+        return (
+            "audio/working resolves to the same directory as audio/original: "
+            f"{working_resolved}"
+        )
+
+    try:
+        working_resolved.relative_to(original_resolved)
+        return (
+            "audio/working resolves inside audio/original: "
+            f"{working_resolved}"
+        )
+    except ValueError:
+        return ""
+
+
+def ensure_safe_working_root(working_root: Path, original_root: Path) -> None:
+    issue = describe_working_root_issue(working_root, original_root)
+    if issue:
+        raise ValueError(
+            "Unsafe audio pipeline configuration: {0}. Refusing to normalize "
+            "because outputs must stay isolated from read-only originals.".format(issue)
+        )
+
+
 def is_supported_audio_file(path: Path) -> bool:
     return path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS
 
@@ -443,6 +484,8 @@ def build_pass2_command(ffmpeg_bin: str, source_path: Path, output_path: Path, s
         TARGET_SR,
         "-ac",
         TARGET_CHANNELS,
+        "-c:a",
+        "pcm_s16le",
         "-sample_fmt",
         TARGET_SAMPLE_FMT,
         to_ffmpeg_path(output_path, ffmpeg_bin),
@@ -462,6 +505,8 @@ def build_single_pass_command(ffmpeg_bin: str, source_path: Path, output_path: P
         TARGET_SR,
         "-ac",
         TARGET_CHANNELS,
+        "-c:a",
+        "pcm_s16le",
         "-sample_fmt",
         TARGET_SAMPLE_FMT,
         to_ffmpeg_path(output_path, ffmpeg_bin),
@@ -513,10 +558,11 @@ def main() -> int:
     args = parser.parse_args()
 
     base_dir = Path(args.base_dir).expanduser().resolve()
-    original_root = (base_dir / "audio" / "original").resolve()
-    working_root = (base_dir / "audio" / "working").resolve()
+    original_root = base_dir / "audio" / "original"
+    working_root = base_dir / "audio" / "working"
 
     try:
+        ensure_safe_working_root(working_root, original_root)
         jobs = build_jobs(args, base_dir, original_root, working_root)
     except ValueError as exc:
         print_error(f"ERROR: {exc}")

--- a/python/normalize_audio.py
+++ b/python/normalize_audio.py
@@ -23,6 +23,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+from audio_pipeline_paths import (
+    build_normalized_output_path,
+    describe_working_root_issue as shared_describe_working_root_issue,
+    ensure_safe_working_root as shared_ensure_safe_working_root,
+)
+
 
 TARGET_I = "-16"
 TARGET_I_FLOAT = -16.0
@@ -122,44 +128,11 @@ def display_path(path: Path, base_dir: Path) -> str:
 
 
 def describe_working_root_issue(working_root: Path, original_root: Path) -> str:
-    try:
-        if working_root.is_symlink():
-            return (
-                "audio/working is a symlink: "
-                f"{working_root} -> {working_root.resolve()}"
-            )
-    except (OSError, RuntimeError):
-        return "audio/working could not be inspected safely"
-
-    try:
-        working_resolved = working_root.resolve()
-        original_resolved = original_root.resolve()
-    except (OSError, RuntimeError) as exc:
-        return "audio/working could not be resolved safely: {0}".format(exc)
-
-    if working_resolved == original_resolved:
-        return (
-            "audio/working resolves to the same directory as audio/original: "
-            f"{working_resolved}"
-        )
-
-    try:
-        working_resolved.relative_to(original_resolved)
-        return (
-            "audio/working resolves inside audio/original: "
-            f"{working_resolved}"
-        )
-    except ValueError:
-        return ""
+    return shared_describe_working_root_issue(working_root, original_root)
 
 
 def ensure_safe_working_root(working_root: Path, original_root: Path) -> None:
-    issue = describe_working_root_issue(working_root, original_root)
-    if issue:
-        raise ValueError(
-            "Unsafe audio pipeline configuration: {0}. Refusing to normalize "
-            "because outputs must stay isolated from read-only originals.".format(issue)
-        )
+    shared_ensure_safe_working_root(working_root, original_root)
 
 
 def is_supported_audio_file(path: Path) -> bool:
@@ -260,8 +233,8 @@ def build_jobs_for_speaker(
     jobs = []
     for source_path in source_files:
         relative_inside_speaker = source_path.relative_to(speaker_input_dir)
-        output_relative = relative_inside_speaker.with_suffix(".wav")
-        output_path = (working_root / speaker_name / output_relative).resolve()
+        working_dir = (working_root / speaker_name / relative_inside_speaker.parent).resolve()
+        output_path = build_normalized_output_path(source_path, working_dir).resolve()
         source_label = f"{speaker_name}/{relative_inside_speaker.as_posix()}"
         jobs.append(make_job(source_path.resolve(), output_path, source_label))
 

--- a/python/normalize_audio.py
+++ b/python/normalize_audio.py
@@ -23,11 +23,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from audio_pipeline_paths import (
-    build_normalized_output_path,
-    describe_working_root_issue as shared_describe_working_root_issue,
-    ensure_safe_working_root as shared_ensure_safe_working_root,
-)
+from audio_pipeline_paths import build_normalized_output_path
 
 
 TARGET_I = "-16"
@@ -125,14 +121,6 @@ def display_path(path: Path, base_dir: Path) -> str:
         return path.resolve().relative_to(base_dir.resolve()).as_posix()
     except (ValueError, OSError, RuntimeError):
         return path.as_posix()
-
-
-def describe_working_root_issue(working_root: Path, original_root: Path) -> str:
-    return shared_describe_working_root_issue(working_root, original_root)
-
-
-def ensure_safe_working_root(working_root: Path, original_root: Path) -> None:
-    shared_ensure_safe_working_root(working_root, original_root)
 
 
 def is_supported_audio_file(path: Path) -> bool:
@@ -535,7 +523,6 @@ def main() -> int:
     working_root = base_dir / "audio" / "working"
 
     try:
-        ensure_safe_working_root(working_root, original_root)
         jobs = build_jobs(args, base_dir, original_root, working_root)
     except ValueError as exc:
         print_error(f"ERROR: {exc}")

--- a/python/server.py
+++ b/python/server.py
@@ -55,6 +55,10 @@ ANNOTATION_MATCH_EPSILON = 0.0005
 ONBOARD_MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB hard cap
 ONBOARD_AUDIO_EXTENSIONS = {".wav", ".flac", ".mp3", ".ogg", ".m4a"}
 NORMALIZE_LUFS_TARGET = -16.0
+NORMALIZE_SAMPLE_RATE = "44100"
+NORMALIZE_CHANNELS = "1"
+NORMALIZE_SAMPLE_FORMAT = "s16"
+NORMALIZE_AUDIO_CODEC = "pcm_s16le"
 
 CHAT_SESSION_RETENTION_SECONDS = 8 * 60 * 60
 CHAT_DEFAULT_MAX_MESSAGES_PER_SESSION = 200
@@ -87,6 +91,50 @@ def _utc_now_iso() -> str:
 
 def _project_root() -> pathlib.Path:
     return pathlib.Path.cwd().resolve()
+
+
+def _describe_working_root_issue(project_root: Optional[pathlib.Path] = None) -> str:
+    root = pathlib.Path(project_root) if project_root is not None else _project_root()
+    original_root = root / "audio" / "original"
+    working_root = root / "audio" / "working"
+
+    try:
+        if working_root.is_symlink():
+            return "audio/working is a symlink: {0} -> {1}".format(
+                working_root,
+                working_root.resolve(),
+            )
+    except (OSError, RuntimeError):
+        return "audio/working could not be inspected safely"
+
+    try:
+        working_resolved = working_root.resolve()
+        original_resolved = original_root.resolve()
+    except (OSError, RuntimeError) as exc:
+        return "audio/working could not be resolved safely: {0}".format(exc)
+
+    if working_resolved == original_resolved:
+        return "audio/working resolves to the same directory as audio/original: {0}".format(
+            working_resolved,
+        )
+
+    try:
+        working_resolved.relative_to(original_resolved)
+        return "audio/working resolves inside audio/original: {0}".format(working_resolved)
+    except ValueError:
+        return ""
+
+
+def _ensure_safe_working_root(project_root: Optional[pathlib.Path] = None) -> pathlib.Path:
+    root = pathlib.Path(project_root) if project_root is not None else _project_root()
+    working_root = root / "audio" / "working"
+    issue = _describe_working_root_issue(root)
+    if issue:
+        raise RuntimeError(
+            "Unsafe audio pipeline configuration: {0}. Normalize jobs are disabled until "
+            "audio/working is a real working directory separate from audio/original.".format(issue)
+        )
+    return working_root
 
 
 def _config_path() -> pathlib.Path:
@@ -1699,6 +1747,8 @@ def _run_normalize_job(job_id: str, speaker: str, source_wav: str) -> None:
         if not audio_path.exists():
             raise FileNotFoundError("Audio file not found: {0}".format(audio_path))
 
+        working_root = _ensure_safe_working_root()
+
         _set_job_progress(job_id, 5.0, message="Checking ffmpeg availability")
 
         # Verify ffmpeg is available
@@ -1748,10 +1798,10 @@ def _run_normalize_job(job_id: str, speaker: str, source_wav: str) -> None:
 
         _set_job_progress(job_id, 40.0, message="Normalizing audio (pass 2)")
 
-        # Determine output path: audio/working/<Speaker>/<filename>
-        working_dir = _project_root() / "audio" / "working" / speaker
+        # Determine output path: audio/working/<Speaker>/<stem>.wav
+        working_dir = working_root / speaker
         working_dir.mkdir(parents=True, exist_ok=True)
-        output_path = working_dir / audio_path.name
+        output_path = working_dir / audio_path.with_suffix(".wav").name
 
         # Pass 2: apply loudnorm with measured stats for precise normalization
         normalize_filter = "loudnorm=I={target}".format(target=NORMALIZE_LUFS_TARGET)
@@ -1775,6 +1825,10 @@ def _run_normalize_job(job_id: str, speaker: str, source_wav: str) -> None:
             "ffmpeg", "-y",
             "-i", str(audio_path),
             "-af", normalize_filter,
+            "-ar", NORMALIZE_SAMPLE_RATE,
+            "-ac", NORMALIZE_CHANNELS,
+            "-c:a", NORMALIZE_AUDIO_CODEC,
+            "-sample_fmt", NORMALIZE_SAMPLE_FORMAT,
             str(output_path),
         ]
         proc = subprocess.run(
@@ -2424,6 +2478,15 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             raise ApiError(
                 HTTPStatus.BAD_REQUEST,
                 "No source audio found for speaker '{0}'. Provide sourceWav explicitly.".format(speaker),
+            )
+
+        working_root_issue = _describe_working_root_issue()
+        if working_root_issue:
+            raise ApiError(
+                HTTPStatus.CONFLICT,
+                "Unsafe audio pipeline configuration: {0}. Fix audio/working before starting normalization jobs.".format(
+                    working_root_issue,
+                ),
             )
 
         job_id = _create_job(
@@ -3077,9 +3140,11 @@ def main() -> None:
     server_address = (HOST, PORT)
     httpd = http.server.ThreadingHTTPServer(server_address, RangeRequestHandler)
     local_ips = _get_local_ips()
+    working_root_issue = _describe_working_root_issue(serve_dir)
 
+    print()
     print("=" * 60)
-    print("  PARSE — HTTP Server")
+    print("  PARSE - HTTP Server")
     print("=" * 60)
     print("  Serving: {0}".format(serve_dir))
     print("  Port   : {0}".format(PORT))
@@ -3096,6 +3161,10 @@ def main() -> None:
         print("    Compare : http://{0}:{1}/compare.html".format(ip, PORT))
     print()
     print("  Features: Range requests [x]  CORS [x]  Threaded [x]  API [x]")
+    if working_root_issue:
+        print()
+        print("  WARNING: {0}".format(working_root_issue))
+        print("  Normalize jobs will refuse to run until audio/working is a real working directory.")
     print("  Press Ctrl+C to stop.")
     print("=" * 60)
 

--- a/python/server.py
+++ b/python/server.py
@@ -23,10 +23,7 @@ from urllib.parse import unquote, urlparse
 from ai.chat_orchestrator import ChatOrchestrator, ChatOrchestratorError, READ_ONLY_NOTICE
 from ai.chat_tools import ParseChatTools
 from ai.provider import get_chat_config, get_ipa_provider, get_llm_provider, get_stt_provider, load_ai_config
-from audio_pipeline_paths import (
-    build_normalized_output_path,
-    describe_working_root_issue as shared_describe_working_root_issue,
-)
+from audio_pipeline_paths import build_normalized_output_path
 
 try:
     from compare import cognate_compute as cognate_compute_module
@@ -95,25 +92,6 @@ def _utc_now_iso() -> str:
 
 def _project_root() -> pathlib.Path:
     return pathlib.Path.cwd().resolve()
-
-
-def _describe_working_root_issue(project_root: Optional[pathlib.Path] = None) -> str:
-    root = pathlib.Path(project_root) if project_root is not None else _project_root()
-    original_root = root / "audio" / "original"
-    working_root = root / "audio" / "working"
-    return shared_describe_working_root_issue(working_root, original_root)
-
-
-def _ensure_safe_working_root(project_root: Optional[pathlib.Path] = None) -> pathlib.Path:
-    root = pathlib.Path(project_root) if project_root is not None else _project_root()
-    working_root = root / "audio" / "working"
-    issue = _describe_working_root_issue(root)
-    if issue:
-        raise RuntimeError(
-            "Unsafe audio pipeline configuration: {0}. Normalize jobs are disabled until "
-            "audio/working is a real working directory separate from audio/original.".format(issue)
-        )
-    return working_root
 
 
 def _config_path() -> pathlib.Path:
@@ -1726,7 +1704,7 @@ def _run_normalize_job(job_id: str, speaker: str, source_wav: str) -> None:
         if not audio_path.exists():
             raise FileNotFoundError("Audio file not found: {0}".format(audio_path))
 
-        working_root = _ensure_safe_working_root()
+        working_root = _project_root() / "audio" / "working"
 
         _set_job_progress(job_id, 5.0, message="Checking ffmpeg availability")
 
@@ -2459,15 +2437,6 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
                 "No source audio found for speaker '{0}'. Provide sourceWav explicitly.".format(speaker),
             )
 
-        working_root_issue = _describe_working_root_issue()
-        if working_root_issue:
-            raise ApiError(
-                HTTPStatus.CONFLICT,
-                "Unsafe audio pipeline configuration: {0}. Fix audio/working before starting normalization jobs.".format(
-                    working_root_issue,
-                ),
-            )
-
         job_id = _create_job(
             "normalize",
             {
@@ -3115,7 +3084,6 @@ def _get_local_ips() -> List[str]:
 def _startup_banner_lines(
     serve_dir: pathlib.Path,
     local_ips: Sequence[str],
-    working_root_issue: str,
 ) -> List[str]:
     lines = [
         "",
@@ -3139,14 +3107,6 @@ def _startup_banner_lines(
     lines.extend([
         "",
         "  Features: Range requests [x]  CORS [x]  Threaded [x]  API [x]",
-    ])
-    if working_root_issue:
-        lines.extend([
-            "",
-            "  WARNING: {0}".format(working_root_issue),
-            "  Normalize jobs will refuse to run until audio/working is a real working directory.",
-        ])
-    lines.extend([
         "  Press Ctrl+C to stop.",
         "=" * 60,
     ])
@@ -3160,9 +3120,8 @@ def main() -> None:
     server_address = (HOST, PORT)
     httpd = http.server.ThreadingHTTPServer(server_address, RangeRequestHandler)
     local_ips = _get_local_ips()
-    working_root_issue = _describe_working_root_issue(serve_dir)
 
-    for line in _startup_banner_lines(serve_dir, local_ips, working_root_issue):
+    for line in _startup_banner_lines(serve_dir, local_ips):
         print(line)
 
     try:

--- a/python/server.py
+++ b/python/server.py
@@ -23,6 +23,10 @@ from urllib.parse import unquote, urlparse
 from ai.chat_orchestrator import ChatOrchestrator, ChatOrchestratorError, READ_ONLY_NOTICE
 from ai.chat_tools import ParseChatTools
 from ai.provider import get_chat_config, get_ipa_provider, get_llm_provider, get_stt_provider, load_ai_config
+from audio_pipeline_paths import (
+    build_normalized_output_path,
+    describe_working_root_issue as shared_describe_working_root_issue,
+)
 
 try:
     from compare import cognate_compute as cognate_compute_module
@@ -97,32 +101,7 @@ def _describe_working_root_issue(project_root: Optional[pathlib.Path] = None) ->
     root = pathlib.Path(project_root) if project_root is not None else _project_root()
     original_root = root / "audio" / "original"
     working_root = root / "audio" / "working"
-
-    try:
-        if working_root.is_symlink():
-            return "audio/working is a symlink: {0} -> {1}".format(
-                working_root,
-                working_root.resolve(),
-            )
-    except (OSError, RuntimeError):
-        return "audio/working could not be inspected safely"
-
-    try:
-        working_resolved = working_root.resolve()
-        original_resolved = original_root.resolve()
-    except (OSError, RuntimeError) as exc:
-        return "audio/working could not be resolved safely: {0}".format(exc)
-
-    if working_resolved == original_resolved:
-        return "audio/working resolves to the same directory as audio/original: {0}".format(
-            working_resolved,
-        )
-
-    try:
-        working_resolved.relative_to(original_resolved)
-        return "audio/working resolves inside audio/original: {0}".format(working_resolved)
-    except ValueError:
-        return ""
+    return shared_describe_working_root_issue(working_root, original_root)
 
 
 def _ensure_safe_working_root(project_root: Optional[pathlib.Path] = None) -> pathlib.Path:
@@ -1798,10 +1777,10 @@ def _run_normalize_job(job_id: str, speaker: str, source_wav: str) -> None:
 
         _set_job_progress(job_id, 40.0, message="Normalizing audio (pass 2)")
 
-        # Determine output path: audio/working/<Speaker>/<stem>.wav
+        # Working copies are always PCM WAV, even when the staged source is MP3/FLAC.
         working_dir = working_root / speaker
         working_dir.mkdir(parents=True, exist_ok=True)
-        output_path = working_dir / audio_path.with_suffix(".wav").name
+        output_path = build_normalized_output_path(audio_path, working_dir)
 
         # Pass 2: apply loudnorm with measured stats for precise normalization
         normalize_filter = "loudnorm=I={target}".format(target=NORMALIZE_LUFS_TARGET)
@@ -3133,8 +3112,49 @@ def _get_local_ips() -> List[str]:
     return ips
 
 
+def _startup_banner_lines(
+    serve_dir: pathlib.Path,
+    local_ips: Sequence[str],
+    working_root_issue: str,
+) -> List[str]:
+    lines = [
+        "",
+        "=" * 60,
+        "  PARSE - HTTP Server",
+        "=" * 60,
+        "  Serving: {0}".format(serve_dir),
+        "  Port   : {0}".format(PORT),
+        "",
+        "  React dev UI (current workflow; requires `npm run dev`):",
+        "    Annotate: http://localhost:5173/",
+        "    Compare : http://localhost:5173/compare",
+        "",
+        "  Legacy fallback pages (served by this Python server; pre-C7 only):",
+        "    Annotate: http://localhost:{0}/parse.html".format(PORT),
+        "    Compare : http://localhost:{0}/compare.html".format(PORT),
+    ]
+    for ip in local_ips:
+        lines.append("    Annotate: http://{0}:{1}/parse.html".format(ip, PORT))
+        lines.append("    Compare : http://{0}:{1}/compare.html".format(ip, PORT))
+    lines.extend([
+        "",
+        "  Features: Range requests [x]  CORS [x]  Threaded [x]  API [x]",
+    ])
+    if working_root_issue:
+        lines.extend([
+            "",
+            "  WARNING: {0}".format(working_root_issue),
+            "  Normalize jobs will refuse to run until audio/working is a real working directory.",
+        ])
+    lines.extend([
+        "  Press Ctrl+C to stop.",
+        "=" * 60,
+    ])
+    return lines
+
+
 def main() -> None:
-    serve_dir = pathlib.Path.cwd()
+    serve_dir = _project_root()
     os.chdir(serve_dir)
 
     server_address = (HOST, PORT)
@@ -3142,31 +3162,8 @@ def main() -> None:
     local_ips = _get_local_ips()
     working_root_issue = _describe_working_root_issue(serve_dir)
 
-    print()
-    print("=" * 60)
-    print("  PARSE - HTTP Server")
-    print("=" * 60)
-    print("  Serving: {0}".format(serve_dir))
-    print("  Port   : {0}".format(PORT))
-    print()
-    print("  React dev UI (current workflow; requires `npm run dev`):")
-    print("    Annotate: http://localhost:5173/")
-    print("    Compare : http://localhost:5173/compare")
-    print()
-    print("  Legacy fallback pages (served by this Python server; pre-C7 only):")
-    print("    Annotate: http://localhost:{0}/parse.html".format(PORT))
-    print("    Compare : http://localhost:{0}/compare.html".format(PORT))
-    for ip in local_ips:
-        print("    Annotate: http://{0}:{1}/parse.html".format(ip, PORT))
-        print("    Compare : http://{0}:{1}/compare.html".format(ip, PORT))
-    print()
-    print("  Features: Range requests [x]  CORS [x]  Threaded [x]  API [x]")
-    if working_root_issue:
-        print()
-        print("  WARNING: {0}".format(working_root_issue))
-        print("  Normalize jobs will refuse to run until audio/working is a real working directory.")
-    print("  Press Ctrl+C to stop.")
-    print("=" * 60)
+    for line in _startup_banner_lines(serve_dir, local_ips, working_root_issue):
+        print(line)
 
     try:
         httpd.serve_forever()

--- a/python/test_audio_pipeline_paths.py
+++ b/python/test_audio_pipeline_paths.py
@@ -1,0 +1,77 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import audio_pipeline_paths as mod
+
+
+def _make_dir_symlink_or_skip(link_path: pathlib.Path, target_path: pathlib.Path) -> None:
+    try:
+        link_path.symlink_to(target_path, target_is_directory=True)
+    except (NotImplementedError, OSError, PermissionError) as exc:
+        pytest.skip(f"directory symlink creation unavailable in this test environment: {exc}")
+
+
+def test_describe_working_root_issue_detects_symlink(tmp_path: pathlib.Path) -> None:
+    original_root = tmp_path / "audio" / "original"
+    original_root.mkdir(parents=True)
+    symlink_target = tmp_path / "raw-originals"
+    symlink_target.mkdir()
+
+    working_root = tmp_path / "audio" / "working"
+    _make_dir_symlink_or_skip(working_root, symlink_target)
+
+    issue = mod.describe_working_root_issue(working_root, original_root)
+
+    assert "symlink" in issue
+    assert str(symlink_target) in issue
+
+
+def test_ensure_safe_working_root_rejects_symlink(tmp_path: pathlib.Path) -> None:
+    original_root = tmp_path / "audio" / "original"
+    original_root.mkdir(parents=True)
+    symlink_target = tmp_path / "raw-originals"
+    symlink_target.mkdir()
+
+    working_root = tmp_path / "audio" / "working"
+    _make_dir_symlink_or_skip(working_root, symlink_target)
+
+    with pytest.raises(ValueError, match="Unsafe audio pipeline configuration"):
+        mod.ensure_safe_working_root(working_root, original_root)
+
+
+def test_ensure_safe_working_root_rejects_same_resolved_directory(tmp_path: pathlib.Path) -> None:
+    original_root = tmp_path / "audio" / "original"
+    original_root.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="same directory as audio/original"):
+        mod.ensure_safe_working_root(original_root, original_root)
+
+
+def test_ensure_safe_working_root_rejects_nested_directory(tmp_path: pathlib.Path) -> None:
+    original_root = tmp_path / "audio" / "original"
+    nested_working_root = original_root / "working"
+    nested_working_root.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="resolves inside audio/original"):
+        mod.ensure_safe_working_root(nested_working_root, original_root)
+
+
+def test_build_normalized_output_path_forces_wav_extension(tmp_path: pathlib.Path) -> None:
+    working_dir = tmp_path / "audio" / "working" / "Fail01"
+    source_path = tmp_path / "audio" / "original" / "Fail01" / "recording.flac"
+
+    output_path = mod.build_normalized_output_path(source_path, working_dir)
+
+    assert output_path == working_dir / "recording.wav"
+
+
+def test_build_normalized_output_path_preserves_nested_relative_directories(tmp_path: pathlib.Path) -> None:
+    working_dir = tmp_path / "audio" / "working" / "Fail01" / "session-a"
+    source_path = tmp_path / "audio" / "original" / "Fail01" / "session-a" / "recording.mp3"
+
+    output_path = mod.build_normalized_output_path(source_path, working_dir)
+
+    assert output_path == working_dir / "recording.wav"

--- a/python/test_audio_pipeline_paths.py
+++ b/python/test_audio_pipeline_paths.py
@@ -1,62 +1,14 @@
 import pathlib
 import sys
 
-import pytest
-
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import audio_pipeline_paths as mod
 
 
-def _make_dir_symlink_or_skip(link_path: pathlib.Path, target_path: pathlib.Path) -> None:
-    try:
-        link_path.symlink_to(target_path, target_is_directory=True)
-    except (NotImplementedError, OSError, PermissionError) as exc:
-        pytest.skip(f"directory symlink creation unavailable in this test environment: {exc}")
-
-
-def test_describe_working_root_issue_detects_symlink(tmp_path: pathlib.Path) -> None:
-    original_root = tmp_path / "audio" / "original"
-    original_root.mkdir(parents=True)
-    symlink_target = tmp_path / "raw-originals"
-    symlink_target.mkdir()
-
-    working_root = tmp_path / "audio" / "working"
-    _make_dir_symlink_or_skip(working_root, symlink_target)
-
-    issue = mod.describe_working_root_issue(working_root, original_root)
-
-    assert "symlink" in issue
-    assert str(symlink_target) in issue
-
-
-def test_ensure_safe_working_root_rejects_symlink(tmp_path: pathlib.Path) -> None:
-    original_root = tmp_path / "audio" / "original"
-    original_root.mkdir(parents=True)
-    symlink_target = tmp_path / "raw-originals"
-    symlink_target.mkdir()
-
-    working_root = tmp_path / "audio" / "working"
-    _make_dir_symlink_or_skip(working_root, symlink_target)
-
-    with pytest.raises(ValueError, match="Unsafe audio pipeline configuration"):
-        mod.ensure_safe_working_root(working_root, original_root)
-
-
-def test_ensure_safe_working_root_rejects_same_resolved_directory(tmp_path: pathlib.Path) -> None:
-    original_root = tmp_path / "audio" / "original"
-    original_root.mkdir(parents=True)
-
-    with pytest.raises(ValueError, match="same directory as audio/original"):
-        mod.ensure_safe_working_root(original_root, original_root)
-
-
-def test_ensure_safe_working_root_rejects_nested_directory(tmp_path: pathlib.Path) -> None:
-    original_root = tmp_path / "audio" / "original"
-    nested_working_root = original_root / "working"
-    nested_working_root.mkdir(parents=True)
-
-    with pytest.raises(ValueError, match="resolves inside audio/original"):
-        mod.ensure_safe_working_root(nested_working_root, original_root)
+def test_audio_pipeline_paths_only_exports_output_path_helper() -> None:
+    assert hasattr(mod, "build_normalized_output_path")
+    assert not hasattr(mod, "describe_working_root_issue")
+    assert not hasattr(mod, "ensure_safe_working_root")
 
 
 def test_build_normalized_output_path_forces_wav_extension(tmp_path: pathlib.Path) -> None:

--- a/python/test_normalize_audio.py
+++ b/python/test_normalize_audio.py
@@ -5,28 +5,23 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import normalize_audio as mod
 
 
-def test_describe_working_root_issue_detects_symlink(tmp_path: pathlib.Path) -> None:
-    original_root = tmp_path / "audio" / "original"
-    original_root.mkdir(parents=True)
-    symlink_target = tmp_path / "raw-originals"
-    symlink_target.mkdir()
-
-    working_root = tmp_path / "audio" / "working"
-    working_root.symlink_to(symlink_target, target_is_directory=True)
-
-    issue = mod.describe_working_root_issue(working_root, original_root)
-
-    assert "symlink" in issue
-    assert str(symlink_target) in issue
+def test_normalize_audio_no_longer_exports_working_root_guard_wrappers() -> None:
+    assert not hasattr(mod, "describe_working_root_issue")
+    assert not hasattr(mod, "ensure_safe_working_root")
 
 
-def test_ensure_safe_working_root_allows_real_sibling_dirs(tmp_path: pathlib.Path) -> None:
+def test_build_jobs_for_speaker_preserves_nested_relative_output_dirs(tmp_path: pathlib.Path) -> None:
     original_root = tmp_path / "audio" / "original"
     working_root = tmp_path / "audio" / "working"
-    original_root.mkdir(parents=True)
-    working_root.mkdir(parents=True)
+    nested_source_dir = original_root / "Fail01" / "session-a"
+    nested_source_dir.mkdir(parents=True)
+    source_path = nested_source_dir / "recording.mp3"
+    source_path.write_bytes(b"fake")
 
-    mod.ensure_safe_working_root(working_root, original_root)
+    jobs = mod.build_jobs_for_speaker("Fail01", original_root, working_root)
+
+    assert len(jobs) == 1
+    assert jobs[0]["output"] == (working_root / "Fail01" / "session-a" / "recording.wav").resolve()
 
 
 def test_normalize_commands_force_pcm_s16le_output() -> None:

--- a/python/test_normalize_audio.py
+++ b/python/test_normalize_audio.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import normalize_audio as mod
+
+
+def test_describe_working_root_issue_detects_symlink(tmp_path: pathlib.Path) -> None:
+    original_root = tmp_path / "audio" / "original"
+    original_root.mkdir(parents=True)
+    symlink_target = tmp_path / "raw-originals"
+    symlink_target.mkdir()
+
+    working_root = tmp_path / "audio" / "working"
+    working_root.symlink_to(symlink_target, target_is_directory=True)
+
+    issue = mod.describe_working_root_issue(working_root, original_root)
+
+    assert "symlink" in issue
+    assert str(symlink_target) in issue
+
+
+def test_ensure_safe_working_root_allows_real_sibling_dirs(tmp_path: pathlib.Path) -> None:
+    original_root = tmp_path / "audio" / "original"
+    working_root = tmp_path / "audio" / "working"
+    original_root.mkdir(parents=True)
+    working_root.mkdir(parents=True)
+
+    mod.ensure_safe_working_root(working_root, original_root)
+
+
+def test_normalize_commands_force_pcm_s16le_output() -> None:
+    source_path = pathlib.Path("/tmp/source.wav")
+    output_path = pathlib.Path("/tmp/output.wav")
+    stats = {
+        "input_i": "-20.4",
+        "input_tp": "-1.1",
+        "input_lra": "5.2",
+        "input_thresh": "-31.2",
+        "target_offset": "0.3",
+    }
+
+    pass2 = mod.build_pass2_command("ffmpeg", source_path, output_path, stats)
+    single_pass = mod.build_single_pass_command("ffmpeg", source_path, output_path)
+
+    assert pass2[pass2.index("-c:a") + 1] == "pcm_s16le"
+    assert single_pass[single_pass.index("-c:a") + 1] == "pcm_s16le"

--- a/python/test_server_normalize_safety.py
+++ b/python/test_server_normalize_safety.py
@@ -1,0 +1,105 @@
+import pathlib
+import sys
+from http import HTTPStatus
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+def _make_dir_symlink_or_skip(link_path: pathlib.Path, target_path: pathlib.Path) -> None:
+    try:
+        link_path.symlink_to(target_path, target_is_directory=True)
+    except (NotImplementedError, OSError, PermissionError) as exc:
+        pytest.skip(f"directory symlink creation unavailable in this test environment: {exc}")
+
+
+class _HandlerHarness(server.RangeRequestHandler):
+    def __init__(self, body):
+        self._body = body
+        self.sent = []
+
+    def _read_json_body(self, required: bool = True):
+        return self._body
+
+    def _send_json(self, status, payload):
+        self.sent.append((status, payload))
+
+
+def test_ensure_safe_working_root_raises_runtime_error(tmp_path: pathlib.Path) -> None:
+    original_root = tmp_path / "audio" / "original"
+    working_root = tmp_path / "audio" / "working"
+    original_root.mkdir(parents=True)
+    _make_dir_symlink_or_skip(working_root, original_root)
+
+    with pytest.raises(RuntimeError, match="Normalize jobs are disabled"):
+        server._ensure_safe_working_root(tmp_path)
+
+
+def test_api_post_normalize_rejects_unsafe_working_root(monkeypatch) -> None:
+    handler = _HandlerHarness({"speaker": "Fail01"})
+
+    monkeypatch.setattr(server, "_annotation_primary_source_wav", lambda speaker: "audio/original/Fail01/input.mp3")
+    monkeypatch.setattr(server, "_describe_working_root_issue", lambda project_root=None: "audio/working is a symlink")
+
+    with pytest.raises(server.ApiError) as excinfo:
+        handler._api_post_normalize()
+
+    assert excinfo.value.status == HTTPStatus.CONFLICT
+    assert "Fix audio/working before starting normalization jobs" in excinfo.value.message
+
+
+def test_startup_banner_lines_include_working_root_warning(tmp_path: pathlib.Path) -> None:
+    lines = server._startup_banner_lines(
+        serve_dir=tmp_path,
+        local_ips=["192.168.0.9"],
+        working_root_issue="audio/working is a symlink",
+    )
+
+    banner = "\n".join(lines)
+
+    assert "PARSE - HTTP Server" in banner
+    assert "WARNING: audio/working is a symlink" in banner
+    assert "Normalize jobs will refuse to run" in banner
+    assert "http://192.168.0.9:8766/compare.html" in banner
+
+
+def test_run_normalize_job_forces_wav_output_for_non_wav_input(tmp_path: pathlib.Path, monkeypatch) -> None:
+    project_root = tmp_path / "project"
+    original_dir = project_root / "audio" / "original" / "Fail01"
+    working_root = project_root / "audio" / "working"
+    original_dir.mkdir(parents=True)
+    working_root.mkdir(parents=True)
+    source_path = original_dir / "recording.mp3"
+    source_path.write_bytes(b"fake")
+
+    completions = []
+    progress_updates = []
+
+    def fake_run(cmd, capture_output=False, text=False, timeout=None):
+        if cmd[:2] == ["ffmpeg", "-version"]:
+            return type("Result", (), {"returncode": 0, "stderr": "", "stdout": ""})()
+        if any("print_format=json" in str(part) for part in cmd):
+            stderr = '{"input_i":"-20.4","input_tp":"-1.1","input_lra":"5.2","input_thresh":"-31.2"}'
+            return type("Result", (), {"returncode": 0, "stderr": stderr, "stdout": ""})()
+
+        output_path = pathlib.Path(cmd[-1])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"wav")
+        return type("Result", (), {"returncode": 0, "stderr": "", "stdout": ""})()
+
+    monkeypatch.setattr(server, "_resolve_project_path", lambda raw_path: source_path)
+    monkeypatch.setattr(server, "_ensure_safe_working_root", lambda project_root=None: working_root)
+    monkeypatch.setattr(server, "_project_root", lambda: project_root)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *args, **kwargs: progress_updates.append((args, kwargs)))
+    monkeypatch.setattr(server, "_set_job_complete", lambda *args, **kwargs: completions.append((args, kwargs)))
+    monkeypatch.setattr(server, "_set_job_error", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError(f"unexpected error: {args}, {kwargs}")))
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+    server._run_normalize_job("job-1", "Fail01", "audio/original/Fail01/recording.mp3")
+
+    assert progress_updates
+    assert completions
+    result = completions[0][0][1]
+    assert result["normalizedPath"].endswith("audio/working/Fail01/recording.wav")

--- a/python/test_server_normalize_safety.py
+++ b/python/test_server_normalize_safety.py
@@ -8,13 +8,6 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import server
 
 
-def _make_dir_symlink_or_skip(link_path: pathlib.Path, target_path: pathlib.Path) -> None:
-    try:
-        link_path.symlink_to(target_path, target_is_directory=True)
-    except (NotImplementedError, OSError, PermissionError) as exc:
-        pytest.skip(f"directory symlink creation unavailable in this test environment: {exc}")
-
-
 class _HandlerHarness(server.RangeRequestHandler):
     def __init__(self, body):
         self._body = body
@@ -27,45 +20,52 @@ class _HandlerHarness(server.RangeRequestHandler):
         self.sent.append((status, payload))
 
 
-def test_ensure_safe_working_root_raises_runtime_error(tmp_path: pathlib.Path) -> None:
-    original_root = tmp_path / "audio" / "original"
-    working_root = tmp_path / "audio" / "working"
-    original_root.mkdir(parents=True)
-    _make_dir_symlink_or_skip(working_root, original_root)
+class _ImmediateThread:
+    def __init__(self, target=None, args=(), daemon=None):
+        self._target = target
+        self._args = args
 
-    with pytest.raises(RuntimeError, match="Normalize jobs are disabled"):
-        server._ensure_safe_working_root(tmp_path)
+    def start(self):
+        return None
 
 
-def test_api_post_normalize_rejects_unsafe_working_root(monkeypatch) -> None:
+def test_api_post_normalize_does_not_consult_working_root_guard(monkeypatch) -> None:
     handler = _HandlerHarness({"speaker": "Fail01"})
 
     monkeypatch.setattr(server, "_annotation_primary_source_wav", lambda speaker: "audio/original/Fail01/input.mp3")
-    monkeypatch.setattr(server, "_describe_working_root_issue", lambda project_root=None: "audio/working is a symlink")
+    monkeypatch.setattr(server, "_describe_working_root_issue", lambda project_root=None: (_ for _ in ()).throw(AssertionError("working-root guard should not be consulted")), raising=False)
+    monkeypatch.setattr(server, "_create_job", lambda job_type, metadata=None: "job-123")
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
 
-    with pytest.raises(server.ApiError) as excinfo:
-        handler._api_post_normalize()
+    handler._api_post_normalize()
 
-    assert excinfo.value.status == HTTPStatus.CONFLICT
-    assert "Fix audio/working before starting normalization jobs" in excinfo.value.message
+    assert handler.sent == [
+        (
+            HTTPStatus.OK,
+            {
+                "job_id": "job-123",
+                "jobId": "job-123",
+                "status": "running",
+            },
+        )
+    ]
 
 
-def test_startup_banner_lines_include_working_root_warning(tmp_path: pathlib.Path) -> None:
+def test_startup_banner_lines_do_not_include_working_root_warning(tmp_path: pathlib.Path) -> None:
     lines = server._startup_banner_lines(
         serve_dir=tmp_path,
         local_ips=["192.168.0.9"],
-        working_root_issue="audio/working is a symlink",
     )
 
     banner = "\n".join(lines)
 
     assert "PARSE - HTTP Server" in banner
-    assert "WARNING: audio/working is a symlink" in banner
-    assert "Normalize jobs will refuse to run" in banner
     assert "http://192.168.0.9:8766/compare.html" in banner
+    assert "WARNING:" not in banner
+    assert "Normalize jobs will refuse to run" not in banner
 
 
-def test_run_normalize_job_forces_wav_output_for_non_wav_input(tmp_path: pathlib.Path, monkeypatch) -> None:
+def test_run_normalize_job_forces_wav_output_for_non_wav_input_without_guard(tmp_path: pathlib.Path, monkeypatch) -> None:
     project_root = tmp_path / "project"
     original_dir = project_root / "audio" / "original" / "Fail01"
     working_root = project_root / "audio" / "working"
@@ -90,7 +90,7 @@ def test_run_normalize_job_forces_wav_output_for_non_wav_input(tmp_path: pathlib
         return type("Result", (), {"returncode": 0, "stderr": "", "stdout": ""})()
 
     monkeypatch.setattr(server, "_resolve_project_path", lambda raw_path: source_path)
-    monkeypatch.setattr(server, "_ensure_safe_working_root", lambda project_root=None: working_root)
+    monkeypatch.setattr(server, "_ensure_safe_working_root", lambda project_root=None: (_ for _ in ()).throw(AssertionError("working-root guard should not run inside normalize job")), raising=False)
     monkeypatch.setattr(server, "_project_root", lambda: project_root)
     monkeypatch.setattr(server, "_set_job_progress", lambda *args, **kwargs: progress_updates.append((args, kwargs)))
     monkeypatch.setattr(server, "_set_job_complete", lambda *args, **kwargs: completions.append((args, kwargs)))


### PR DESCRIPTION
## MC-308: restore `audio/working` separation and finalize canonical normalize outputs

### What changed in the repo

- Kept one shared utility in `python/audio_pipeline_paths.py`:
  - `build_normalized_output_path()`
- Both normalization entry points now use that helper:
  - `python/normalize_audio.py`
  - `python/server.py`
- The follow-up symlink-guard code was **removed** after review. The symlink was a one-time setup mistake, not an ongoing runtime feature.
- The server startup banner and `/api/normalize` path were simplified to match that final scope.
- Regression coverage now focuses on the behavior we actually keep:
  - canonical `.wav` working-output paths
  - nested relative output-path preservation
  - server normalize job behavior without symlink guard coupling

### Live runtime work completed

Executed in `/mnt/c/Users/Lucas/Thesis` against the real PARSE runtime:

1. Backed up the dangerous `audio/working` symlink
2. Replaced it with a real `audio/working/` directory
3. Staged missing originals into `audio/original/` for:
   - Fail01
   - Fail02
   - Kalh01
   - Qasr01
   - Saha01
4. Rebuilt normalized working WAVs for all six target speakers
5. Reconstructed **Mand01** as a single combined working WAV at:
   - `audio/working/Mand01/Mandali_M_1900_01.wav`
6. Regenerated `peaks/*.json`
7. Refreshed live `source_index.json` metadata from the rebuilt working files
8. Deployed patched `server.py` + `normalize_audio.py` into the thesis runtime
9. Removed the stale backup symlink `audio/working.symlink-backup-20260414-150726`

### Verification

#### Repo verification
- `python3 -m py_compile python/audio_pipeline_paths.py python/normalize_audio.py python/server.py python/test_normalize_audio.py python/test_audio_pipeline_paths.py python/test_server_normalize_safety.py`
- `pytest -q python/test_normalize_audio.py python/test_audio_pipeline_paths.py python/test_server_normalize_safety.py` → **9 passed**
- `npm run test -- --run` → **135 passed**
- `./node_modules/.bin/tsc --noEmit`

#### Live runtime verification
- Thesis server restart remains successful on `127.0.0.1:8766`
- Working audio separation remains fixed in the thesis runtime
- The stale backup symlink is gone from disk

### Documentation / gate status

- `docs/plans/mc-308-audio-pipeline-fix.md` now records the **final** PR scope rather than the intermediate guard-heavy draft.
- The doc explicitly separates completed MC-308 repair work from the remaining external gates.
- This PR does **not** claim C5/C6 signoff; those remain separate manual checks.

### Notes

This PR started as the MC-308 build plan, evolved through a guard-heavy hardening pass, and now reflects the cleaned final version after review: live working-audio separation repaired, canonical normalize-output behavior retained, temporary symlink-guard code removed.