### PR TITLE
docs: remove stale claims and drop Phase-N language from live docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Repository: [ArdeleanLucas/PARSE](https://github.com/ArdeleanLucas/PARSE)
 
 PARSE is a browser-based research tool for linguists working with long field recordings, concept-based wordlists, and multi-speaker datasets. It combines audio navigation, annotation, and comparative analysis in one workspace, so researchers can move from raw recordings to analysis-ready linguistic data without switching between disconnected tools.
 
-Phase 5 of the project introduces a dual-mode architecture: **Annotate** for per-speaker segmentation and transcription, and **Compare** for cross-speaker cognate review and borrowing adjudication. Both modes are hosted in a **unified React shell** (`ParseUI.tsx`) alongside the tag system and AI chat dock, with precise time-aligned annotations and a shared tag system across workflows.
+PARSE has a dual-mode architecture: **Annotate** for per-speaker segmentation and transcription, and **Compare** for cross-speaker cognate review and borrowing adjudication. Both modes are hosted in a **unified React shell** (`ParseUI.tsx`) alongside the tag system and AI chat dock, with precise time-aligned annotations and a shared tag system across workflows.
 
 The active frontend architecture is **React + Vite** (`index.html` + `src/`), with the preferred development routes at `http://localhost:5173/` (Annotate) and `http://localhost:5173/compare` (Compare). The legacy HTML entrypoints, old review page, and root vanilla-JS tree have been removed. For non-dev/local-server usage, run `npm run build` and the Python backend will serve the built frontend from `http://localhost:8766/` and `http://localhost:8766/compare`. LingPy export verification and full browser regression remain on a deferred to-test list until onboarding/import and end-to-end testing are ready.
 
@@ -46,7 +46,7 @@ Cross-speaker analysis workspace for cognates and phylogenetic data preparation.
 
 CLEF provides contact-language similarity data for borrowing adjudication in Compare mode. It fetches lexical data from multiple third-party and local sources via a **provider registry** (`python/compare/providers/`), then surfaces similarity signals in the `ContactLexemePanel` UI component.
 
-**Providers (11):**
+**Providers (10):**
 
 | Provider | Source type |
 |---|---|
@@ -75,13 +75,13 @@ CLEF provides contact-language similarity data for borrowing adjudication in Com
 
 ## AI Provider System
 
-PARSE (Phase 5) supports multiple AI backends, routed per task type:
+PARSE supports multiple AI backends, routed per task type:
 
 | Task | Supported providers |
 |---|---|
 | STT (speech-to-text) | faster-whisper (local, GPU), OpenAI Whisper API |
 | IPA transcription | wav2vec2 (local), epitran (fallback) |
-| LLM / chat | xAI (Grok), OpenAI, Ollama |
+| LLM / chat | xAI (Grok), OpenAI |
 
 Provider selection is feature-specific — STT, IPA, and LLM tasks can each route to a different backend in the same project. Configuration lives in `config/ai_config.json`, which is gitignored because it contains machine-specific paths (e.g. a local Razhan CT2 model path). Copy `config/ai_config.example.json` to `config/ai_config.json` on a fresh clone and edit for your machine. If the file is missing entirely, the backend falls back to built-in defaults with a `[WARN]` on stderr.
 
@@ -124,7 +124,7 @@ The system presents ranked candidates. The annotator verifies, adjusts boundarie
 
 ## AI Workflow Assistant
 
-Both Annotate and Compare modes include a built-in AI chat dock powered by the configured LLM provider (xAI/Grok, OpenAI, or Ollama). This is not a general-purpose chatbot — it is a domain-specific assistant designed to guide users through the entire PARSE workflow from start to finish.
+Both Annotate and Compare modes include a built-in AI chat dock powered by the configured LLM provider (xAI/Grok or OpenAI). This is not a general-purpose chatbot — it is a domain-specific assistant designed to guide users through the entire PARSE workflow from start to finish.
 
 The assistant has full access to project state via the `ParseChatTools` interface (`python/ai/chat_tools.py`) and can:
 
@@ -404,7 +404,7 @@ The enrichments layer stores computed structures while preserving manual adjudic
 - React 18 + TypeScript + Vite (current frontend architecture)
 - Zustand (state management)
 - Tailwind CSS v3 (styling)
-- Python 3.10+ backend serving API routes and the built frontend (`dist/`) for non-dev usage
+- Python 3.10–3.12 backend serving API routes and the built frontend (`dist/`) for non-dev usage (3.13+ is blocked by `cgi.FieldStorage` removal until `python/server.py` migrates off it)
 - WaveSurfer 7
 - faster-whisper + CTranslate2 (local STT)
 - wav2vec2 via HuggingFace transformers (local IPA)


### PR DESCRIPTION
## Summary

Two-part docs cleanup, one PR, docs-only. 6 files, +21/-21.

### Part 1 — stale claims in README.md

| # | Claim | Reality | Fix |
|---|---|---|---|
| 1 | CLEF "Providers (11)" | 10 real providers under `python/compare/providers/` (base.py and registry.py are infrastructure). Table rows already listed 10. | Header → "(10)". |
| 2 | "LLM / chat: xAI (Grok), OpenAI, Ollama" (×2) | Stage 2 resolved the provider question to xAI-or-OpenAI only. `SpeakerImport.tsx` exposes a 2-choice radio; server validates `provider ∈ {"xai","openai"}`. Ollama scaffolding in `provider.py` has no UI selector. | Dropped Ollama from both places. |
| 3 | "Python 3.10+" | `server.py:3` does `import cgi`, which was **removed in Python 3.13**. A fresh Homebrew install ships 3.14 and fails with `ModuleNotFoundError` on first launch. | "Python 3.10–3.12" with a note that the upper bound is `cgi.FieldStorage` until server.py migrates off it. |

### Part 2 — drop all "Phase N" / "Phase" language

Per Lucas: _"Phase 5 is not useful. Remove all concepts of 'phase'. It's unnecessary. This is a build towards a working beta."_

Cleared every live "Phase" reference outside `docs/archive/`:

- **AGENTS.md** — "Phase C1–C4 complete" → "Cross-mode integration complete"; "new phase completion" → "new milestone completion".
- **docs/desktop_product_architecture.md** — §8.1 "Target strategy by phase" → "by milestone"; §10 "Phase policy" → "Milestone policy"; §19 "Phase 0/1/2/3" section headers dropped (kept the descriptive titles and the 1–12 numbered task sequence).
- **docs/plans/react-vite-pivot.md** — "shared contract in Phase 0 ... integrated in Phase C" → "shared contract up front ... integrated after each track passed its own gates".
- **docs/plans/repo-state-cleanup-and-architecture-unification.md** — renamed "Phase 5" to "legacy-removal slice" throughout; rephrased the intro so prep / post-merge steps are described, not numbered.
- **reviews/generate_source_index_review.md** — two "Phase 0 invariants" references → "normalized-audio pipeline invariants".

Post-grep verification: `grep -rEi '\bphase\s*[0-9]|\bphase-[0-9a-z]|\bphase:|\bphase\b' --include='*.md' --include='*.py' --include='*.ts' --include='*.tsx' --include='*.json' . | grep -v docs/archive` → **0 hits**.

Archive docs (`docs/archive/`) intentionally keep historical Phase language since they're frozen planning records.

## Test plan

- [ ] Confirm dropping Ollama from the README is the intent. If Ollama is a genuine future direction, I can add a "(no UI selector yet)" qualifier instead of removing the mention.
- [ ] Confirm the Python-version wording ("3.10–3.12 ... blocked by `cgi.FieldStorage` removal") is how you'd phrase it.
- [ ] Confirm the numbered-task-sequence in `desktop_product_architecture.md` §19 still reads well without the four "Phase" subheadings, or ask me to re-add grouping headers with different labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)