### PR TITLE
fix(ops): add scripts/parse-run.sh + parse-stop.sh with WSL+Windows cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,17 @@ The assistant operates with read and write access to the project. It can stage f
 
 ### One-command launch (recommended)
 
-The `parse-run` shell alias starts both servers, pulls the latest code, and
-health-checks the API before printing URLs. It is defined in `~/.bash_aliases`
-and sourced automatically by Bash.
+The `scripts/parse-run.sh` launcher (tracked in this repo) starts both servers, pulls the latest code, cleans up stale processes on both WSL and Windows sides, and health-checks the API before printing URLs. A shell alias (`parse-run`) is typically wired to call this script.
 
 ```bash
-parse-run          # pull main → start API + Vite → health-check → print URLs
+scripts/parse-run.sh    # same as `parse-run` alias; run directly from repo root
+```
+
+The alias version lives in `~/.bash_aliases`:
+
+```bash
+alias parse-run='/path/to/parse/scripts/parse-run.sh'
+alias parse-stop='/path/to/parse/scripts/parse-stop.sh'
 ```
 
 On success you will see:
@@ -181,17 +186,31 @@ On success you will see:
 
 Open **http://localhost:5173/** in your browser for the React UI.
 
+Environment overrides:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PARSE_PY` | `python3` | Python interpreter. Set to a Windows `python.exe` (e.g. `/mnt/c/Users/Lucas/anaconda3/envs/kurdish_asr/python.exe`) when running from WSL against a Windows conda env. |
+| `PARSE_ROOT` | auto-detected | Repo root. |
+| `PARSE_API_PORT` | `8766` | API server port. |
+| `PARSE_VITE_PORT` | `5173` | Vite dev server port. |
+| `PARSE_SKIP_PULL` | `0` | Set to `1` to skip the `git pull` step. |
+
 Two companion commands are also available:
 
 ```bash
-parse-stop         # kill both servers
-parse-logs api     # tail Python API stderr
-parse-logs vite    # tail Vite dev server output
+scripts/parse-stop.sh   # kill both servers (WSL + Windows-side zombies)
+parse-logs api          # tail Python API stderr
+parse-logs vite         # tail Vite dev server output
 ```
 
-#### What `parse-run` does
+#### WSL + Windows python.exe note
 
-1. `git pull origin main --ff-only` — fast-forward to latest main
+When `PARSE_PY` points at a Windows `python.exe` (a conda env on `C:`), the actual server process runs on the Windows side. WSL's `pkill`/`fuser` cannot signal Windows processes, so `parse-run.sh` detects this case and additionally calls `taskkill.exe` via `/mnt/c/Windows/System32/` to clean up zombie `python.exe` instances holding port 8766. This prevents the "empty reply from server" failure mode where a broken prior process blocks the port.
+
+#### What `scripts/parse-run.sh` does
+
+1. `git pull origin main --ff-only` — fast-forward to latest main (skipped if `PARSE_SKIP_PULL=1`)
 2. Kills any stale Python or Vite processes on ports 8766 / 5173
 3. Starts the **Python API server** (`python/server.py`) on `:8766`
 4. Waits for `/api/config` to return 200 (up to 12 s)

--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# scripts/parse-run.sh — PARSE dev launcher (API + Vite)
+#
+# Pulls main, kills stale servers on both WSL and Windows sides, starts
+# the Python API on :8766, waits for health, then starts Vite on :5173.
+#
+# Usage
+# -----
+#   scripts/parse-run.sh
+#
+# Environment overrides
+# ---------------------
+#   PARSE_PY         Python interpreter (default: python3, or $PARSE_PY if set)
+#   PARSE_ROOT       Repo root (default: auto-detected from script location)
+#   PARSE_API_PORT   API server port (default: 8766)
+#   PARSE_VITE_PORT  Vite dev server port (default: 5173)
+#   PARSE_SKIP_PULL  Set to 1 to skip `git pull` (default: 0)
+#
+# WSL + Windows python.exe note
+# -----------------------------
+# When PARSE_PY points at a Windows python.exe (e.g. a conda env on C:),
+# the actual server process runs on the Windows side. WSL's pkill/fuser
+# cannot signal it, which historically left zombie python.exe processes
+# holding port 8766 and breaking subsequent launches. This script detects
+# that case and uses taskkill.exe to clean both sides.
+
+set -u
+
+# ---------- Defaults ------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${PARSE_ROOT:=$(cd "${SCRIPT_DIR}/.." && pwd)}"
+: "${PARSE_PY:=python3}"
+: "${PARSE_API_PORT:=8766}"
+: "${PARSE_VITE_PORT:=5173}"
+: "${PARSE_SKIP_PULL:=0}"
+
+API_STDOUT_LOG="/tmp/parse_api_stdout.log"
+API_STDERR_LOG="/tmp/parse_api_stderr.log"
+VITE_LOG="/tmp/parse_vite.log"
+
+log() { printf '[parse-run] %s\n' "$*"; }
+
+# ---------- Windows-aware process cleanup --------------------------------
+#
+# When PARSE_PY is a Windows path (/mnt/c/...), the Python process is a
+# Windows process. `pkill` from WSL can only signal the WSL-side /init stub,
+# not the actual Windows python.exe. Use taskkill.exe to kill the Windows
+# side too.
+
+parse_py_is_windows() {
+  case "${PARSE_PY}" in
+    /mnt/?/*|/mnt/?/*python.exe) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+find_taskkill() {
+  if command -v taskkill.exe >/dev/null 2>&1; then
+    command -v taskkill.exe
+    return
+  fi
+  if [ -x "/mnt/c/Windows/System32/taskkill.exe" ]; then
+    echo "/mnt/c/Windows/System32/taskkill.exe"
+    return
+  fi
+  return 1
+}
+
+kill_windows_python() {
+  local taskkill
+  taskkill="$(find_taskkill)" || {
+    log "WARNING: taskkill.exe not found — cannot clean Windows-side python.exe"
+    return 0
+  }
+  # Kill any python.exe whose command line references server.py in our repo.
+  # Use WMIC filter via tasklist + findstr + taskkill /F /PID.
+  local pids
+  pids=$(
+    /mnt/c/Windows/System32/wbem/WMIC.exe process where \
+      "name='python.exe' and CommandLine like '%%server.py%%'" \
+      get ProcessId 2>/dev/null \
+      | tr -d '\r' \
+      | awk 'NR>1 && $1 ~ /^[0-9]+$/ {print $1}'
+  ) || true
+  if [ -n "${pids}" ]; then
+    local pid
+    for pid in ${pids}; do
+      "${taskkill}" /F /PID "${pid}" >/dev/null 2>&1 || true
+      log "killed Windows python.exe PID ${pid}"
+    done
+  fi
+}
+
+stop_servers() {
+  log "Stopping stale servers..."
+
+  # WSL-side process cleanup (covers Linux-native python, node/vite, WSL stubs)
+  pkill -9 -f "python.*server\.py" 2>/dev/null || true
+  pkill -9 -f "python\.exe.*server\.py" 2>/dev/null || true
+  pkill -9 -f "node.*vite" 2>/dev/null || true
+
+  # Windows-side cleanup (zombie python.exe holding :8766)
+  if parse_py_is_windows; then
+    kill_windows_python
+  fi
+
+  # Port-level cleanup as a last resort
+  fuser -k "${PARSE_API_PORT}/tcp" 2>/dev/null || true
+  fuser -k "${PARSE_VITE_PORT}/tcp" 2>/dev/null || true
+
+  sleep 1
+}
+
+# ---------- Git pull (defensive) -----------------------------------------
+
+pull_main() {
+  if [ "${PARSE_SKIP_PULL}" = "1" ]; then
+    log "PARSE_SKIP_PULL=1 — skipping git pull"
+    return 0
+  fi
+  log "Pulling latest main..."
+  (
+    cd "${PARSE_ROOT}" || return 1
+    # Only stash if there are actual modifications — avoids empty-stash churn.
+    local stashed=0
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+      git stash push -q -m "parse-run autostash $(date +%Y-%m-%d_%H:%M:%S)" && stashed=1
+    fi
+    if git pull origin main --ff-only; then
+      [ "${stashed}" = "1" ] && git stash pop -q 2>/dev/null || true
+      return 0
+    else
+      log "WARNING: git pull failed — running on current checkout"
+      [ "${stashed}" = "1" ] && git stash pop -q 2>/dev/null || true
+      return 0
+    fi
+  )
+}
+
+# ---------- Start API ----------------------------------------------------
+
+start_api() {
+  log "Starting Python API server on :${PARSE_API_PORT}..."
+  # -u = unbuffered stdout (so logs appear immediately; critical for remote debugging).
+  (
+    cd "${PARSE_ROOT}" || exit 1
+    "${PARSE_PY}" -u python/server.py \
+      >"${API_STDOUT_LOG}" 2>"${API_STDERR_LOG}"
+  ) &
+  API_PID=$!
+
+  log "Waiting for API on :${PARSE_API_PORT}..."
+  local i
+  for i in $(seq 1 24); do
+    if curl -sf --max-time 2 \
+      "http://127.0.0.1:${PARSE_API_PORT}/api/config" >/dev/null 2>&1; then
+      log "API ready (PID: ${API_PID})"
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  log "WARNING: API did not respond after 12s — check: parse-logs api"
+  return 1
+}
+
+# ---------- Start Vite ---------------------------------------------------
+
+start_vite() {
+  log "Starting Vite dev server on :${PARSE_VITE_PORT}..."
+  (
+    cd "${PARSE_ROOT}" || exit 1
+    npx vite --host >"${VITE_LOG}" 2>&1
+  ) &
+  VITE_PID=$!
+
+  local i
+  for i in $(seq 1 20); do
+    if curl -sf --max-time 2 \
+      "http://127.0.0.1:${PARSE_VITE_PORT}/" >/dev/null 2>&1; then
+      log "Vite ready (PID: ${VITE_PID})"
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  log "WARNING: Vite did not respond after 10s — check: parse-logs vite"
+  return 1
+}
+
+# ---------- Banner -------------------------------------------------------
+
+print_banner() {
+  echo ""
+  log "════════════════════════════════════════"
+  log "  PARSE is running"
+  log "  React UI:  http://localhost:${PARSE_VITE_PORT}/"
+  log "  Compare:   http://localhost:${PARSE_VITE_PORT}/compare"
+  log "  API:       http://localhost:${PARSE_API_PORT}/api/config"
+  log "════════════════════════════════════════"
+}
+
+# ---------- Main ---------------------------------------------------------
+
+main() {
+  pull_main
+  stop_servers
+  start_api || return 1
+  start_vite || return 1
+  print_banner
+}
+
+main "$@"

--- a/scripts/parse-stop.sh
+++ b/scripts/parse-stop.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scripts/parse-stop.sh — PARSE dev stop helper
+#
+# Kills the Python API server and Vite dev server on both WSL and Windows
+# sides. Safe to run when nothing is running.
+#
+# Usage
+# -----
+#   scripts/parse-stop.sh
+#
+# Environment overrides
+# ---------------------
+#   PARSE_API_PORT   API server port (default: 8766)
+#   PARSE_VITE_PORT  Vite dev server port (default: 5173)
+
+set -u
+
+: "${PARSE_API_PORT:=8766}"
+: "${PARSE_VITE_PORT:=5173}"
+
+log() { printf '[parse-stop] %s\n' "$*"; }
+
+find_taskkill() {
+  if command -v taskkill.exe >/dev/null 2>&1; then
+    command -v taskkill.exe
+    return
+  fi
+  if [ -x "/mnt/c/Windows/System32/taskkill.exe" ]; then
+    echo "/mnt/c/Windows/System32/taskkill.exe"
+    return
+  fi
+  return 1
+}
+
+log "Killing PARSE servers..."
+
+# WSL-side
+pkill -9 -f "python.*server\.py" 2>/dev/null || true
+pkill -9 -f "python\.exe.*server\.py" 2>/dev/null || true
+pkill -9 -f "node.*vite" 2>/dev/null || true
+
+# Windows-side zombie python.exe cleanup
+taskkill="$(find_taskkill)" || taskkill=""
+if [ -n "${taskkill}" ]; then
+  pids=$(
+    /mnt/c/Windows/System32/wbem/WMIC.exe process where \
+      "name='python.exe' and CommandLine like '%%server.py%%'" \
+      get ProcessId 2>/dev/null \
+      | tr -d '\r' \
+      | awk 'NR>1 && $1 ~ /^[0-9]+$/ {print $1}'
+  ) || true
+  for pid in ${pids}; do
+    "${taskkill}" /F /PID "${pid}" >/dev/null 2>&1 || true
+    log "killed Windows python.exe PID ${pid}"
+  done
+fi
+
+# Port-level fallback
+fuser -k "${PARSE_API_PORT}/tcp" 2>/dev/null || true
+fuser -k "${PARSE_VITE_PORT}/tcp" 2>/dev/null || true
+
+log "Done."


### PR DESCRIPTION
## Problem

The `parse-run` shell alias (local to `~/.bash_aliases`, not tracked in-repo) uses `pkill -9 -f "python.exe.*server.py"` to clean stale servers. When `PARSE_PY` points at a Windows `python.exe` (e.g. a conda env on `C:`), the server process is a Windows process — `pkill` from WSL only signals the `/init` stub, not the real Windows `python.exe`.

Result: **zombie `python.exe` processes hold port 8766 with broken handler state, returning "empty reply from server" to every request**. Fresh `parse-run` invocations then fail the API health-check with `API did not respond after 12s`, even though the new server starts fine.

Lucas hit this today after PR #45 merged — a zombie from a prior run blocked `:8766` and had to be killed manually via `taskkill.exe`.

## Fix

Move launcher logic from `~/.bash_aliases` into tracked scripts so it's PR-reviewable and consistent across machines:

- **`scripts/parse-run.sh`** — pull → stop → start API → health-check → start Vite → print URLs. Detects `/mnt/c/...` Windows interpreters and runs `taskkill.exe` (via `WMIC process` filter on `server.py`) **in addition to** `pkill`/`fuser`.
- **`scripts/parse-stop.sh`** — symmetric cleanup covering both sides.
- Adds `-u` to the python invocation (unbuffered stdout) so the startup banner appears immediately — avoided the earlier "looks hung" failure mode during diagnosis.
- Guards the `git stash` dance: only stashes when there are actual modifications, so benign pulls don't create empty-stash churn.
- Environment knobs: `PARSE_PY`, `PARSE_ROOT`, `PARSE_API_PORT`, `PARSE_VITE_PORT`, `PARSE_SKIP_PULL`.

The local alias wiring stays in `~/.bash_aliases` and just delegates:

```bash
alias parse-run='/path/to/parse/scripts/parse-run.sh'
alias parse-stop='/path/to/parse/scripts/parse-stop.sh'
```

## README

Updated to document the new scripts, the env knobs, and the WSL/Windows zombie-cleanup rationale.

## Verification

- `bash -n` syntax check passes for both scripts.
- `parse-stop.sh` runs clean on an empty system (no false errors).
- `parse-run.sh` progresses through pull → stop → start phases with `PARSE_SKIP_PULL=1` and a dummy `PARSE_PY`.
- **Live-tested** against `/mnt/c/Users/Lucas/parse_v2` with the Windows conda env — API reached HTTP 200 on `/api/config` within 12s; Vite served `http://localhost:5173/` successfully. Lucas is currently working on top of this same launch.