### PR TITLE
fix: xAI/Grok chat integration — provider routing, error display, key validation

### DIFF
--- a/python/ai/openai_auth.py
+++ b/python/ai/openai_auth.py
@@ -369,6 +369,18 @@ def get_api_key() -> Optional[str]:
         return None
 
 
+def get_api_key_provider() -> str:
+    """Return the provider associated with the saved API key, or 'openai'."""
+    path = _token_path()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            tokens = json.load(f)
+        provider = tokens.get("direct_api_key_provider", "").strip().lower()
+        return provider if provider else "openai"
+    except (json.JSONDecodeError, OSError):
+        return "openai"
+
+
 def clear_api_key() -> None:
     """Remove the stored direct API key."""
     path = _token_path()

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -287,6 +287,24 @@ def get_chat_config(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
 class OpenAIChatRuntime:
     """Thin OpenAI chat runtime wrapper with tool-call support and reasoning fallback."""
 
+    # Provider-specific base URLs for the OpenAI-compatible API
+    _PROVIDER_BASE_URLS: Dict[str, str] = {
+        "xai": "https://api.x.ai/v1",
+        "grok": "https://api.x.ai/v1",
+        "x.ai": "https://api.x.ai/v1",
+    }
+
+    # Default models per provider (used when config still has a placeholder/OpenAI model)
+    _PROVIDER_DEFAULT_MODELS: Dict[str, str] = {
+        "xai": "grok-3-mini",
+        "grok": "grok-3-mini",
+        "x.ai": "grok-3-mini",
+        "openai": "gpt-4o",
+    }
+
+    # Model names that are clearly OpenAI-only and should be swapped for xAI
+    _OPENAI_ONLY_MODELS = {"gpt54", "gpt-4o", "gpt-4", "gpt-3.5-turbo", "o1", "o1-mini", "o1-preview", "o3", "o3-mini"}
+
     def __init__(
         self,
         config: Optional[Dict[str, Any]] = None,
@@ -322,12 +340,20 @@ class OpenAIChatRuntime:
         try:
             try:
                 from python.ai.openai_auth import get_api_key as _get_direct_key
+                from python.ai.openai_auth import get_api_key_provider as _get_provider
             except ImportError:
                 from .openai_auth import get_api_key as _get_direct_key
+                from .openai_auth import get_api_key_provider as _get_provider
             _direct_key = _get_direct_key()
             if _direct_key:
-                # Build client with direct key and correct base_url for provider
-                _base_url = self.chat_config.get("base_url") or None
+                # Resolve provider and route to correct base_url + model
+                _provider = _get_provider()
+                _base_url = self.chat_config.get("base_url") or self._PROVIDER_BASE_URLS.get(_provider)
+
+                # Swap model if it's an OpenAI-only model and we're using a different provider
+                if _provider in self._PROVIDER_DEFAULT_MODELS and self.model in self._OPENAI_ONLY_MODELS:
+                    self.model = self._PROVIDER_DEFAULT_MODELS[_provider]
+
                 try:
                     from openai import OpenAI
                 except ImportError as exc:

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -276,17 +276,24 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
   }, [isConnected, hasData, conceptName, speakerCount, messages.length]);
 
   const handleConnect = async (p: AIProvider) => {
-    if (apiKey.trim()) {
-      try {
-        await saveApiKey(apiKey.trim(), p);
-      } catch {
-        // non-fatal — key saved in session even if persist fails
-      }
-    }
-    setProvider(p);
-    setView('connected');
-    setTestStatus('idle');
+    if (!apiKey.trim()) return;
+    setTestStatus('testing');
     setTestMessage('');
+    try {
+      const result = await saveApiKey(apiKey.trim(), p);
+      if (result && result.authenticated) {
+        setProvider(p);
+        setView('connected');
+        setTestStatus('idle');
+        setTestMessage('');
+      } else {
+        setTestStatus('error');
+        setTestMessage('Key was saved but could not be verified.');
+      }
+    } catch (err) {
+      setTestStatus('error');
+      setTestMessage(err instanceof Error ? err.message : 'Connection failed.');
+    }
   };
 
   const handleTestConnection = async () => {
@@ -620,7 +627,7 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
                   </div>
 
                   <button
-                    onClick={() => handleConnect('openai')}
+                    onClick={() => { setProvider('openai'); setView('connected'); }}
                     className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-[12px] font-semibold text-slate-800 transition hover:bg-slate-50"
                   >
                     Sign in with Codex
@@ -665,6 +672,15 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
               ))}
             </div>
           </div>
+
+          {/* Error display */}
+          {chatSession.error && (
+            <div className="shrink-0 px-6 py-2">
+              <div className="mx-auto max-w-3xl rounded-lg border border-rose-200 bg-rose-50 px-4 py-2.5 text-[12px] text-rose-700">
+                <span className="font-semibold">Error:</span> {chatSession.error}
+              </div>
+            </div>
+          )}
 
           {/* Quick actions + input */}
           <div className="shrink-0 border-t border-slate-200/70 bg-white/50 px-6 py-3 backdrop-blur-sm">

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -78,6 +78,7 @@ export interface ChatJob {
 export interface ChatStatus {
   status: string;
   result?: string;
+  error?: string;
 }
 
 export interface ComputeJob {

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -93,7 +93,7 @@ export function useChatSession(): UseChatSessionResult {
                 if (status.status === "done" || status.status === "completed") {
                   resolve(status.result ?? "")
                 } else if (status.status === "error") {
-                  reject(new Error(status.result ?? "Chat error"))
+                  reject(new Error(status.error ?? status.result ?? "Chat error"))
                 } else if (polls >= MAX_POLLS) {
                   reject(new Error("Chat timed out"))
                 } else {


### PR DESCRIPTION
## Summary

The PARSE AI chat panel shows a green "Connected to xAI" badge after entering an API key, but no response ever arrives from Grok. The badge was cosmetic (not validated), the backend always targeted the OpenAI API even with an xAI key, and errors were silently swallowed.

## Changes (5 files, 68+/13-)

### Backend
- **`python/ai/openai_auth.py`** — Added `get_api_key_provider()` to read stored provider from `auth_tokens.json`
- **`python/ai/provider.py`** — Added provider→base_url routing (`https://api.x.ai/v1` for xAI), provider→default_model mapping, and OpenAI-only model detection. `_load_client()` now reads the stored provider and auto-configures the OpenAI client accordingly.

### Frontend
- **`src/api/types.ts`** — Added `error?: string` to `ChatStatus` (server returns errors in this field, not `result`)
- **`src/hooks/useChatSession.ts`** — Poll error handler now reads `status.error ?? status.result` instead of just `status.result`
- **`src/ParseUI.tsx`** — (1) `handleConnect()` validates key via `saveApiKey()` response before showing green badge. (2) Error banner renders `chatSession.error` in the chat panel. (3) Codex OAuth button separated from key-validation flow.

## Root Causes Fixed

| # | Issue | Fix |
|---|---|---|
| 1 | Green badge shown without validation | `handleConnect()` now checks `result.authenticated` |
| 2 | Backend never set `base_url` for xAI | Provider routing map in `OpenAIChatRuntime` |
| 3 | Model defaulted to `gpt54` for xAI | Auto-swap to `grok-3-mini` when provider is xAI |
| 4 | Stored provider never read back at runtime | New `get_api_key_provider()` + used in `_load_client()` |
| 5 | `chatSession.error` never rendered | Rose error banner added to chat panel |
| 6 | `ChatStatus.error` field missing from type | Added to interface |
| 7 | Poll handler read wrong field for errors | Reads `error` field first |

## Tests
- ✅ 135/135 tests pass (above 132 floor)
- ✅ Clean `tsc --noEmit`
