### PR TITLE
fix(chat): xAI error surfaces as "OpenAI credentials missing"

### DIFF
--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -336,76 +336,71 @@ class OpenAIChatRuntime:
         if self._client is not None:
             return self._client
 
-        # Check direct API key first (paste-key flow)
         try:
-            try:
-                from python.ai.openai_auth import get_api_key as _get_direct_key
-                from python.ai.openai_auth import get_api_key_provider as _get_provider
-            except ImportError:
-                from .openai_auth import get_api_key as _get_direct_key
-                from .openai_auth import get_api_key_provider as _get_provider
-            _direct_key = _get_direct_key()
-            if _direct_key:
-                # Resolve provider and route to correct base_url + model
-                _provider = _get_provider()
-                _base_url = self.chat_config.get("base_url") or self._PROVIDER_BASE_URLS.get(_provider)
+            from python.ai.openai_auth import (
+                get_access_token as _get_access_token,
+                get_api_key as _get_direct_key,
+                get_api_key_provider as _get_provider,
+            )
+        except ImportError:
+            from .openai_auth import (
+                get_access_token as _get_access_token,
+                get_api_key as _get_direct_key,
+                get_api_key_provider as _get_provider,
+            )
 
-                # Swap model if it's an OpenAI-only model and we're using a different provider
-                if _provider in self._PROVIDER_DEFAULT_MODELS and self.model in self._OPENAI_ONLY_MODELS:
-                    self.model = self._PROVIDER_DEFAULT_MODELS[_provider]
+        _direct_key = (_get_direct_key() or "").strip()
+        _provider = _get_provider().strip().lower() if _direct_key else ""
 
-                try:
-                    from openai import OpenAI
-                except ImportError as exc:
-                    raise RuntimeError("openai dependency missing") from exc
-                self._client = OpenAI(api_key=_direct_key, base_url=_base_url)
-                return self._client
-        except Exception:
-            pass
-
-        api_key = os.environ.get(self.api_key_env, "").strip()
+        api_key = _direct_key
+        if not api_key:
+            api_key = os.environ.get(self.api_key_env, "").strip()
 
         if not api_key:
-            oauth_token = ""
-            _get_access_token = None
-
             try:
-                from python.ai.openai_auth import get_access_token as _get_access_token
-            except ImportError:
-                try:
-                    from .openai_auth import get_access_token as _get_access_token
-                except ImportError:
-                    _get_access_token = None
-
-            if callable(_get_access_token):
-                try:
-                    oauth_token = str(_get_access_token() or "").strip()
-                except Exception:
-                    oauth_token = ""
-
+                oauth_token = str(_get_access_token() or "").strip()
+            except Exception:
+                oauth_token = ""
             if oauth_token:
                 api_key = oauth_token
+                _provider = _provider or "openai"
 
         if not api_key:
+            label, env_hint = self._credential_labels(_provider)
             raise RuntimeError(
-                "OpenAI credentials are missing. Set {0} env var or sign in via the PARSE UI".format(
-                    self.api_key_env
+                "{0} credentials are missing. Set {1} env var or sign in via the PARSE UI".format(
+                    label, env_hint,
                 )
             )
+
+        if _provider in self._PROVIDER_DEFAULT_MODELS and self.model in self._OPENAI_ONLY_MODELS:
+            self.model = self._PROVIDER_DEFAULT_MODELS[_provider]
+
+        _base_url = (
+            self.base_url
+            or self.chat_config.get("base_url")
+            or self._PROVIDER_BASE_URLS.get(_provider)
+            or ""
+        )
 
         try:
             from openai import OpenAI
         except ImportError as exc:
-            raise RuntimeError("openai dependency missing") from exc
+            raise RuntimeError("openai dependency missing — run: pip install openai") from exc
 
-        client_kwargs: Dict[str, Any] = {
-            "api_key": api_key,
-        }
-        if self.base_url:
-            client_kwargs["base_url"] = self.base_url
+        client_kwargs: Dict[str, Any] = {"api_key": api_key}
+        if _base_url:
+            client_kwargs["base_url"] = _base_url
 
         self._client = OpenAI(**client_kwargs)
         return self._client
+
+    @classmethod
+    def _credential_labels(cls, provider: str) -> tuple:
+        """Return (display_label, env_var_hint) for a provider."""
+        if provider in cls._PROVIDER_BASE_URLS:
+            return ("xAI", "XAI_API_KEY")
+        return ("OpenAI", "OPENAI_API_KEY")
 
     def _call_with_token_fallback(self, client: Any, payload: Dict[str, Any]) -> Tuple[Any, str]:
         """Call chat.completions.create while handling token-parameter differences."""


### PR DESCRIPTION
## Summary

After PRs #48 and #51 landed, users with a saved xAI key still hit:
> `OpenAI credentials are missing. Set OPENAI_API_KEY env var or sign in via the PARSE UI.`

The message is wrong (user is on xAI, not OpenAI) and misleading (key *is* stored).

## Root cause

`OpenAIChatRuntime._load_client()` in `python/ai/provider.py` wrapped the direct-key branch in:

```python
try:
    ...
    self._client = OpenAI(api_key=_direct_key, base_url=_base_url)
    return self._client
except Exception:
    pass   # swallows RuntimeError("openai dependency missing") and anything else
```

Any failure in the direct-key flow (missing `openai` pip package, constructor error, etc.) was silently dropped. Control fell through to the env-var / OAuth path, which then raised the hardcoded `"OpenAI credentials are missing…"` message — regardless of which provider was actually configured.

## Fix

One file, 44+/49-.

- Remove the outer `try/except Exception: pass` and flatten credential resolution: **direct key → env var → OAuth**.
- Label the missing-creds error from the stored provider: `xAI` + `XAI_API_KEY` when provider is `xai`/`grok`/`x.ai`, otherwise `OpenAI` + `OPENAI_API_KEY` (via new `_credential_labels` classmethod).
- Move base_url resolution + model-swap below the credential check so they run once for any path.
- Let `RuntimeError("openai dependency missing — run: pip install openai")` surface directly instead of being masked.

## Verification

Reproduced the original bug (xAI key in `config/auth_tokens.json`, `openai` pip package uninstalled → bogus `"OpenAI credentials are missing"`). After the fix:

| Scenario | Result |
|---|---|
| xAI key stored, `openai` installed | client routed to `https://api.x.ai/v1`, model auto-swapped to `grok-3-mini` |
| xAI key stored, `openai` missing | clear `"openai dependency missing — run: pip install openai"` |
| No key / no env / no OAuth | `"OpenAI credentials are missing…"` (correct — no provider hint exists) |

- `python3.12 -m py_compile python/ai/provider.py` — clean
- `npx tsc --noEmit` — clean
- `npm test -- --run` — 135/135 pass (same floor as #51)

## Test plan

- [ ] Save an xAI API key via the UI → chat message routes to Grok and returns a reply
- [ ] Clear `config/auth_tokens.json`, unset `OPENAI_API_KEY` → chat returns `"OpenAI credentials are missing…"` (accurate for an empty-state user)
- [ ] Save an xAI key on a machine with `openai` uninstalled → chat returns `"openai dependency missing"` instead of the credentials message

🤖 Generated with [Claude Code](https://claude.com/claude-code)