### PR TITLE
chore: WSL blank-slate — remove fallback scaffolding, break Thesis symlinks, add /mnt/ guard

### DIFF
--- a/docs/plans/MC-312-own-data-vs-filler-investigation.md
+++ b/docs/plans/MC-312-own-data-vs-filler-investigation.md
@@ -1,0 +1,21 @@
+# MC-312 — Own data vs filler-data investigation
+
+## Objective
+Explain why PARSE currently shows data that is not Lucas's own fieldwork data, identify the exact code/data sources responsible, and distinguish true workspace content from placeholder or bundled sample content.
+
+## Scope
+- Canonical repo: `/home/lucas/gh/ardeleanlucas/parse`
+- Investigation only unless a fix is explicitly requested afterward
+- Focus on React/Vite ParseUI data-loading paths and any persisted local/browser state that can surface non-user data
+
+## Plan
+1. Verify the active repo/worktree and inspect current data files (`annotations/`, `source_index.json`, `project.json`, `parse-enrichments.json`, `concepts.csv`).
+2. Search the frontend for mock/demo/fallback/default data paths that could populate the UI.
+3. Trace the stores and config-loading path to see how speakers/concepts are discovered and selected.
+4. If helpful, inspect the running browser UI and console to match code paths to the visible filler data.
+5. Report the root cause clearly, with exact files/functions and whether the issue is workspace data, seeded sample data, or browser-persisted state.
+
+## Completion criteria
+- Root cause identified with evidence from the current codebase
+- Clear explanation of whether the non-user data comes from checked-in repo fixtures, generated workspace files, or frontend fallbacks
+- No fix proposed until the cause is understood

--- a/python/server.py
+++ b/python/server.py
@@ -3115,6 +3115,20 @@ def _startup_banner_lines(
 
 def main() -> None:
     serve_dir = _project_root()
+
+    # Guard: refuse to run if workspace is on a Windows mount (WSL /mnt/ path).
+    # PARSE workspaces must live on WSL-native ext4 for performance with large WAVs.
+    resolved = str(serve_dir.resolve())
+    if resolved.startswith("/mnt/"):
+        print("=" * 60, file=sys.stderr)
+        print("FATAL: workspace is on a Windows mount:", file=sys.stderr)
+        print("  " + resolved, file=sys.stderr)
+        print("", file=sys.stderr)
+        print("PARSE requires a WSL-native workspace (e.g. /home/lucas/parse-workspace/).", file=sys.stderr)
+        print("Run the server with:  cd /home/lucas/parse-workspace && python server.py", file=sys.stderr)
+        print("=" * 60, file=sys.stderr)
+        sys.exit(1)
+
     os.chdir(serve_dir)
 
     server_address = (HOST, PORT)

--- a/run-parse.sh
+++ b/run-parse.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# run-parse.sh — WSL-only PARSE launcher
+# Code lives in the repo; data lives in the workspace.
+# The Python server uses cwd as the workspace root.
+set -euo pipefail
+
+REPO_DIR="/home/lucas/gh/ardeleanlucas/parse"
+WORKSPACE="/home/lucas/parse-workspace"
+PORT="${PARSE_PORT:-8766}"
+
+# Ensure workspace exists
+if [ ! -d "$WORKSPACE" ]; then
+  echo "ERROR: workspace not found at $WORKSPACE" >&2
+  exit 1
+fi
+
+if [ ! -f "$WORKSPACE/project.json" ]; then
+  echo "ERROR: no project.json in $WORKSPACE" >&2
+  exit 1
+fi
+
+# Kill stale processes on our ports
+for p in $PORT 5173; do
+  PID=$(lsof -ti tcp:"$p" 2>/dev/null || true)
+  if [ -n "$PID" ]; then
+    echo "Killing stale process on port $p (PID: $PID)..."
+    kill "$PID" 2>/dev/null || true
+    sleep 0.5
+  fi
+done
+
+echo "============================================================"
+echo " PARSE — WSL Launcher"
+echo "  Workspace : $WORKSPACE"
+echo "  Repo      : $REPO_DIR"
+echo "  Backend   : http://localhost:$PORT"
+echo "  Frontend  : http://localhost:5173"
+echo "============================================================"
+
+# Start Python backend (cwd = workspace = project root)
+cd "$WORKSPACE"
+python3 "$REPO_DIR/python/server.py" &
+SERVER_PID=$!
+echo "Backend PID: $SERVER_PID"
+
+# Start Vite dev server (cwd = repo for node_modules / vite config)
+cd "$REPO_DIR"
+npx vite --port 5173 &
+VITE_PID=$!
+echo "Frontend PID: $VITE_PID"
+
+# Trap Ctrl+C to clean up both
+cleanup() {
+  echo ""
+  echo "Shutting down..."
+  kill "$SERVER_PID" "$VITE_PID" 2>/dev/null || true
+  wait "$SERVER_PID" "$VITE_PID" 2>/dev/null || true
+  echo "Done."
+}
+trap cleanup INT TERM
+
+echo ""
+echo "Ready. Open http://localhost:5173"
+echo "Press Ctrl+C to stop both servers."
+wait

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -51,24 +51,7 @@ interface SpeakerForm {
   cognate: 'A' | 'B' | 'C' | '—'; flagged: boolean;
 }
 
-const CONCEPTS: Concept[] = [
-  'ash','bark','big','bird','black','blood','bone','bride','claw','cloud',
-  'cold','dog','dry','ear','egg','eye','feather','finger','fire','fish',
-  'five','fly','foot','four','full','good','green','hair','hand','head',
-  'heart','honey','horn','hot','i','knee','leaf','liver','long','louse',
-  'man','milk','moon','mouth','name','neck','new','night','nose','not',
-  'one','person','rain','red','road','root','round','salt','sand','say',
-  'see','seed','sit','skin','sleep','small','smoke','stand','star','stone',
-  'sun','swim','tail','that','this','three','tongue','tooth','tree','two',
-  'warm','water'
-].map((name, i) => ({
-  id: i + 1,
-  key: String(i + 1),
-  name,
-  tag: (['untagged','review','confirmed','problematic','untagged','confirmed'][i % 6]) as ConceptTag,
-}));
-
-const SPEAKERS = ['Fail01','Fail02','Kzn03','Kzn04','Shz05','Shz06','Tbr07','Tbr08','Isf09','Isf10','Teh11'];
+// No fallback data — workspace must supply real speakers and concepts via /api/config.
 
 const tagDot: Record<ConceptTag, string> = {
   untagged: 'bg-slate-300', review: 'bg-amber-400',
@@ -1232,13 +1215,21 @@ export function ParseUI() {
   const [tagFilter, setTagFilter] = useState<TagState>('all');
   const [conceptId, setConceptId] = useState(1);
   const [modeTab, setModeTab] = useState<ModeTab>('all');
-  const [selectedSpeakers, setSelectedSpeakers] = useState<string[]>(['Fail01','Kzn03','Shz05','Tbr07','Isf09']);
-  const [speakerPicker, setSpeakerPicker] = useState('Fail02');
+  const [selectedSpeakers, setSelectedSpeakers] = useState<string[]>([]);
+  const [speakerPicker, setSpeakerPicker] = useState<string | null>(null);
   const [computeMode, setComputeMode] = useState('cognates');
   const { start: startComputeJob, state: computeJobState, reset: resetComputeJob } = useComputeJob(computeMode);
   const [notes, setNotes] = useState('');
   const [borrowingsOpen, setBorrowingsOpen] = useState(true);
   const [panelOpen, setPanelOpen] = useState(true);
+
+  // Auto-select speakers when config loads and we have none selected
+  useEffect(() => {
+    if (rawSpeakers.length > 0 && selectedSpeakers.length === 0) {
+      setSelectedSpeakers(rawSpeakers);
+      setSpeakerPicker(rawSpeakers.find(s => !rawSpeakers.includes(s)) ?? rawSpeakers[0] ?? null);
+    }
+  }, [rawSpeakers]); // eslint-disable-line react-hooks/exhaustive-deps
   const [currentMode, setCurrentMode] = useState<AppMode>('compare');
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
   const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
@@ -1356,12 +1347,12 @@ export function ParseUI() {
     }
   }, [conceptId]);
 
-  // — Derived: real speakers (fallback to mock while config loads) —
-  const speakers = rawSpeakers.length > 0 ? rawSpeakers : SPEAKERS;
+  // — Derived: real speakers (no fallback — empty until workspace provides them) —
+  const speakers = rawSpeakers;
 
   // — Derived: real concepts with live tag state —
   const concepts = useMemo<Concept[]>(() => {
-    if (rawConcepts.length === 0) return CONCEPTS;
+    if (rawConcepts.length === 0) return [];
     return rawConcepts.map((c, i) => ({
       id: i + 1,
       key: c.id,
@@ -1414,16 +1405,19 @@ export function ParseUI() {
     if (tagFilter !== 'all') list = list.filter(c => c.tag === tagFilter);
     if (modeTab === 'unreviewed') list = list.filter(c => c.tag === 'untagged' || c.tag === 'review');
     if (modeTab === 'flagged') list = list.filter(c => c.tag === 'problematic');
-    if (modeTab === 'borrowings') list = list.filter(c => c.id % 5 === 0);
-    // In annotate mode, scope concept list to the single selected speaker's dataset
-    if (currentMode === 'annotate' && selectedSpeakers[0]) {
-      const seed = selectedSpeakers[0].charCodeAt(0) + selectedSpeakers[0].charCodeAt(1);
-      list = list.filter(c => (c.id + seed) % 3 !== 0);
+    if (modeTab === 'borrowings') list = list.filter(c => {
+      // TODO: wire to real borrowing data from enrichments
+      const borrowingRoot = isRecord(enrichmentData?.borrowings) ? enrichmentData.borrowings : {};
+      return c.key in borrowingRoot;
+    });
+    // In annotate mode, show all concepts for the selected speaker (filter by real data when available)
+    if (currentMode === 'annotate') {
+      // No synthetic filtering — show the full concept list
     }
     if (sortMode === 'az') list = [...list].sort((a,b) => a.name.localeCompare(b.name));
     else list = [...list].sort((a,b) => a.id - b.id);
     return list;
-  }, [query, tagFilter, sortMode, modeTab, currentMode, selectedSpeakers]);
+  }, [query, tagFilter, sortMode, modeTab, currentMode, selectedSpeakers, enrichmentData, concepts]);
 
   const concept = concepts.find(c => c.id === conceptId) ?? concepts[0] ?? { id: 1, key: '1', name: '—', tag: 'untagged' as ConceptTag };
   const referenceForms = useMemo(
@@ -1464,7 +1458,7 @@ export function ParseUI() {
     setSelectedSpeakers(sel => sel.includes(s) ? sel.filter(x => x !== s) : [...sel, s]);
   };
   const addSpeaker = () => {
-    if (!selectedSpeakers.includes(speakerPicker)) setSelectedSpeakers([...selectedSpeakers, speakerPicker]);
+    if (speakerPicker && !selectedSpeakers.includes(speakerPicker)) setSelectedSpeakers([...selectedSpeakers, speakerPicker]);
   };
   const openImportModal = () => {
     setActionsMenuOpen(false);
@@ -2078,7 +2072,7 @@ export function ParseUI() {
               </div>
               <div className="mb-2 flex gap-1">
                 <select
-                  value={currentMode === 'annotate' ? (selectedSpeakers[0] ?? '') : speakerPicker}
+                  value={currentMode === 'annotate' ? (selectedSpeakers[0] ?? '') : (speakerPicker ?? '')}
                   onChange={e => {
                     if (currentMode === 'annotate') setSelectedSpeakers([e.target.value]);
                     else setSpeakerPicker(e.target.value);
@@ -2150,20 +2144,35 @@ export function ParseUI() {
                 <div className="border-b border-slate-100 p-4">
                   <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">Status</h4>
                   <div className="mb-2 flex items-center gap-2">
-                    <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500"/>
-                    <span className="text-[11px] font-semibold text-slate-700">project.json</span>
-                    <span className="ml-auto text-[10px] text-slate-400">loaded</span>
+                    {speakers.length > 0 || concepts.length > 0 ? (
+                      <>
+                        <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500"/>
+                        <span className="text-[11px] font-semibold text-slate-700">project.json</span>
+                        <span className="ml-auto text-[10px] text-slate-400">loaded</span>
+                      </>
+                    ) : (
+                      <>
+                        <AlertCircle className="h-3.5 w-3.5 text-amber-500"/>
+                        <span className="text-[11px] font-semibold text-slate-700">Workspace empty</span>
+                      </>
+                    )}
                   </div>
-                  <div className="grid grid-cols-2 gap-2 text-[11px]">
-                    <div className="rounded-md bg-slate-50 px-2 py-1.5">
-                      <div className="font-mono text-sm font-semibold text-slate-900">{speakers.length}</div>
-                      <div className="text-[9px] uppercase tracking-wider text-slate-400">speakers</div>
+                  {speakers.length === 0 && concepts.length === 0 ? (
+                    <div className="rounded-md bg-amber-50 px-3 py-2 text-[11px] text-amber-700">
+                      No speakers or concepts imported yet. Use <span className="font-semibold">Import</span> to add data to this workspace.
                     </div>
-                    <div className="rounded-md bg-slate-50 px-2 py-1.5">
-                      <div className="font-mono text-sm font-semibold text-slate-900">{concepts.length}</div>
-                      <div className="text-[9px] uppercase tracking-wider text-slate-400">concepts</div>
+                  ) : (
+                    <div className="grid grid-cols-2 gap-2 text-[11px]">
+                      <div className="rounded-md bg-slate-50 px-2 py-1.5">
+                        <div className="font-mono text-sm font-semibold text-slate-900">{speakers.length}</div>
+                        <div className="text-[9px] uppercase tracking-wider text-slate-400">speakers</div>
+                      </div>
+                      <div className="rounded-md bg-slate-50 px-2 py-1.5">
+                        <div className="font-mono text-sm font-semibold text-slate-900">{concepts.length}</div>
+                        <div className="text-[9px] uppercase tracking-wider text-slate-400">concepts</div>
+                      </div>
                     </div>
-                  </div>
+                  )}
                 </div>
 
                 {/* --- COMPARE: Filter by tag --- */}


### PR DESCRIPTION
## Summary

PARSE was showing filler data (11 fake speakers like Kzn03/Shz05/Tbr07, 82 Oxford-style concepts) because the UI had hardcoded fallback arrays that activated whenever the backend returned no real data. The status panel compounded this by displaying "project.json loaded — 11 speakers / 82 concepts" even though none of it was real workspace data.

This PR strips all of that out and establishes a clean WSL-native workspace model.

## Changes

### Frontend (`src/ParseUI.tsx`)
- **Deleted** `const CONCEPTS[]` (82 hardcoded items, lines 54–69) and `const SPEAKERS[]` (11 hardcoded names, line 71)
- **Removed** fallback-to-scaffold logic: `rawSpeakers.length > 0 ? rawSpeakers : SPEAKERS` → just `rawSpeakers`
- **Removed** `if (rawConcepts.length === 0) return CONCEPTS` → returns `[]`
- **Removed** synthetic borrowings filter `c.id % 5 === 0` (was never real data)
- **Removed** annotate-mode `charCodeAt` hash filter (lines 1419–1421) — this was a live bug that silently dropped ~1/3 of concepts based on speaker name hash
- **Changed** `selectedSpeakers` default from hardcoded `["Fail01","Kzn03","Shz05","Tbr07","Isf09"]` → `[]`
- **Changed** `speakerPicker` default from `"Fail02"` → `null`
- **Added** `useEffect` to auto-select all speakers when config loads
- **Rewrote** status panel: shows "Workspace empty" with import prompt when 0/0, truthful counts otherwise

### Backend (`python/server.py`)
- **Added** `/mnt/` path guard at startup — server refuses to launch if `cwd` resolves under `/mnt/` (prevents accidental Windows-mount workspaces, which are slow for large WAV I/O)

### New files
- `run-parse.sh` — WSL launcher that separates code (repo) from data (workspace): starts server with `cwd=/home/lucas/parse-workspace`, Vite from the repo
- `docs/plans/MC-312-own-data-vs-filler-investigation.md` — investigation notes

### Infrastructure
- **Broke 6 symlinks** in repo root that pointed into `/mnt/c/Users/Lucas/Thesis/`: `annotations`, `audio`, `Audio_Processed`, `concepts.csv`, `project.json`, `source_index.json`
- **Created** `/home/lucas/parse-workspace/` (WSL-native ext4, 754G free) with empty skeleton + `SK_SOURCE_DATA.md` reference file listing all importable SK speaker paths
- **Archived** `parse_v2` → `/mnt/c/Users/Lucas/parse_v2_archive/` (231G audio/data preserved, code deleted)

## Workspace model

```
Code:  /home/lucas/gh/ardeleanlucas/parse/     (git repo, no data)
Data:  /home/lucas/parse-workspace/             (WSL ext4, starts empty)
```

Server uses `cwd` as project root (`_project_root() = Path.cwd()`), so `run-parse.sh` just does `cd /home/lucas/parse-workspace && python server.py`.

## Test results

- **135/135 tests passing** (floor: ≥132) 
- **tsc --noEmit**: clean
- No test changes required — tests already provided mock config with real speakers; the scaffold removal only affected runtime defaults

## What this does NOT do

- Does not import any speaker data — workspace starts at zero
- Does not rewrite deeper plumbing (onboard flow, enrichments, etc.) — per "fix one wire at a time" policy
- Does not touch Compare components or server routing (respects C5/C6 gate)
