### PR TITLE
[MC-313] fix(auth): OpenAI/Codex auth flow — 4 bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ All `src/api/client.ts` helpers have matching routes in `python/server.py`:
 | `updateConfig()` | `PUT /api/config` | ✅ |
 | `getAuthStatus()` | `GET /api/auth/status` | ✅ |
 | `startAuthFlow()` | `POST /api/auth/start` | ✅ |
-| `pollAuth()` | `POST /api/auth/poll` | ✅ |
+| ~~`pollAuth()`~~ | `POST /api/auth/poll` | ✅ (server route exists; client helper removed — use `getAuthStatus()`) |
 | `saveApiKey()` | `POST /api/auth/key` | ✅ |
 | `logoutAuth()` | `POST /api/auth/logout` | ✅ |
 | `startSTT()` | `POST /api/stt` | ✅ |

--- a/python/server.py
+++ b/python/server.py
@@ -2772,8 +2772,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
     def _api_auth_key(self) -> None:
         """POST /api/auth/key — store a direct API key."""
         try:
-            body = self._read_body()
-            data = json.loads(body)
+            data = self._read_json_body()
             key = str(data.get("key") or "").strip()
             provider = str(data.get("provider") or "xai").strip()
             if not key:

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -12,7 +12,7 @@ import {
   Sun, Moon, XCircle
 } from 'lucide-react';
 import type { AnnotationInterval, AnnotationRecord, Tag as StoreTag } from './api/types';
-import { getLingPyExport, saveApiKey, startSTT, startCompute, startNormalize, pollSTT, pollNormalize, pollCompute } from './api/client';
+import { getLingPyExport, saveApiKey, getAuthStatus, startAuthFlow, startSTT, startCompute, startNormalize, pollSTT, pollNormalize, pollCompute } from './api/client';
 import { useChatSession, type UseChatSessionResult } from './hooks/useChatSession';
 import { useSpectrogram } from './hooks/useSpectrogram';
 import { useWaveSurfer } from './hooks/useWaveSurfer';
@@ -257,6 +257,10 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
   const [apiKey, setApiKey] = useState('');
   const [testStatus, setTestStatus] = useState<TestStatus>('idle');
   const [testMessage, setTestMessage] = useState('');
+  const [oauthPending, setOauthPending] = useState(false);
+  const [oauthCode, setOauthCode] = useState('');
+  const [oauthUri, setOauthUri] = useState('');
+  const oauthPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isConnected = view === 'connected' && provider !== null;
   const hasData = speakerCount > 0;
 
@@ -301,7 +305,7 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
     setTestStatus('testing');
     setTestMessage('');
     try {
-      await saveApiKey(apiKey.trim(), provider ?? 'openai');
+      await saveApiKey(apiKey.trim(), provider ?? (view === 'form-xai' ? 'xai' : 'openai'));
       setTestStatus('success');
       setTestMessage('Connection verified — key saved.');
     } catch (err) {
@@ -330,6 +334,42 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
     setView('welcome');
     setTestStatus('idle');
     setTestMessage('');
+  };
+
+  // Cleanup OAuth poll on unmount
+  useEffect(() => {
+    return () => { if (oauthPollRef.current) clearInterval(oauthPollRef.current); };
+  }, []);
+
+  const handleCodexSignIn = async () => {
+    setOauthPending(true);
+    setOauthCode('');
+    setOauthUri('');
+    setTestMessage('');
+    try {
+      await startAuthFlow();
+      const status = await getAuthStatus();
+      if (status.user_code) {
+        setOauthCode(status.user_code);
+        setOauthUri(status.verification_uri ?? '');
+      }
+      oauthPollRef.current = setInterval(async () => {
+        try {
+          const s = await getAuthStatus();
+          if (s.authenticated) {
+            if (oauthPollRef.current) clearInterval(oauthPollRef.current);
+            oauthPollRef.current = null;
+            setOauthPending(false);
+            setProvider('openai');
+            setView('connected');
+          }
+        } catch { /* keep polling */ }
+      }, 5000);
+    } catch (err) {
+      setOauthPending(false);
+      setTestStatus('error');
+      setTestMessage(err instanceof Error ? err.message : 'OAuth start failed.');
+    }
   };
 
   useEffect(() => {
@@ -627,11 +667,27 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
                   </div>
 
                   <button
-                    onClick={() => { setProvider('openai'); setView('connected'); }}
-                    className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-[12px] font-semibold text-slate-800 transition hover:bg-slate-50"
+                    onClick={handleCodexSignIn}
+                    disabled={oauthPending}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-[12px] font-semibold text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    Sign in with Codex
+                    {oauthPending ? 'Waiting for sign-in...' : 'Sign in with Codex'}
                   </button>
+                  {oauthPending && oauthCode && (
+                    <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-4 text-center">
+                      <div className="text-[11px] text-slate-500 mb-1">Enter this code:</div>
+                      <div className="text-lg font-mono font-bold tracking-widest text-slate-900">
+                        {oauthCode}
+                      </div>
+                      {oauthUri && (
+                        <a href={oauthUri} target="_blank" rel="noreferrer"
+                           className="mt-1 block text-[11px] text-indigo-600 hover:underline">
+                          {oauthUri}
+                        </a>
+                      )}
+                      <div className="mt-2 text-[10px] text-slate-400">Waiting for confirmation...</div>
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -114,10 +114,6 @@ export async function startAuthFlow(): Promise<void> {
   await apiFetch<void>("/api/auth/start", { method: "POST" });
 }
 
-export async function pollAuth(): Promise<AuthStatus> {
-  return apiFetch<AuthStatus>("/api/auth/poll", { method: "POST" });
-}
-
 export async function saveApiKey(key: string, provider: string): Promise<AuthStatus> {
   return apiFetch<AuthStatus>("/api/auth/key", {
     method: "POST",

--- a/src/components/annotate/ChatPanel.test.tsx
+++ b/src/components/annotate/ChatPanel.test.tsx
@@ -23,7 +23,6 @@ vi.mock("../../hooks/useChatSession", () => ({
 vi.mock("../../api/client", () => ({
   getAuthStatus: () => Promise.resolve({ authenticated: true, method: "api_key", provider: "xai" }),
   startAuthFlow: vi.fn(),
-  pollAuth: vi.fn(),
   saveApiKey: vi.fn(),
   logoutAuth: vi.fn(),
 }))

--- a/src/components/annotate/ChatPanel.tsx
+++ b/src/components/annotate/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react"
 import { useChatSession } from "../../hooks/useChatSession"
 import type { ChatMessage } from "../../hooks/useChatSession"
-import { getAuthStatus, startAuthFlow, pollAuth, saveApiKey, logoutAuth } from "../../api/client"
+import { getAuthStatus, startAuthFlow, saveApiKey, logoutAuth } from "../../api/client"
 import type { AuthStatus } from "../../api/types"
 
 export interface ChatPanelProps {
@@ -73,14 +73,14 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
     setAuthState("oauth")
     try {
       await startAuthFlow()
-      const status = await pollAuth()
+      const status = await getAuthStatus()
       if (status.user_code) {
         setOauthInfo({ user_code: status.user_code, verification_uri: status.verification_uri })
       }
       // Start polling
       pollRef.current = setInterval(async () => {
         try {
-          const s = await pollAuth()
+          const s = await getAuthStatus()
           if (s.authenticated) {
             if (pollRef.current) clearInterval(pollRef.current)
             pollRef.current = null


### PR DESCRIPTION
## MC-313 — Fix OpenAI/Codex Auth Flow

Plan: `docs/plans/fix-openai-codex-auth.md` (PR #50)

### Bugs Fixed

| # | Bug | File | Fix |
|---|-----|------|-----|
| 1 | `_api_auth_key` calls `self._read_body()` which doesn't exist → 500 on every key save/test | `python/server.py` | `_read_body()` + `json.loads()` → `_read_json_body()` |
| 2 | "Sign in with Codex" button just flips UI state, never runs OAuth | `src/ParseUI.tsx` | Wired to `startAuthFlow()` + `getAuthStatus()` + 5s poll loop + device code display |
| 3 | ChatPanel OAuth polls `pollAuth()` which returns `{status:"pending"}`, not the `user_code` | `src/components/annotate/ChatPanel.tsx` | `pollAuth()` → `getAuthStatus()` (returns `user_code` + `verification_uri` when flow active) |
| 4 | `handleTestConnection` falls back to `'openai'` even on xAI form | `src/ParseUI.tsx` | View-aware fallback: `provider ?? (view === 'form-xai' ? 'xai' : 'openai')` |

### Test Gates
- `tsc --noEmit`: clean
- `npm run test -- --run`: 135 passed (24 files)

### Supersedes
PR #49 (Bug 1 only) — this PR includes all 4 fixes. PR #49 can be closed.