### PR TITLE
[MC-316] Harden Codex auth start connectivity

### DIFF
--- a/docs/plans/MC-316-codex-auth-start-connectivity.md
+++ b/docs/plans/MC-316-codex-auth-start-connectivity.md
@@ -1,0 +1,33 @@
+# MC-316 — Codex auth start connectivity and proxy verification
+
+## Objective
+Determine why PARSE showed `Could not reach the PARSE API for POST /api/auth/start...` during Codex login, verify the real root cause on the canonical repo/runtime, and implement the smallest durable fix if the failure is code-related rather than just a dead dev server.
+
+## Scope
+1. Verify the canonical repo/runtime state and current branch/PR context.
+2. Inspect the backend auth-start route, frontend auth flow wiring, and Vite proxy configuration.
+3. Check live backend/frontend availability on `127.0.0.1:8766` and `127.0.0.1:5173`.
+4. Reproduce `POST /api/auth/start` both direct-to-backend and through the Vite proxy/browser path.
+5. If a real code bug exists, add failing regression coverage first, then patch minimally.
+6. Re-run targeted and full validation; ship on a fresh branch/PR if code changes are required.
+
+## Files likely in scope
+- `python/server.py`
+- `src/api/client.ts`
+- `src/ParseUI.tsx`
+- `src/components/annotate/ChatPanel.tsx`
+- `vite.config.ts`
+- auth-related tests/docs as needed
+
+## Constraints
+- Canonical repo only: `/home/lucas/gh/ardeleanlucas/parse`
+- Current open PR #64 is for Grok reasoning-effort only; do not mix unrelated auth changes into it.
+- PR #62 is already merged; do not push further work to its merged branch.
+- Preserve working xAI auth/key flow while checking Codex/OpenAI auth.
+
+## Completion criteria
+- Real cause of the `/api/auth/start` reachability error is tool-grounded.
+- If code changes are needed, failing tests are written first and pass after the fix.
+- `npm run test -- --run` passes.
+- `./node_modules/.bin/tsc --noEmit` passes.
+- A fresh PR exists if code changes are required.

--- a/python/ai/openai_auth.py
+++ b/python/ai/openai_auth.py
@@ -307,7 +307,16 @@ def poll_device_auth() -> Dict[str, Any]:
 
 def get_auth_status() -> Dict[str, Any]:
     """Return current auth status."""
-    # Check direct API key first
+    with _auth_lock:
+        if _auth_state.get("status") == "pending":
+            return {
+                "authenticated": False,
+                "flow_active": True,
+                "user_code": _auth_state.get("user_code", ""),
+                "verification_uri": _auth_state.get("verification_uri", ""),
+            }
+
+    # Check direct API key first once no device flow is active.
     path = _token_path()
     try:
         with open(path, "r", encoding="utf-8") as f:
@@ -330,15 +339,6 @@ def get_auth_status() -> Dict[str, Any]:
             "provider": "openai",
             "expires_in": max(0, int(expires - time.time())) if expires else None,
         }
-
-    with _auth_lock:
-        if _auth_state.get("status") == "pending":
-            return {
-                "authenticated": False,
-                "flow_active": True,
-                "user_code": _auth_state.get("user_code", ""),
-                "verification_uri": _auth_state.get("verification_uri", ""),
-            }
 
     return {"authenticated": False, "flow_active": False}
 

--- a/python/test_openai_auth_status.py
+++ b/python/test_openai_auth_status.py
@@ -1,0 +1,57 @@
+import json
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import ai.openai_auth as openai_auth
+
+
+def test_get_auth_status_prefers_pending_device_flow_over_saved_api_key(tmp_path, monkeypatch) -> None:
+    token_path = tmp_path / "auth_tokens.json"
+    token_path.write_text(
+        json.dumps({"direct_api_key": "xai-test-key", "direct_api_key_provider": "xai"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(openai_auth, "_token_path", lambda: token_path)
+
+    with openai_auth._auth_lock:
+        openai_auth._auth_state.clear()
+        openai_auth._auth_state.update(
+            {
+                "status": "pending",
+                "user_code": "ABCD-1234",
+                "verification_uri": "https://auth.openai.com/codex/device",
+                "expires_at": time.time() + 600,
+            }
+        )
+
+    status = openai_auth.get_auth_status()
+
+    assert status == {
+        "authenticated": False,
+        "flow_active": True,
+        "user_code": "ABCD-1234",
+        "verification_uri": "https://auth.openai.com/codex/device",
+    }
+
+
+
+def test_get_auth_status_returns_saved_api_key_when_no_flow_is_active(tmp_path, monkeypatch) -> None:
+    token_path = tmp_path / "auth_tokens.json"
+    token_path.write_text(
+        json.dumps({"direct_api_key": "xai-test-key", "direct_api_key_provider": "xai"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(openai_auth, "_token_path", lambda: token_path)
+
+    with openai_auth._auth_lock:
+        openai_auth._auth_state.clear()
+
+    status = openai_auth.get_auth_status()
+
+    assert status == {
+        "authenticated": True,
+        "method": "api_key",
+        "provider": "xai",
+    }

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { resolveParseApiTarget } from "./vite.config";
+
+describe("resolveParseApiTarget", () => {
+  it("defaults to port 8766", () => {
+    expect(resolveParseApiTarget({})).toBe("http://127.0.0.1:8766");
+  });
+
+  it("uses PARSE_API_PORT when provided", () => {
+    expect(resolveParseApiTarget({ PARSE_API_PORT: "9000" })).toBe("http://127.0.0.1:9000");
+  });
+
+  it("falls back to legacy PARSE_PORT when PARSE_API_PORT is absent", () => {
+    expect(resolveParseApiTarget({ PARSE_PORT: "9123" })).toBe("http://127.0.0.1:9123");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,20 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+export function resolveParseApiTarget(env: Record<string, string | undefined> = process.env): string {
+  const port = (env.PARSE_API_PORT ?? env.PARSE_PORT ?? "8766").trim() || "8766";
+  return `http://127.0.0.1:${port}`;
+}
+
+const parseApiTarget = resolveParseApiTarget();
+
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:8766",
+        target: parseApiTarget,
         changeOrigin: true,
         ws: false,
         configure: (proxy) => {
@@ -17,22 +24,22 @@ export default defineConfig({
         },
       },
       "/project.json": {
-        target: "http://127.0.0.1:8766",
+        target: parseApiTarget,
         changeOrigin: true,
         ws: false,
       },
       "/source_index.json": {
-        target: "http://127.0.0.1:8766",
+        target: parseApiTarget,
         changeOrigin: true,
         ws: false,
       },
       "/annotations": {
-        target: "http://127.0.0.1:8766",
+        target: parseApiTarget,
         changeOrigin: true,
         ws: false,
       },
       "/audio": {
-        target: "http://127.0.0.1:8766",
+        target: parseApiTarget,
         changeOrigin: true,
         ws: false,
       },


### PR DESCRIPTION
## Summary
- fix Codex device-auth status reporting so an active pending flow is not hidden by a saved direct API key
- make the Vite proxy target follow `PARSE_API_PORT` / legacy `PARSE_PORT` instead of hardcoding `127.0.0.1:8766`
- add regression coverage for auth-status precedence and proxy target resolution

## Root cause
There were two separate issues behind the reported Codex login failure surface:

1. **Immediate live failure**
   - the backend on `127.0.0.1:8766` was healthy, but the Vite dev server was not running/listening on `127.0.0.1:5173`
   - that made browser `/api/auth/start` requests fail at the proxy layer and collapse into the generic PARSE reachability error

2. **Latent code bugs that could still break Codex login**
   - `python/ai/openai_auth.py:get_auth_status()` returned saved direct API-key auth before reporting an active pending device flow, so a Codex sign-in could fail to surface `user_code` / `verification_uri`
   - `vite.config.ts` hardcoded `http://127.0.0.1:8766`, so any non-default backend port set via `PARSE_API_PORT` / `PARSE_PORT` would silently break the dev proxy with the same browser-side error

## Test plan
- `pytest python/test_openai_auth_status.py python/test_server_chat_policy.py -q` → 10 passed
- `pytest python/test_openai_auth_status.py -q` → 2 passed
- `npx vitest run vite.config.test.ts` → 3 passed
- `npm run test:api` → 24 passed
- `npm run test -- --run` → 145 passed
- `./node_modules/.bin/tsc --noEmit`
- live verification after restarting the canonical dev stack:
  - direct backend `POST http://127.0.0.1:8766/api/auth/start` → 200 with `user_code`
  - proxied `POST http://127.0.0.1:5173/api/auth/start` → 200 with `user_code`
  - backend/proxied `GET /api/auth/status` after starting device auth now returns `flow_active: true` plus `user_code` / `verification_uri`
  - browser-page `fetch('/api/auth/start', { method: 'POST' })` and `fetch('/api/auth/status')` both succeed from `http://127.0.0.1:5173/`

## Notes
- this PR does not change the Grok/xAI reasoning-effort work in PR #64; it is a separate follow-up for Codex auth connectivity and proxy hardening
- existing baseline Vitest stderr warnings remain unchanged (`React Router future flag` warnings and `tagStore localStorage` warnings in `storePersistence.test.ts`)
