### PR TITLE
fix: stabilize xAI chat session wiring

### DIFF
--- a/config/ai_config.example.json
+++ b/config/ai_config.example.json
@@ -14,7 +14,7 @@
   },
   "llm": {
     "provider": "openai",
-    "model": "gpt-4o",
+    "model": "gpt-5.4",
     "api_key_env": "OPENAI_API_KEY"
   },
   "chat": {
@@ -22,7 +22,7 @@
     "read_only": false,
     "attachments_supported": false,
     "provider": "openai",
-    "model": "gpt-4o",
+    "model": "gpt-5.4",
     "api_key_env": "OPENAI_API_KEY",
     "reasoning_effort": "",
     "temperature": 0.1,

--- a/docs/plans/MC-314-pr62-gpt54-normalization.md
+++ b/docs/plans/MC-314-pr62-gpt54-normalization.md
@@ -1,0 +1,32 @@
+# MC-314 — PR #62 GPT 5.4 normalization hardening
+
+## Objective
+Finish the final pre-merge pass for PR #62 by eliminating remaining legacy `gpt54` placeholder paths and making the canonical OpenAI default model `gpt-5.4` across active PARSE chat/provider configuration surfaces.
+
+## Scope
+1. Inspect the current PR branch and targeted failing tests.
+2. Normalize legacy `gpt54` placeholders to `gpt-5.4` in the backend config/runtime path without regressing xAI provider remapping.
+3. Update active example config defaults if they still advertise stale OpenAI defaults.
+4. Re-run targeted Python tests plus full PARSE frontend gates.
+5. Confirm PR #62 state and record merge-readiness evidence.
+
+## Files
+- `python/ai/provider.py`
+- `python/server.py`
+- `python/test_server_chat_policy.py`
+- `config/ai_config.example.json`
+- PR #62 metadata if visible behavior changes
+
+## Constraints
+- Use the canonical repo: `/home/lucas/gh/ardeleanlucas/parse`
+- Keep the fix minimal and targeted.
+- Preserve explicit OpenAI model selections such as `o3`.
+- Preserve xAI direct-key override behavior and xAI default model routing.
+- Do not touch C7 cleanup or protected Compare surfaces.
+
+## Completion criteria
+- `pytest python/test_server_chat_policy.py -q` passes.
+- `npm run test -- --run` passes.
+- `./node_modules/.bin/tsc --noEmit` passes.
+- No active OpenAI default/model placeholders remain as `gpt54` in runtime config paths for this PR scope.
+- PR #62 has a clean follow-up commit (if code changed) and a precise merge-readiness summary.

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -72,9 +72,9 @@ _CHAT_PROVIDER_BASE_URLS: Dict[str, str] = {
 }
 
 _CHAT_PROVIDER_DEFAULT_MODELS: Dict[str, str] = {
-    "xai": "grok-3-mini",
-    "grok": "grok-3-mini",
-    "x.ai": "grok-3-mini",
+    "xai": "grok-4.20-0309-reasoning",
+    "grok": "grok-4.20-0309-reasoning",
+    "x.ai": "grok-4.20-0309-reasoning",
     "openai": "gpt-4o",
 }
 

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -65,6 +65,33 @@ _DEFAULT_AI_CONFIG: Dict[str, Any] = {
     "specialized_layers": [],
 }
 
+_CHAT_PROVIDER_BASE_URLS: Dict[str, str] = {
+    "xai": "https://api.x.ai/v1",
+    "grok": "https://api.x.ai/v1",
+    "x.ai": "https://api.x.ai/v1",
+}
+
+_CHAT_PROVIDER_DEFAULT_MODELS: Dict[str, str] = {
+    "xai": "grok-3-mini",
+    "grok": "grok-3-mini",
+    "x.ai": "grok-3-mini",
+    "openai": "gpt-4o",
+}
+
+_CHAT_OPENAI_ONLY_MODELS = {
+    "gpt54",
+    "gpt-4o",
+    "gpt-4",
+    "gpt-3.5-turbo",
+    "o1",
+    "o1-mini",
+    "o1-preview",
+    "o3",
+    "o3-mini",
+}
+
+_CHAT_SUPPORTED_PROVIDERS = {"openai", "xai", "grok", "x.ai"}
+
 
 def _deep_merge_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
     """Recursively merge dictionaries without mutating inputs."""
@@ -213,9 +240,22 @@ def _build_chat_config(merged_config: Dict[str, Any]) -> Dict[str, Any]:
 
     resolved = _deep_merge_dicts(defaults, chat_config)
 
+    stored_provider = ""
+    try:
+        try:
+            from python.ai.openai_auth import get_api_key as _get_direct_key, get_api_key_provider as _get_provider
+        except ImportError:
+            from .openai_auth import get_api_key as _get_direct_key, get_api_key_provider as _get_provider
+
+        if (_get_direct_key() or "").strip():
+            stored_provider = str(_get_provider() or "").strip().lower()
+    except Exception:
+        stored_provider = ""
+
     provider_name = str(resolved.get("provider") or "openai").strip().lower()
-    _SUPPORTED_CHAT_PROVIDERS = {"openai", "xai", "grok", "x.ai"}
-    if provider_name not in _SUPPORTED_CHAT_PROVIDERS:
+    if stored_provider in _CHAT_SUPPORTED_PROVIDERS:
+        provider_name = stored_provider
+    if provider_name not in _CHAT_SUPPORTED_PROVIDERS:
         print(
             "[WARN] chat.provider={0!r} is unsupported; forcing 'openai'".format(provider_name),
             file=sys.stderr,
@@ -224,10 +264,19 @@ def _build_chat_config(merged_config: Dict[str, Any]) -> Dict[str, Any]:
     resolved["provider"] = provider_name
 
     model_name = str(resolved.get("model") or "").strip()
-    resolved["model"] = model_name or "gpt54"
+    if provider_name in _CHAT_PROVIDER_BASE_URLS and model_name in _CHAT_OPENAI_ONLY_MODELS:
+        model_name = _CHAT_PROVIDER_DEFAULT_MODELS[provider_name]
+    resolved["model"] = model_name or _CHAT_PROVIDER_DEFAULT_MODELS.get(provider_name, "gpt54")
 
     api_key_env = str(resolved.get("api_key_env") or "").strip()
+    if provider_name in _CHAT_PROVIDER_BASE_URLS and (not api_key_env or api_key_env == "OPENAI_API_KEY"):
+        api_key_env = "XAI_API_KEY"
     resolved["api_key_env"] = api_key_env or "OPENAI_API_KEY"
+
+    base_url = str(resolved.get("base_url") or "").strip()
+    if not base_url and provider_name in _CHAT_PROVIDER_BASE_URLS:
+        base_url = _CHAT_PROVIDER_BASE_URLS[provider_name]
+    resolved["base_url"] = base_url
 
     reasoning_effort = str(resolved.get("reasoning_effort") or "").strip().lower()
     if reasoning_effort not in {"minimal", "low", "medium", "high"}:
@@ -288,22 +337,13 @@ class OpenAIChatRuntime:
     """Thin OpenAI chat runtime wrapper with tool-call support and reasoning fallback."""
 
     # Provider-specific base URLs for the OpenAI-compatible API
-    _PROVIDER_BASE_URLS: Dict[str, str] = {
-        "xai": "https://api.x.ai/v1",
-        "grok": "https://api.x.ai/v1",
-        "x.ai": "https://api.x.ai/v1",
-    }
+    _PROVIDER_BASE_URLS: Dict[str, str] = dict(_CHAT_PROVIDER_BASE_URLS)
 
     # Default models per provider (used when config still has a placeholder/OpenAI model)
-    _PROVIDER_DEFAULT_MODELS: Dict[str, str] = {
-        "xai": "grok-3-mini",
-        "grok": "grok-3-mini",
-        "x.ai": "grok-3-mini",
-        "openai": "gpt-4o",
-    }
+    _PROVIDER_DEFAULT_MODELS: Dict[str, str] = dict(_CHAT_PROVIDER_DEFAULT_MODELS)
 
     # Model names that are clearly OpenAI-only and should be swapped for xAI
-    _OPENAI_ONLY_MODELS = {"gpt54", "gpt-4o", "gpt-4", "gpt-3.5-turbo", "o1", "o1-mini", "o1-preview", "o3", "o3-mini"}
+    _OPENAI_ONLY_MODELS = set(_CHAT_OPENAI_ONLY_MODELS)
 
     def __init__(
         self,

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -43,7 +43,7 @@ _DEFAULT_AI_CONFIG: Dict[str, Any] = {
     },
     "llm": {
         "provider": "openai",
-        "model": "gpt-4o",
+        "model": "gpt-5.4",
         "api_key_env": "OPENAI_API_KEY",
     },
     "chat": {
@@ -51,7 +51,7 @@ _DEFAULT_AI_CONFIG: Dict[str, Any] = {
         "read_only": True,
         "attachments_supported": False,
         "provider": "openai",
-        "model": "gpt54",
+        "model": "gpt-5.4",
         "api_key_env": "OPENAI_API_KEY",
         "reasoning_effort": "high",
         "temperature": 0.1,
@@ -75,12 +75,17 @@ _CHAT_PROVIDER_DEFAULT_MODELS: Dict[str, str] = {
     "xai": "grok-4.20-0309-reasoning",
     "grok": "grok-4.20-0309-reasoning",
     "x.ai": "grok-4.20-0309-reasoning",
-    "openai": "gpt-4o",
+    "openai": "gpt-5.4",
+}
+
+_LEGACY_OPENAI_MODEL_NAMES = {
+    "gpt54": "gpt-5.4",
 }
 
 _CHAT_OPENAI_ONLY_MODELS = {
     "gpt54",
     "gpt-4o",
+    "gpt-5.4",
     "gpt-4",
     "gpt-3.5-turbo",
     "o1",
@@ -122,6 +127,14 @@ def _coerce_bool(value: Any, default: bool) -> bool:
             return False
 
     return bool(default)
+
+
+def _normalize_openai_model_name(model_name: Any, default: str = "gpt-5.4") -> str:
+    """Rewrite legacy OpenAI placeholder model names to the canonical default."""
+    normalized = str(model_name or "").strip()
+    if not normalized:
+        return default
+    return _LEGACY_OPENAI_MODEL_NAMES.get(normalized, normalized)
 
 
 def _coerce_int(
@@ -225,7 +238,7 @@ def _build_chat_config(merged_config: Dict[str, Any]) -> Dict[str, Any]:
         "read_only": True,
         "attachments_supported": False,
         "provider": "openai",
-        "model": str(chat_config.get("model") or llm_config.get("model") or "gpt54").strip() or "gpt54",
+        "model": str(chat_config.get("model") or llm_config.get("model") or "gpt-5.4").strip() or "gpt-5.4",
         "api_key_env": str(chat_config.get("api_key_env") or llm_config.get("api_key_env") or "OPENAI_API_KEY").strip()
         or "OPENAI_API_KEY",
         "reasoning_effort": str(chat_config.get("reasoning_effort") or "high").strip() or "high",
@@ -263,10 +276,10 @@ def _build_chat_config(merged_config: Dict[str, Any]) -> Dict[str, Any]:
         provider_name = "openai"
     resolved["provider"] = provider_name
 
-    model_name = str(resolved.get("model") or "").strip()
+    model_name = _normalize_openai_model_name(resolved.get("model"), default="")
     if provider_name in _CHAT_PROVIDER_BASE_URLS and model_name in _CHAT_OPENAI_ONLY_MODELS:
         model_name = _CHAT_PROVIDER_DEFAULT_MODELS[provider_name]
-    resolved["model"] = model_name or _CHAT_PROVIDER_DEFAULT_MODELS.get(provider_name, "gpt54")
+    resolved["model"] = model_name or _CHAT_PROVIDER_DEFAULT_MODELS.get(provider_name, "gpt-5.4")
 
     api_key_env = str(resolved.get("api_key_env") or "").strip()
     if provider_name in _CHAT_PROVIDER_BASE_URLS and (not api_key_env or api_key_env == "OPENAI_API_KEY"):
@@ -355,7 +368,7 @@ class OpenAIChatRuntime:
         merged_config = _deep_merge_dicts(file_config, config or {})
 
         self.chat_config = _build_chat_config(merged_config)
-        self.model = str(self.chat_config.get("model") or "gpt54").strip() or "gpt54"
+        self.model = str(self.chat_config.get("model") or "gpt-5.4").strip() or "gpt-5.4"
         self.api_key_env = str(self.chat_config.get("api_key_env") or "OPENAI_API_KEY").strip() or "OPENAI_API_KEY"
         self.reasoning_effort = str(self.chat_config.get("reasoning_effort") or "high").strip() or "high"
 
@@ -976,7 +989,7 @@ class OpenAIProvider(AIProvider):
 
         self.stt_model = str(stt_config.get("model", "whisper-1")).strip() or "whisper-1"
         self.language = str(stt_config.get("language", "")).strip() or None
-        self.llm_model = str(llm_config.get("model", "gpt-4o")).strip() or "gpt-4o"
+        self.llm_model = _normalize_openai_model_name(llm_config.get("model"), default="gpt-5.4")
         self.api_key_env = (
             str(llm_config.get("api_key_env", "OPENAI_API_KEY")).strip()
             or "OPENAI_API_KEY"
@@ -1144,8 +1157,8 @@ class XAIProvider(OpenAIProvider):
         self.api_key_env = configured_api_key_env
 
         configured_llm_model = str(llm_config.get("model", "")).strip()
-        if not configured_llm_model or configured_llm_model == "gpt-4o":
-            configured_llm_model = "grok-4-0201"
+        if not configured_llm_model or configured_llm_model in {"gpt54", "gpt-4o", "gpt-5.4"}:
+            configured_llm_model = "grok-4.20-0309-reasoning"
         self.llm_model = configured_llm_model
 
         self.stt_model = (

--- a/python/server.py
+++ b/python/server.py
@@ -399,7 +399,7 @@ def _chat_runtime_policy(config: Optional[Dict[str, Any]] = None) -> Dict[str, A
         "attachmentsSupported": False,
         "readOnlyNotice": READ_ONLY_NOTICE,
         "provider": str(chat_config.get("provider") or "openai").strip() or "openai",
-        "model": str(chat_config.get("model") or "gpt54").strip() or "gpt54",
+        "model": str(chat_config.get("model") or "gpt-5.4").strip() or "gpt-5.4",
         "apiKeyEnv": str(chat_config.get("api_key_env") or "OPENAI_API_KEY").strip() or "OPENAI_API_KEY",
         "reasoningEffort": str(chat_config.get("reasoning_effort") or "high").strip() or "high",
         "temperature": _coerce_float_range(chat_config.get("temperature"), 0.1, 0.0, 2.0),

--- a/python/test_server_chat_policy.py
+++ b/python/test_server_chat_policy.py
@@ -1,0 +1,35 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+import ai.openai_auth as openai_auth
+import ai.provider as provider_module
+
+
+def test_chat_runtime_policy_uses_saved_xai_provider_defaults(monkeypatch) -> None:
+    stub_config = {"chat": {"provider": "openai", "model": "gpt54"}}
+    monkeypatch.setattr(server, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(openai_auth, "get_api_key", lambda: "xai-test-key")
+    monkeypatch.setattr(openai_auth, "get_api_key_provider", lambda: "xai")
+
+    policy = server._chat_runtime_policy()
+
+    assert policy["provider"] == "xai"
+    assert policy["model"] == "grok-3-mini"
+    assert policy["apiKeyEnv"] == "XAI_API_KEY"
+
+
+def test_chat_runtime_policy_preserves_explicit_openai_model(monkeypatch) -> None:
+    stub_config = {"chat": {"provider": "openai", "model": "o3"}}
+    monkeypatch.setattr(server, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(openai_auth, "get_api_key", lambda: None)
+    monkeypatch.setattr(openai_auth, "get_api_key_provider", lambda: "openai")
+
+    policy = server._chat_runtime_policy()
+
+    assert policy["provider"] == "openai"
+    assert policy["model"] == "o3"
+    assert policy["apiKeyEnv"] == "OPENAI_API_KEY"

--- a/python/test_server_chat_policy.py
+++ b/python/test_server_chat_policy.py
@@ -8,7 +8,7 @@ import ai.provider as provider_module
 
 
 def test_chat_runtime_policy_uses_saved_xai_provider_defaults(monkeypatch) -> None:
-    stub_config = {"chat": {"provider": "openai", "model": "gpt54"}}
+    stub_config = {"chat": {"provider": "openai", "model": "gpt-5.4"}}
     monkeypatch.setattr(server, "load_ai_config", lambda config_path=None: stub_config)
     monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
     monkeypatch.setattr(openai_auth, "get_api_key", lambda: "xai-test-key")
@@ -19,6 +19,20 @@ def test_chat_runtime_policy_uses_saved_xai_provider_defaults(monkeypatch) -> No
     assert policy["provider"] == "xai"
     assert policy["model"] == "grok-4.20-0309-reasoning"
     assert policy["apiKeyEnv"] == "XAI_API_KEY"
+
+
+def test_chat_runtime_policy_defaults_openai_to_gpt_5_4(monkeypatch) -> None:
+    stub_config = {"chat": {"provider": "openai"}}
+    monkeypatch.setattr(server, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(openai_auth, "get_api_key", lambda: None)
+    monkeypatch.setattr(openai_auth, "get_api_key_provider", lambda: "openai")
+
+    policy = server._chat_runtime_policy()
+
+    assert policy["provider"] == "openai"
+    assert policy["model"] == "gpt-5.4"
+    assert policy["apiKeyEnv"] == "OPENAI_API_KEY"
 
 
 def test_chat_runtime_policy_preserves_explicit_openai_model(monkeypatch) -> None:
@@ -33,3 +47,52 @@ def test_chat_runtime_policy_preserves_explicit_openai_model(monkeypatch) -> Non
     assert policy["provider"] == "openai"
     assert policy["model"] == "o3"
     assert policy["apiKeyEnv"] == "OPENAI_API_KEY"
+
+
+def test_chat_runtime_policy_rewrites_legacy_gpt54_placeholder(monkeypatch) -> None:
+    stub_config = {"chat": {"provider": "openai", "model": "gpt54"}}
+    monkeypatch.setattr(server, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(openai_auth, "get_api_key", lambda: None)
+    monkeypatch.setattr(openai_auth, "get_api_key_provider", lambda: "openai")
+
+    policy = server._chat_runtime_policy()
+
+    assert policy["provider"] == "openai"
+    assert policy["model"] == "gpt-5.4"
+
+
+def test_openai_provider_defaults_to_gpt_5_4(monkeypatch) -> None:
+    stub_config = {"llm": {"provider": "openai"}}
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+
+    provider = provider_module.OpenAIProvider(config={"llm": {"provider": "openai"}})
+
+    assert provider.llm_model == "gpt-5.4"
+
+
+def test_openai_provider_rewrites_legacy_gpt54_placeholder(monkeypatch) -> None:
+    stub_config = {"llm": {"provider": "openai", "model": "gpt54"}}
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+
+    provider = provider_module.OpenAIProvider(config={"llm": {"provider": "openai", "model": "gpt54"}})
+
+    assert provider.llm_model == "gpt-5.4"
+
+
+def test_xai_provider_rewrites_gpt_5_4_placeholder_model(monkeypatch) -> None:
+    stub_config = {"llm": {"provider": "xai", "model": "gpt-5.4"}}
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+
+    provider = provider_module.XAIProvider(config={"llm": {"provider": "xai", "model": "gpt-5.4"}})
+
+    assert provider.llm_model == "grok-4.20-0309-reasoning"
+
+
+def test_xai_provider_rewrites_legacy_gpt54_placeholder_model(monkeypatch) -> None:
+    stub_config = {"llm": {"provider": "xai", "model": "gpt54"}}
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+
+    provider = provider_module.XAIProvider(config={"llm": {"provider": "xai", "model": "gpt54"}})
+
+    assert provider.llm_model == "grok-4.20-0309-reasoning"

--- a/python/test_server_chat_policy.py
+++ b/python/test_server_chat_policy.py
@@ -17,7 +17,7 @@ def test_chat_runtime_policy_uses_saved_xai_provider_defaults(monkeypatch) -> No
     policy = server._chat_runtime_policy()
 
     assert policy["provider"] == "xai"
-    assert policy["model"] == "grok-3-mini"
+    assert policy["model"] == "grok-4.20-0309-reasoning"
     assert policy["apiKeyEnv"] == "XAI_API_KEY"
 
 

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runChat, startChatSession } from "./client";
+
+describe("chat API client contracts", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("startChatSession unwraps the server's camelCase sessionId payload", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ sessionId: "chat_123" }),
+    });
+
+    await expect(startChatSession()).resolves.toMatchObject({ session_id: "chat_123" });
+  });
+
+  it("runChat turns raw fetch failures into actionable PARSE API errors", async () => {
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expect(runChat("chat_123", "hello")).rejects.toThrow(
+      /Could not reach the PARSE API.*8766/i,
+    );
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -55,11 +55,46 @@ function unwrapEnrichments(payload: unknown): EnrichmentsPayload {
   return (payload ?? {}) as EnrichmentsPayload;
 }
 
+function resolveSessionId(payload: unknown): string {
+  if (!isRecord(payload)) {
+    return "";
+  }
+
+  const fromSnake = payload.session_id;
+  if (typeof fromSnake === "string" && fromSnake.trim()) {
+    return fromSnake.trim();
+  }
+
+  const fromCamel = payload.sessionId;
+  if (typeof fromCamel === "string" && fromCamel.trim()) {
+    return fromCamel.trim();
+  }
+
+  return "";
+}
+
+function networkError(path: string, options: RequestInit | undefined, error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error ?? "Unknown fetch error");
+  if (/failed to fetch|networkerror/i.test(message)) {
+    return new Error(
+      `Could not reach the PARSE API for ${options?.method ?? "GET"} ${path}. `
+      + `Check that the Python server is running on http://127.0.0.1:8766 and that the Vite /api proxy is active.`,
+    );
+  }
+  return error instanceof Error ? error : new Error(message);
+}
+
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const response = await fetch(path, {
-    headers: { "Content-Type": "application/json", ...options?.headers },
-    ...options,
-  });
+  let response: Response;
+  try {
+    response = await fetch(path, {
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      ...options,
+    });
+  } catch (error) {
+    throw networkError(path, options, error);
+  }
+
   if (!response.ok) {
     const text = await response.text().catch(() => response.statusText);
     throw new Error(`API ${options?.method ?? "GET"} ${path} failed ${response.status}: ${text}`);
@@ -177,11 +212,16 @@ export async function requestSuggestions(
 }
 
 // Chat
-export async function startChatSession(sessionId?: string): Promise<{ session_id: string }> {
-  return apiFetch<{ session_id: string }>("/api/chat/session", {
+export async function startChatSession(sessionId?: string): Promise<{ session_id: string; sessionId?: string }> {
+  const payload = await apiFetch<unknown>("/api/chat/session", {
     method: "POST",
     body: JSON.stringify({ session_id: sessionId }),
   });
+  const id = resolveSessionId(payload);
+  if (!id) {
+    throw new Error("API POST /api/chat/session returned no sessionId");
+  }
+  return { session_id: id, sessionId: id };
 }
 
 export async function getChatSession(sessionId: string): Promise<unknown> {

--- a/src/hooks/__tests__/useChatSession.test.tsx
+++ b/src/hooks/__tests__/useChatSession.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { startChatSession, runChat, pollChat, syncFromServer } = vi.hoisted(() => ({
+  startChatSession: vi.fn(),
+  runChat: vi.fn(),
+  pollChat: vi.fn(),
+  syncFromServer: vi.fn(),
+}));
+
+vi.mock("../../api/client", () => ({
+  startChatSession,
+  runChat,
+  pollChat,
+}));
+
+vi.mock("../../stores/tagStore", () => ({
+  useTagStore: {
+    getState: () => ({ syncFromServer }),
+  },
+}));
+
+import { useChatSession } from "../useChatSession";
+
+describe("useChatSession", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hydrates a normalized session id returned by the API client", async () => {
+    startChatSession.mockResolvedValue({ session_id: "chat_123" });
+
+    const { result } = renderHook(() => useChatSession());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.sessionId).toBe("chat_123");
+    expect(sessionStorage.getItem("parse-chat-session-id")).toBe("chat_123");
+  });
+
+  it("treats a complete poll status as a successful assistant reply", async () => {
+    startChatSession.mockResolvedValue({ session_id: "chat_123" });
+    runChat.mockResolvedValue({ job_id: "job_123" });
+    pollChat
+      .mockResolvedValueOnce({ status: "complete", result: "assistant reply" })
+      .mockResolvedValueOnce({ status: "error", error: "should not poll twice" });
+
+    const { result } = renderHook(() => useChatSession());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.sessionId).toBe("chat_123");
+
+    await act(async () => {
+      void result.current.send("hello");
+    });
+
+    expect(result.current.messages.map((message) => message.content)).toEqual(["hello"]);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2100);
+      await Promise.resolve();
+    });
+
+    expect(result.current.messages.map((message) => message.content)).toEqual([
+      "hello",
+      "assistant reply",
+    ]);
+    expect(result.current.error).toBeNull();
+    expect(pollChat).toHaveBeenCalledTimes(1);
+    expect(syncFromServer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -90,7 +90,11 @@ export function useChatSession(): UseChatSessionResult {
             polls++
             pollChat(job.job_id)
               .then((status) => {
-                if (status.status === "done" || status.status === "completed") {
+                if (
+                  status.status === "done"
+                  || status.status === "completed"
+                  || status.status === "complete"
+                ) {
                   resolve(status.result ?? "")
                 } else if (status.status === "error") {
                   reject(new Error(status.error ?? status.result ?? "Chat error"))


### PR DESCRIPTION
## Summary
- normalize chat session IDs in the React API client so `/api/chat/session` works with the server's camelCase `sessionId` payload
- convert raw browser `Failed to fetch` failures into actionable PARSE API guidance for the `:8766` backend / Vite proxy path
- accept `status: "complete"` in `useChatSession()` and align public chat policy with saved xAI direct-key defaults (`provider`, `model`, `apiKeyEnv`, `base_url`)
- normalize remaining OpenAI legacy placeholders so the canonical GPT model is `gpt-5.4` across active defaults, runtime policy, and `config/ai_config.example.json`
- add regression coverage for client contract normalization, chat polling completion, OpenAI `gpt54 -> gpt-5.4` normalization, and xAI placeholder remapping without regressing explicit OpenAI model choices

## Test Plan
- `npx vitest run src/api/client.test.ts src/hooks/__tests__/useChatSession.test.tsx`
- `pytest python/test_server_chat_policy.py -q` → 8 passed
- `python3 -m py_compile python/ai/provider.py python/server.py python/test_server_chat_policy.py`
- `npm run test -- --run` → 142 passed
- `./node_modules/.bin/tsc --noEmit`
- Browser smoke test from `http://127.0.0.1:5173/` in browser context:
  - `POST /api/auth/key` with provider `xai`
  - `POST /api/chat/session` returned `provider=xai`, `model=grok-4.20-0309-reasoning`
  - `POST /api/chat/run` returned `provider=xai`, `model=grok-4.20-0309-reasoning`
  - `POST /api/chat/run/status` surfaced the xAI invalid-key API error instead of a generic fetch failure

## Notes
- follow-up commit `fdd9145` updates the xAI default model name to `grok-4.20-0309-reasoning`
- follow-up commit `c3bbdcf` makes `gpt-5.4` the canonical OpenAI default and rewrites legacy `gpt54` placeholders without overwriting explicit OpenAI selections like `o3`
- existing Vitest stderr warnings remain unchanged from baseline (`React Router future flag` warnings and `tagStore localStorage` warnings in `storePersistence.test.ts`)
