### PR TITLE
docs: drop all "Phase N" / "Phase" language from live docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
   - Wired: `useWaveSurfer`, `useChatSession`, `useConfigStore`, `useTagStore`, `usePlaybackStore`, `useUIStore`, `useAnnotationSync`
   - Spectrogram Worker TS port + `useSpectrogram` hook (MC-297, PR #31)
   - Annotate prefill/save/mark/badge, compare real data, import modal, notes, compute basics, decisions basics, tags bulk-selection — all landed
-- **Phase C1–C4 complete** on integration branch:
+- **Cross-mode integration complete** on integration branch:
   - Track merge (`feat/annotate-react` + `feat/compare-react`)
   - Cross-mode navigation (Annotate ↔ Compare)
   - Store persistence regression coverage
@@ -160,4 +160,4 @@ Expected floor: **>=132 passing tests** and clean TypeScript compile.
 
 ---
 
-If pivot status changes (new phase completion, gating updates, ownership shifts), update this file immediately to prevent stale coordination instructions.
+If pivot status changes (new milestone completion, gating updates, ownership shifts), update this file immediately to prevent stale coordination instructions.

--- a/docs/desktop_product_architecture.md
+++ b/docs/desktop_product_architecture.md
@@ -219,7 +219,7 @@ Use Electron `app.getPath('userData')` as root.
 
 ## 8) Python runtime strategy
 
-## 8.1 Target strategy by phase
+## 8.1 Target strategy by milestone
 
 ### Alpha (internal)
 - Allow system Python for speed of iteration.
@@ -286,7 +286,7 @@ Use Electron `app.getPath('userData')` as root.
 - Runtime capability detection should happen at startup and on demand.
 - If GPU init fails, auto-fallback to CPU with clear messaging.
 
-### Phase policy
+### Milestone policy
 
 - **Alpha:** prioritize CPU correctness.
 - **Beta:** Windows CUDA path support with fallback.
@@ -490,7 +490,7 @@ Annotate + Compare are unified in `src/ParseUI.tsx` (React SPA), sharing stores,
 
 ## 19) Concrete recommended next tasks (buildable sequence)
 
-## Phase 0 — Foundation contracts (no disruptive rewrites)
+## Foundation contracts (no disruptive rewrites)
 
 1. **Define desktop bootstrap contract**
    - Add backend startup flags spec (`project_root`, host/port, auth token, user-data root).
@@ -499,19 +499,19 @@ Annotate + Compare are unified in `src/ParseUI.tsx` (React SPA), sharing stores,
 3. **Define compute capability matrix**
    - Explicitly document which `/api/compute/*` routes are implemented vs planned.
 
-## Phase 1 — Desktop shell spike
+## Desktop shell spike
 
 4. Create `desktop/` shell prototype with Electron main + preload.
 5. Spawn existing backend and load Compare mode in desktop window.
 6. Add startup health check, backend logs, and graceful shutdown.
 
-## Phase 2 — Packaging viability
+## Packaging viability
 
 7. Introduce Python dependency manifest/lock strategy and CI smoke install for Windows/macOS.
 8. Vendor frontend third-party JS needed for offline packaged builds (remove mandatory CDN dependency).
 9. Harden default backend bind/CORS/token behavior for desktop runtime.
 
-## Phase 3 — Product-level polish
+## Product-level polish
 
 10. Implement settings UI for storage/model/performance/update controls.
 11. Implement updater channels (`alpha` first).

--- a/docs/plans/react-vite-pivot.md
+++ b/docs/plans/react-vite-pivot.md
@@ -13,7 +13,7 @@
 ## Background (historical, for context)
 
 - **Original scope:** replace the vanilla-JS monolith (36,951 lines across `parse.html`, `compare.html`, and 25 JS modules) with React + Vite, keeping the Python backend (`127.0.0.1:8766`) unchanged.
-- **Execution:** dual-agent — ParseBuilder (Track A, Annotate) and Oda (Track B, Compare). Tracks agreed a shared contract in Phase 0, worked in parallel, and integrated in Phase C.
+- **Execution:** dual-agent — ParseBuilder (Track A, Annotate) and Oda (Track B, Compare). Tracks agreed a shared contract up front, worked in parallel, and integrated after each track passed its own gates.
 - **Constraint:** no emoji in the UI; annotation timestamps are immutable.
 - **Result:** React SPA in `src/ParseUI.tsx` is the sole runtime frontend. Stage 3 / PR #58 removed the remaining vanilla-JS runtime (`js/`, `parse.html`, `compare.html`, `review_tool_dev.html`, legacy launchers).
 

--- a/docs/plans/repo-state-cleanup-and-architecture-unification.md
+++ b/docs/plans/repo-state-cleanup-and-architecture-unification.md
@@ -4,11 +4,11 @@
 
 **Goal:** Finish the React cutover by deleting the vanilla-JS legacy surface and making the Python server serve the React build — in a scoped, reversible PR that can only run once Lucas authorizes destructive cleanup.
 
-Phases 0–4 (preflight, canonicalization, non-destructive messaging, deferred-validation maintenance) and Phase 6 (post-merge branch pruning) are no longer active execution work; see the Stage 1 archive under `docs/archive/` for their history. This doc is now the Phase 5 slice only.
+Earlier prep steps (preflight, canonicalization, non-destructive messaging, deferred-validation maintenance) and later post-merge branch pruning are no longer active execution work; see the Stage 1 archive under `docs/archive/` for their history. This doc is now the legacy-removal slice only.
 
 ---
 
-## Phase 5 — Legacy removal and Python-served React build ✅ complete on PR #58
+## Legacy removal and Python-served React build ✅ complete on PR #58
 
 ### Objective
 
@@ -16,7 +16,7 @@ Make PARSE expose only the React SPA at runtime and remove every vanilla-JS entr
 
 ### Gating note
 
-This slice was formerly labeled "C7". Per `AGENTS.md` § Deferred Validation Backlog, C5 (LingPy TSV export verification) and C6 (full Annotate/Compare browser regression) are **not hard gates** for this PR. They stay on the deferred-validation list and are run once onboarding/import testing is usable enough for them to be meaningful. Phase 5 still requires a scoped PR, rollback notes, and Lucas-review-before-merge.
+This slice was formerly labeled "C7". Per `AGENTS.md` § Deferred Validation Backlog, C5 (LingPy TSV export verification) and C6 (full Annotate/Compare browser regression) are **not hard gates** for this PR. They stay on the deferred-validation list and are run once onboarding/import testing is usable enough for them to be meaningful. The slice still requires a scoped PR, rollback notes, and Lucas-review-before-merge.
 
 ---
 
@@ -82,7 +82,7 @@ This slice was formerly labeled "C7". Per `AGENTS.md` § Deferred Validation Bac
 
 ---
 
-## Exit criteria (Phase 5 overall)
+## Exit criteria (overall)
 
 - [x] `rg -l 'parse\.html\|compare\.html\|review_tool_dev\.html\|^js/' -- . ':!docs/archive'` returns no hits.
 - [x] `npm run build && python/server.py` serves the React SPA on `127.0.0.1:8766` with `/api/*` still returning JSON.

--- a/reviews/generate_source_index_review.md
+++ b/reviews/generate_source_index_review.md
@@ -66,7 +66,7 @@ This is especially important because the project plan explicitly says unsupporte
 - positive integers for `file_size_bytes`, `sample_rate`, `channels`, `bit_depth`
 - boolean type for `has_csv`
 - optional string-only `notes`
-- project-specific constraints such as `bit_depth == 16` and `channels in {1, 2}` if this script is meant to enforce Phase 0 output
+- project-specific constraints such as `bit_depth == 16` and `channels in {1, 2}` if this script is meant to enforce the normalized-audio pipeline invariants
 
 ---
 
@@ -137,7 +137,7 @@ I did not find obvious companion tests for this script under `parse/`. At minimu
 5. **Audio metadata validation**
    - negative/zero duration
    - non-integer `channels`, `sample_rate`, `bit_depth`
-   - unsupported `bit_depth` / channel counts if Phase 0 invariants are enforced here
+   - unsupported `bit_depth` / channel counts if normalized-audio invariants are enforced here
 
 6. **Path normalization**
    - Windows backslash paths normalized or rejected


### PR DESCRIPTION
## Summary

Per Lucas: _\"Phase 5 is not useful. Remove all concepts of 'phase'. It's unnecessary. This is a build towards a working beta.\"_

Cleared every live \"Phase\" reference outside \`docs/archive/\`. Docs-only, 5 files, +15/-15.

Follow-up to #60 — PR #60 fixed stale README claims and dropped Phase labels in README specifically; this PR finishes the removal across the rest of the live docs.

## Changes

- **\`AGENTS.md\`** — \"Phase C1–C4 complete\" → \"Cross-mode integration complete\"; \"new phase completion\" → \"new milestone completion\".
- **\`docs/desktop_product_architecture.md\`** — §8.1 \"Target strategy by phase\" → \"by milestone\"; §10 \"Phase policy\" → \"Milestone policy\"; §19 \"Phase 0 / Phase 1 / Phase 2 / Phase 3\" subheaders dropped (kept the descriptive titles — \"Foundation contracts\", \"Desktop shell spike\", \"Packaging viability\", \"Product-level polish\" — and the existing 1–12 numbered task sequence so the buildable plan is still readable).
- **\`docs/plans/react-vite-pivot.md\`** — historical paragraph: \"shared contract in Phase 0 ... integrated in Phase C\" → \"shared contract up front ... integrated after each track passed its own gates\".
- **\`docs/plans/repo-state-cleanup-and-architecture-unification.md\`** — renamed \"Phase 5\" to \"legacy-removal slice\" throughout; intro paragraph now describes prep/post-merge steps without numbering them.
- **\`reviews/generate_source_index_review.md\`** — two \"Phase 0 invariants\" references → \"normalized-audio pipeline invariants\" (more descriptive and doesn't invoke a retired phase scheme).

## Verification

\`\`\`
grep -rEi '\bphase\s*[0-9]|\bphase-[0-9a-z]|\bphase:|\bphase\b' --include='*.md' --include='*.py' --include='*.ts' --include='*.tsx' --include='*.json' . | grep -v docs/archive
→ 0 hits
\`\`\`

Archive docs under \`docs/archive/\` intentionally keep historical \"Phase\" language since they're frozen planning records.

## Test plan

- [ ] Confirm \`desktop_product_architecture.md\` §19's numbered task sequence still reads well without the four \"Phase\" subheadings, or ask me to re-add grouping headers with different labels.
- [ ] Confirm no other label/vocabulary you want swept out at the same time (e.g. \"C5/C6/C7\" — deliberately left alone for now since it's tied to the still-active deferred-validation language in \`AGENTS.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)