### PR TITLE
[MC-315] Fix Grok reasoning-effort incompatibility

### DIFF
--- a/docs/plans/MC-315-grok-reasoning-effort-compat.md
+++ b/docs/plans/MC-315-grok-reasoning-effort-compat.md
@@ -1,0 +1,31 @@
+# MC-315 — Grok reasoning-effort compatibility fix
+
+## Objective
+Fix PARSE AI chat so Grok/xAI requests do not send a `reasoningEffort` / `reasoning_effort` parameter to models that reject it, while preserving OpenAI reasoning-effort behavior where supported.
+
+## Scope
+1. Inspect the current canonical PARSE repo and locate every active chat/runtime path that injects `reasoning_effort`.
+2. Reproduce the incompatibility with a failing regression test before changing production code.
+3. Implement the smallest backend fix that suppresses unsupported reasoning-effort parameters for xAI/Grok chat models.
+4. Re-run targeted Python tests plus full PARSE frontend gates.
+5. Deliver the fix on a fresh post-merge branch, update PR metadata if needed, and log the outcome.
+
+## Files likely in scope
+- `python/ai/provider.py`
+- `python/server.py`
+- `python/test_server_chat_policy.py`
+- `config/ai_config.example.json` only if policy defaults need clarification
+
+## Constraints
+- Canonical repo only: `/home/lucas/gh/ardeleanlucas/parse`
+- PR #62 is already merged; do not push further work to its merged branch
+- Keep the fix minimal and targeted
+- Preserve explicit OpenAI model selections and any supported OpenAI reasoning-effort behavior
+- Preserve xAI provider routing and model normalization already fixed in PR #62
+
+## Completion criteria
+- A regression test fails first for the unsupported Grok/xAI reasoning-effort path
+- Targeted Python regressions pass after the fix
+- `npm run test -- --run` passes
+- `./node_modules/.bin/tsc --noEmit` passes
+- New branch/PR exists if code changes are required

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -382,7 +382,6 @@ class OpenAIChatRuntime:
         merged_config = _deep_merge_dicts(file_config, config or {})
 
         self.chat_config = _build_chat_config(merged_config)
-        self.provider = str(self.chat_config.get("provider") or "openai").strip().lower() or "openai"
         self.model = str(self.chat_config.get("model") or "gpt-5.4").strip() or "gpt-5.4"
         self.api_key_env = str(self.chat_config.get("api_key_env") or "OPENAI_API_KEY").strip() or "OPENAI_API_KEY"
         self.reasoning_effort = str(self.chat_config.get("reasoning_effort") or "").strip().lower()

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -137,6 +137,17 @@ def _normalize_openai_model_name(model_name: Any, default: str = "gpt-5.4") -> s
     return _LEGACY_OPENAI_MODEL_NAMES.get(normalized, normalized)
 
 
+def _chat_supports_reasoning_effort(provider_name: Any, model_name: Any) -> bool:
+    """Return True when the resolved chat provider/model should receive reasoning hints."""
+    provider = str(provider_name or "").strip().lower()
+    model = str(model_name or "").strip().lower()
+    if provider in _CHAT_PROVIDER_BASE_URLS:
+        return False
+    if model.startswith("grok"):
+        return False
+    return True
+
+
 def _coerce_int(
     value: Any,
     default: int,
@@ -292,8 +303,11 @@ def _build_chat_config(merged_config: Dict[str, Any]) -> Dict[str, Any]:
     resolved["base_url"] = base_url
 
     reasoning_effort = str(resolved.get("reasoning_effort") or "").strip().lower()
-    if reasoning_effort not in {"minimal", "low", "medium", "high"}:
-        reasoning_effort = "high"
+    if _chat_supports_reasoning_effort(provider_name, resolved.get("model")):
+        if reasoning_effort not in {"minimal", "low", "medium", "high"}:
+            reasoning_effort = "high"
+    else:
+        reasoning_effort = ""
     resolved["reasoning_effort"] = reasoning_effort
 
     resolved["enabled"] = _coerce_bool(resolved.get("enabled"), True)
@@ -368,9 +382,10 @@ class OpenAIChatRuntime:
         merged_config = _deep_merge_dicts(file_config, config or {})
 
         self.chat_config = _build_chat_config(merged_config)
+        self.provider = str(self.chat_config.get("provider") or "openai").strip().lower() or "openai"
         self.model = str(self.chat_config.get("model") or "gpt-5.4").strip() or "gpt-5.4"
         self.api_key_env = str(self.chat_config.get("api_key_env") or "OPENAI_API_KEY").strip() or "OPENAI_API_KEY"
-        self.reasoning_effort = str(self.chat_config.get("reasoning_effort") or "high").strip() or "high"
+        self.reasoning_effort = str(self.chat_config.get("reasoning_effort") or "").strip().lower()
 
         try:
             self.temperature = float(self.chat_config.get("temperature", 0.1))

--- a/python/server.py
+++ b/python/server.py
@@ -401,7 +401,7 @@ def _chat_runtime_policy(config: Optional[Dict[str, Any]] = None) -> Dict[str, A
         "provider": str(chat_config.get("provider") or "openai").strip() or "openai",
         "model": str(chat_config.get("model") or "gpt-5.4").strip() or "gpt-5.4",
         "apiKeyEnv": str(chat_config.get("api_key_env") or "OPENAI_API_KEY").strip() or "OPENAI_API_KEY",
-        "reasoningEffort": str(chat_config.get("reasoning_effort") or "high").strip() or "high",
+        "reasoningEffort": str(chat_config.get("reasoning_effort") or "").strip(),
         "temperature": _coerce_float_range(chat_config.get("temperature"), 0.1, 0.0, 2.0),
         "maxToolRounds": _coerce_int_range(chat_config.get("max_tool_rounds"), 4, 1, 8),
         "maxHistoryMessages": _coerce_int_range(chat_config.get("max_history_messages"), 24, 1, 64),

--- a/python/test_server_chat_policy.py
+++ b/python/test_server_chat_policy.py
@@ -33,6 +33,7 @@ def test_chat_runtime_policy_defaults_openai_to_gpt_5_4(monkeypatch) -> None:
     assert policy["provider"] == "openai"
     assert policy["model"] == "gpt-5.4"
     assert policy["apiKeyEnv"] == "OPENAI_API_KEY"
+    assert policy["reasoningEffort"] == "high"
 
 
 def test_chat_runtime_policy_preserves_explicit_openai_model(monkeypatch) -> None:
@@ -96,3 +97,91 @@ def test_xai_provider_rewrites_legacy_gpt54_placeholder_model(monkeypatch) -> No
     provider = provider_module.XAIProvider(config={"llm": {"provider": "xai", "model": "gpt54"}})
 
     assert provider.llm_model == "grok-4.20-0309-reasoning"
+
+
+def test_chat_runtime_policy_omits_reasoning_effort_for_xai_grok(monkeypatch) -> None:
+    stub_config = {
+        "chat": {
+            "provider": "xai",
+            "model": "grok-4.20-0309-reasoning",
+            "reasoning_effort": "high",
+        }
+    }
+    monkeypatch.setattr(server, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(openai_auth, "get_api_key", lambda: None)
+    monkeypatch.setattr(openai_auth, "get_api_key_provider", lambda: "xai")
+
+    policy = server._chat_runtime_policy()
+
+    assert policy["provider"] == "xai"
+    assert policy["model"] == "grok-4.20-0309-reasoning"
+    assert policy["reasoningEffort"] == ""
+
+
+class _FakeCompletionsClient:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"ok": True}
+
+
+class _FakeChatClient:
+    def __init__(self) -> None:
+        self.chat = type("ChatAPI", (), {"completions": _FakeCompletionsClient()})()
+
+
+def test_openai_chat_runtime_skips_reasoning_params_for_xai_grok(monkeypatch) -> None:
+    stub_config = {
+        "chat": {
+            "provider": "xai",
+            "model": "grok-4.20-0309-reasoning",
+            "reasoning_effort": "high",
+        }
+    }
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(openai_auth, "get_api_key", lambda: None)
+    monkeypatch.setattr(openai_auth, "get_api_key_provider", lambda: "xai")
+
+    runtime = provider_module.OpenAIChatRuntime(config=stub_config)
+    fake_client = _FakeChatClient()
+    monkeypatch.setattr(runtime, "_load_client", lambda: fake_client)
+
+    _response, meta = runtime.complete([{"role": "user", "content": "hello"}])
+    sent = fake_client.chat.completions.calls[-1]
+
+    assert runtime.reasoning_effort == ""
+    assert "reasoning" not in sent
+    assert "reasoning_effort" not in sent
+    assert meta["reasoningApplied"] is False
+    assert meta["reasoningAttempt"] == "none"
+    assert meta["reasoningConfigured"] == ""
+
+
+def test_openai_chat_runtime_keeps_reasoning_params_for_openai(monkeypatch) -> None:
+    stub_config = {
+        "chat": {
+            "provider": "openai",
+            "model": "gpt-5.4",
+            "reasoning_effort": "high",
+        }
+    }
+    monkeypatch.setattr(provider_module, "load_ai_config", lambda config_path=None: stub_config)
+    monkeypatch.setattr(openai_auth, "get_api_key", lambda: None)
+    monkeypatch.setattr(openai_auth, "get_api_key_provider", lambda: "openai")
+
+    runtime = provider_module.OpenAIChatRuntime(config=stub_config)
+    fake_client = _FakeChatClient()
+    monkeypatch.setattr(runtime, "_load_client", lambda: fake_client)
+
+    _response, meta = runtime.complete([{"role": "user", "content": "hello"}])
+    sent = fake_client.chat.completions.calls[-1]
+
+    assert runtime.reasoning_effort == "high"
+    assert sent["reasoning"] == {"effort": "high"}
+    assert "reasoning_effort" not in sent
+    assert meta["reasoningApplied"] is True
+    assert meta["reasoningAttempt"] == "reasoning"
+    assert meta["reasoningConfigured"] == "high"


### PR DESCRIPTION
## Summary
- stop exposing `reasoningEffort` for xAI/Grok chat policy payloads
- suppress reasoning-hint injection for Grok/xAI chat runtime requests while keeping OpenAI reasoning behavior intact
- add regression coverage for xAI policy/runtime omission and explicit OpenAI retention of reasoning hints

## Root cause
PR #62 normalized xAI/Grok provider/model routing, but the chat runtime still defaulted `reasoning_effort` to `high` for every provider and `OpenAIChatRuntime.complete()` attempted reasoning payloads whenever that field was non-empty. Grok/xAI then rejected the request with:

`400 Client specified an invalid argument: Model grok-4.20-0309-reasoning does not support parameter reasoningEffort`

## Test plan
- `pytest python/test_server_chat_policy.py -q` → 11 passed
- `python3 -m py_compile python/ai/provider.py python/server.py python/test_server_chat_policy.py`
- `npm run test -- --run` → 142 passed
- `./node_modules/.bin/tsc --noEmit`

## Notes
- follow-up to merged PR #62: this is a post-merge runtime compatibility fix for Grok/xAI reasoning-effort handling
- existing baseline Vitest stderr warnings remain unchanged (`React Router future flag` warnings and `tagStore localStorage` warnings in `storePersistence.test.ts`)
