### PR TITLE
fix: chat run returns string result so React can render it (blank-UI crash)

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -1395,13 +1395,9 @@ def _run_chat_job(job_id: str, session_id: str) -> None:
             },
         )
 
-        fresh_session = _chat_get_session_snapshot(session_id) or {}
-        response_payload = copy.deepcopy(result) if isinstance(result, dict) else {}
-        response_payload["session"] = _chat_session_public_payload(fresh_session)
-
         _set_job_complete(
             job_id,
-            response_payload,
+            assistant_content,
             message="Chat run complete",
         )
     except ChatOrchestratorError as exc:
@@ -1492,7 +1488,7 @@ def _set_job_progress(
 
 def _set_job_complete(
     job_id: str,
-    result: Dict[str, Any],
+    result: Any,
     message: Optional[str] = None,
     segments_processed: Optional[int] = None,
     total_segments: Optional[int] = None,

--- a/python/test_chat_job_result_shape.py
+++ b/python/test_chat_job_result_shape.py
@@ -1,0 +1,76 @@
+"""Regression coverage for the chat-run job result shape.
+
+The UI expects `result` to be a plain string (the assistant's content).
+Prior code set the job result to a dict (`{assistant: {...}, session: {...}, ...}`)
+which React then tried to render as a child, unmounting the chat panel and
+blanking the page.
+"""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+def test_run_chat_job_stores_assistant_string_as_result(monkeypatch) -> None:
+    job_id = server._create_job("chat:run", {"sessionId": "chat-1"})
+
+    monkeypatch.setattr(
+        server,
+        "_chat_get_session_snapshot",
+        lambda sid: {"id": sid, "messages": []},
+    )
+
+    class _FakeOrchestrator:
+        def run(self, session_id, session_messages):
+            return {
+                "assistant": {"content": "hello from grok"},
+                "model": "grok-4.20-0309-reasoning",
+                "toolTrace": [],
+            }
+
+    monkeypatch.setattr(
+        server,
+        "_get_chat_runtime",
+        lambda: (None, _FakeOrchestrator()),
+    )
+    monkeypatch.setattr(server, "_chat_append_message", lambda *a, **kw: None)
+
+    server._run_chat_job(job_id, "chat-1")
+
+    snapshot = server._get_job_snapshot(job_id)
+    assert snapshot is not None
+    assert snapshot["status"] == "complete"
+    assert snapshot["result"] == "hello from grok", (
+        "Job result must be a plain string — a dict here crashes the React chat panel."
+    )
+    assert isinstance(snapshot["result"], str)
+
+
+def test_run_chat_job_result_falls_back_to_default_when_content_missing(monkeypatch) -> None:
+    job_id = server._create_job("chat:run", {"sessionId": "chat-2"})
+
+    monkeypatch.setattr(
+        server,
+        "_chat_get_session_snapshot",
+        lambda sid: {"id": sid, "messages": []},
+    )
+
+    class _EmptyOrchestrator:
+        def run(self, session_id, session_messages):
+            return {}
+
+    monkeypatch.setattr(
+        server,
+        "_get_chat_runtime",
+        lambda: (None, _EmptyOrchestrator()),
+    )
+    monkeypatch.setattr(server, "_chat_append_message", lambda *a, **kw: None)
+
+    server._run_chat_job(job_id, "chat-2")
+
+    snapshot = server._get_job_snapshot(job_id)
+    assert snapshot is not None
+    assert snapshot["status"] == "complete"
+    assert isinstance(snapshot["result"], str)
+    assert snapshot["result"]  # non-empty fallback

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -77,7 +77,7 @@ export interface ChatJob {
 
 export interface ChatStatus {
   status: string;
-  result?: string;
+  result?: string | Record<string, unknown>;
   error?: string;
 }
 

--- a/src/hooks/__tests__/useChatSession.test.tsx
+++ b/src/hooks/__tests__/useChatSession.test.tsx
@@ -28,6 +28,10 @@ describe("useChatSession", () => {
     sessionStorage.clear();
     vi.useFakeTimers();
     vi.clearAllMocks();
+    startChatSession.mockReset();
+    runChat.mockReset();
+    pollChat.mockReset();
+    syncFromServer.mockReset();
   });
 
   afterEach(() => {
@@ -80,5 +84,41 @@ describe("useChatSession", () => {
     expect(result.current.error).toBeNull();
     expect(pollChat).toHaveBeenCalledTimes(1);
     expect(syncFromServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("extracts assistant content when the server returns a dict result (blank-UI crash fix)", async () => {
+    startChatSession.mockResolvedValue({ session_id: "chat_123" });
+    runChat.mockResolvedValue({ job_id: "job_123" });
+    pollChat
+      .mockResolvedValueOnce({
+        status: "complete",
+        result: {
+          assistant: { content: "hi from grok" },
+          session: { id: "chat_123", messages: [] },
+          model: "grok-4.20-0309-reasoning",
+        },
+      })
+      .mockResolvedValueOnce({ status: "error", error: "should not poll twice" });
+
+    const { result } = renderHook(() => useChatSession());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      void result.current.send("hello");
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2100);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.messages.map((m) => m.content)).toEqual([
+      "hello",
+      "hi from grok",
+    ]);
   });
 });

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -20,6 +20,21 @@ const SESSION_KEY = "parse-chat-session-id"
 const MAX_POLLS = 60
 const POLL_INTERVAL_MS = 2000
 
+export function extractAssistantContent(raw: unknown): string {
+  if (typeof raw === "string") return raw
+  if (raw && typeof raw === "object") {
+    const r = raw as Record<string, unknown>
+    const assistant = r.assistant
+    if (assistant && typeof assistant === "object") {
+      const content = (assistant as Record<string, unknown>).content
+      if (typeof content === "string") return content
+    }
+    if (typeof r.content === "string") return r.content
+    if (typeof r.message === "string") return r.message
+  }
+  return ""
+}
+
 export function useChatSession(): UseChatSessionResult {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [sessionId, setSessionId] = useState<string | null>(
@@ -95,7 +110,7 @@ export function useChatSession(): UseChatSessionResult {
                   || status.status === "completed"
                   || status.status === "complete"
                 ) {
-                  resolve(status.result ?? "")
+                  resolve(extractAssistantContent(status.result))
                 } else if (status.status === "error") {
                   reject(new Error(status.error ?? status.result ?? "Chat error"))
                 } else if (polls >= MAX_POLLS) {


### PR DESCRIPTION
## Root cause

Sending a message to Grok (or OpenAI) blanked the whole page and made the chat panel vanish. The tell in the backend log was a single \`POST /api/chat/run/status\` 200, then a flood of \`/api/chat/session\` re-creation attempts — React was unmounting the tree and remounting ChatPanel, which re-failed on each attempt.

The actual error (captured from a local repro):

> Objects are not valid as a React child (found: object with keys {assistant, session, model, toolTrace}).

In [python/server.py:1398-1406](python/server.py:1398), \`_run_chat_job\` wrapped the orchestrator's output in a \`response_payload\` dict and stored that dict as the job's \`result\`:

\`\`\`python
response_payload = copy.deepcopy(result) if isinstance(result, dict) else {}
response_payload[\"session\"] = _chat_session_public_payload(fresh_session)
_set_job_complete(job_id, response_payload, ...)
\`\`\`

\`_job_response_payload\` then shipped \`result\` (the dict) out via \`/api/chat/run/status\`. The frontend type [ChatStatus.result](src/api/types.ts) declared \`string\`, and [useChatSession.ts](src/hooks/useChatSession.ts) did \`resolve(status.result ?? \"\")\` — so the hook's message list ended up with \`content: { assistant: {...}, session: {...}, ... }\`, and \`<div>{msg.content}</div>\` in [ChatPanel.tsx:368](src/components/annotate/ChatPanel.tsx:368) threw on render. No component error boundary caught it, so the whole tree unmounted.

No frontend consumer ever used the rich dict fields (\`session\`, \`model\`, \`toolTrace\`) — grep confirms zero references. The session state is already persisted server-side by \`_chat_append_message\` before the job finishes, so dropping the dict wrapper loses nothing.

## Fix (two-sided so this class of bug can't recur)

**Backend** — [python/server.py](python/server.py)
- \`_run_chat_job\` now stores the plain \`assistant_content\` string as the job result. The dict-wrapping (\`response_payload\`) is gone.
- \`_set_job_complete\` signature widened from \`result: Dict[str, Any]\` to \`result: Any\` — other job types were already safe; this documents the relaxation.

**Frontend** — [src/hooks/useChatSession.ts](src/hooks/useChatSession.ts)
- New exported \`extractAssistantContent()\` helper that accepts \`string\`, \`{ assistant: { content } }\`, \`{ content }\`, or \`{ message }\`, and degrades to \`\"\"\` for anything else. The hook now routes \`status.result\` through it instead of \`?? \"\"\`.

**Types** — [src/api/types.ts](src/api/types.ts)
- \`ChatStatus.result\` widened from \`string\` to \`string | Record<string, unknown>\` so the TS contract matches reality.

## Test plan

| Check | Result |
|---|---|
| \`pytest python/test_chat_job_result_shape.py python/test_server_chat_policy.py -q\` | **13 passed** (2 new regression tests — string shape + empty-orchestrator fallback) |
| \`pytest python/ -q\` (excluding \`compare/providers\` which needs optional \`requests\`) | **27 passed** |
| \`npx vitest run\` | **146 passed** (new hook test: dict result → string message content) |
| \`./node_modules/.bin/tsc --noEmit\` | clean |
| Live preview: app loads, no console errors, \`extractAssistantContent\` returns a string for every realistic shape | confirmed |

Regression coverage locks in both sides: Python tests assert \`snapshot[\"result\"]\` is a \`str\`; the TS test asserts the hook yields a string \`content\` when the server returns the legacy dict shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)