### PR TITLE
docs: add citation guidance (README + CITATION.cff)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+# This CITATION.cff file was generated for GitHub's "Cite this repository" feature.
+# See: https://citation-file-format.github.io/
+cff-version: 1.2.0
+message: "If you use PARSE in academic work, please cite it as research software."
+title: "PARSE: Phonetic Analysis & Review Source Explorer"
+abstract: >-
+  PARSE is a browser-based dual-mode research workstation for linguistic
+  fieldwork and cross-speaker comparison. It combines waveform review,
+  tiered annotation (IPA, orthography, concept, speaker), AI-assisted STT,
+  cognate adjudication, and contact-lexeme similarity analysis (CLEF) in
+  a single React + Vite frontend backed by a Python API server. PARSE was
+  developed for a Southern Kurdish dialect phylogenetics thesis at the
+  University of Bamberg and targets downstream Bayesian phylogenetic
+  analysis in BEAST 2.
+type: software
+authors:
+  - family-names: Ardelean
+    given-names: Lucas M.
+repository-code: "https://github.com/ArdeleanLucas/PARSE"
+url: "https://github.com/ArdeleanLucas/PARSE"
+license: MIT
+keywords:
+  - computational-linguistics
+  - phonetics
+  - annotation
+  - cognate-detection
+  - phylogenetics
+  - southern-kurdish
+  - fieldwork
+  - speech-to-text

--- a/README.md
+++ b/README.md
@@ -397,6 +397,30 @@ PARSE was built for a Southern Kurdish dialect phylogenetics thesis at the Unive
 
 ---
 
+## Citation
+
+If you use PARSE in academic work, please cite it as research software. A machine-readable `CITATION.cff` is included in the repository root, so GitHub's **"Cite this repository"** sidebar button will produce APA/BibTeX entries automatically.
+
+Suggested citation:
+
+> Ardelean, L. M. (2026). *PARSE: Phonetic Analysis & Review Source Explorer* [Computer software]. University of Bamberg. https://github.com/ArdeleanLucas/PARSE
+
+BibTeX:
+
+```bibtex
+@software{ardelean_parse_2026,
+  author  = {Ardelean, Lucas M.},
+  title   = {{PARSE}: Phonetic Analysis \& Review Source Explorer},
+  year    = {2026},
+  url     = {https://github.com/ArdeleanLucas/PARSE},
+  note    = {Research software for Southern Kurdish dialect phylogenetics}
+}
+```
+
+PARSE is research software developed alongside a Southern Kurdish dialect phylogenetics thesis at the University of Bamberg; please also cite the associated thesis if/when it is published.
+
+---
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds citation guidance so users can cite PARSE in academic work, and enables GitHub's **"Cite this repository"** sidebar widget.

## Changes

- **`README.md`** — new `## Citation` section (between Context and License) with:
  - APA-style suggested citation
  - BibTeX `@software` entry (author: Ardelean, Lucas M.)
  - Pointer to the thesis for when it is published
- **`CITATION.cff`** (new, repo root) — machine-readable citation metadata following [citation-file-format v1.2.0](https://citation-file-format.github.io/). Validates as YAML.

## Verification

- YAML parse check passed (`python3 -c "import yaml; yaml.safe_load(open('CITATION.cff'))"`)
- Docs-only change — no code touched, no tests affected
- Branched fresh from `origin/main` per `AGENTS.md` policy

## Effect

Once merged, GitHub renders a **"Cite this repository"** button in the right sidebar of the repo page, producing APA/BibTeX automatically.