### PR TITLE
fix(ui): dark-mode gaps — chat panel, amber card, orphan header circle

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1769,7 +1769,6 @@ export function ParseUI() {
             >
               {darkMode ? <Sun className="h-4 w-4"/> : <Moon className="h-4 w-4"/>}
             </button>
-            <div className="h-7 w-7 rounded-full bg-gradient-to-br from-amber-200 to-rose-300 ring-2 ring-white" />
           </div>
         </div>
       </header>

--- a/src/components/annotate/ChatPanel.tsx
+++ b/src/components/annotate/ChatPanel.tsx
@@ -12,6 +12,17 @@ export interface ChatPanelProps {
 
 type AuthState = "checking" | "unauthenticated" | "entering-xai" | "entering-openai" | "oauth" | "authenticated"
 
+const primaryBtnClass =
+  "rounded-md border border-indigo-600 bg-indigo-600 px-3.5 py-2 text-[13px] font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+const clearBtnClass =
+  "rounded-md border border-slate-300 bg-white px-3.5 py-2 text-[13px] font-semibold text-slate-700 hover:bg-slate-50"
+const inputClass =
+  "flex-1 rounded-md border border-slate-300 bg-white px-2.5 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+const authPrimaryBtnClass =
+  "w-full rounded-md border border-indigo-600 bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+const authSecondaryBtnClass =
+  "w-full rounded-md border border-indigo-600 bg-white px-5 py-2.5 text-sm font-semibold text-indigo-600 hover:bg-slate-50"
+
 export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
   const { messages, sending, tokensUsed, tokensLimit, send, clear } = useChatSession()
   const [inputText, setInputText] = useState("")
@@ -23,7 +34,6 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
   const [oauthInfo, setOauthInfo] = useState<{ user_code?: string; verification_uri?: string }>({})
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  // Check auth on mount
   useEffect(() => {
     getAuthStatus()
       .then((s: AuthStatus) => {
@@ -32,14 +42,12 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
       .catch(() => setAuthState("unauthenticated"))
   }, [])
 
-  // Clean up poll on unmount
   useEffect(() => {
     return () => {
       if (pollRef.current) clearInterval(pollRef.current)
     }
   }, [])
 
-  // Auto-scroll to bottom on new messages
   useEffect(() => {
     if (messagesEndRef.current && typeof messagesEndRef.current.scrollIntoView === "function") {
       messagesEndRef.current.scrollIntoView({ behavior: "smooth" })
@@ -78,7 +86,6 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
       if (status.user_code) {
         setOauthInfo({ user_code: status.user_code, verification_uri: status.verification_uri })
       }
-      // Start polling
       pollRef.current = setInterval(async () => {
         try {
           const s = await getAuthStatus()
@@ -110,151 +117,56 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
     setOauthInfo({})
   }
 
-  const containerStyle: React.CSSProperties = {
-    display: "flex",
-    flexDirection: "column",
-    height: "100%",
-    fontFamily: "system-ui, -apple-system, sans-serif",
-    color: "#0f172a",
-  }
-
-  const headerStyle: React.CSSProperties = {
-    padding: "12px 16px",
-    borderBottom: "1px solid #e2e8f0",
-    fontSize: 14,
-    fontWeight: 700,
-    display: "flex",
-    justifyContent: "space-between",
-    alignItems: "center",
-  }
-
-  const messageListStyle: React.CSSProperties = {
-    flex: 1,
-    overflowY: "auto",
-    padding: 16,
-    display: "flex",
-    flexDirection: "column",
-    gap: 12,
-  }
-
-  const inputRowStyle: React.CSSProperties = {
-    display: "flex",
-    gap: 8,
-    padding: "12px 16px",
-    borderTop: "1px solid #e2e8f0",
-  }
-
-  const inputStyle: React.CSSProperties = {
-    flex: 1,
-    padding: "8px 10px",
-    border: "1px solid #cbd5e1",
-    borderRadius: 8,
-    fontSize: 14,
-  }
-
-  const btnStyle: React.CSSProperties = {
-    padding: "8px 14px",
-    borderRadius: 8,
-    fontSize: 13,
-    fontWeight: 600,
-    cursor: "pointer",
-    border: "1px solid #6366f1",
-    background: "#6366f1",
-    color: "#fff",
-  }
-
-  const disabledBtnStyle: React.CSSProperties = {
-    ...btnStyle,
-    opacity: 0.5,
-    cursor: "not-allowed",
-  }
-
-  const clearBtnStyle: React.CSSProperties = {
-    padding: "8px 14px",
-    borderRadius: 8,
-    fontSize: 13,
-    fontWeight: 600,
-    cursor: "pointer",
-    border: "1px solid #cbd5e1",
-    background: "#fff",
-    color: "#374151",
-  }
-
-  const userMsgStyle: React.CSSProperties = {
-    alignSelf: "flex-end",
-    background: "#eff6ff",
-    border: "1px solid #bfdbfe",
-    borderRadius: 10,
-    padding: "8px 12px",
-    maxWidth: "80%",
-  }
-
-  const assistantMsgStyle: React.CSSProperties = {
-    alignSelf: "flex-start",
-    background: "#f8fafc",
-    border: "1px solid #e2e8f0",
-    borderRadius: 10,
-    padding: "8px 12px",
-    maxWidth: "80%",
-  }
-
-  const authBtnStyle: React.CSSProperties = {
-    padding: "10px 20px",
-    borderRadius: 8,
-    fontSize: 14,
-    fontWeight: 600,
-    cursor: "pointer",
-    border: "1px solid #6366f1",
-    background: "#6366f1",
-    color: "#fff",
-    width: "100%",
-  }
-
-  const secondaryBtnStyle: React.CSSProperties = {
-    ...authBtnStyle,
-    background: "#fff",
-    color: "#6366f1",
-  }
-
-  const signOutStyle: React.CSSProperties = {
-    fontSize: 12,
-    color: "#6366f1",
-    cursor: "pointer",
-    background: "none",
-    border: "none",
-    padding: 0,
-    fontWeight: 500,
-  }
-
   const headerText = `AI Assistant${speaker ? ` — ${speaker}` : ""}${conceptId ? ` / ${conceptId}` : ""}`
   const canSend = inputText.trim() !== "" && !sending
+
+  const headerRow = (
+    <div className="flex items-center justify-between border-b border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900">
+      <span>{headerText}</span>
+      {authState === "authenticated" && (
+        <span className="flex items-center gap-3">
+          <ContextRing used={tokensUsed} limit={tokensLimit} />
+          <button
+            onClick={handleSignOut}
+            className="border-none bg-transparent p-0 text-xs font-medium text-indigo-600 hover:text-indigo-700"
+          >
+            Sign out
+          </button>
+        </span>
+      )}
+    </div>
+  )
 
   // Auth screen
   if (authState !== "authenticated") {
     return (
-      <div style={containerStyle}>
-        <div style={headerStyle}>
-          <span>{headerText}</span>
-        </div>
-        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 32 }}>
-          <div style={{ maxWidth: 340, width: "100%", textAlign: "center" }}>
+      <div className="flex h-full flex-col bg-white text-slate-900">
+        {headerRow}
+        <div className="flex flex-1 items-center justify-center p-8">
+          <div className="w-full max-w-[340px] text-center">
             {authState === "checking" && (
-              <div style={{ color: "#94a3b8", fontSize: 14 }}>Checking authentication...</div>
+              <div className="text-sm text-slate-400">Checking authentication...</div>
             )}
 
             {authState === "unauthenticated" && (
               <>
-                <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 24 }}>Connect AI Assistant</div>
-                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  <button style={authBtnStyle} onClick={() => { setAuthState("entering-xai"); setAuthError(""); setApiKeyInput(""); }}>
+                <div className="mb-6 text-lg font-bold">Connect AI Assistant</div>
+                <div className="flex flex-col gap-3">
+                  <button
+                    className={authPrimaryBtnClass}
+                    onClick={() => { setAuthState("entering-xai"); setAuthError(""); setApiKeyInput(""); }}
+                  >
                     Use xAI API Key
                   </button>
-                  <div style={{ fontSize: 12, color: "#94a3b8" }}>or</div>
-                  <button style={secondaryBtnStyle} onClick={() => { setAuthState("entering-openai"); setAuthError(""); setApiKeyInput(""); }}>
+                  <div className="text-xs text-slate-400">or</div>
+                  <button
+                    className={authSecondaryBtnClass}
+                    onClick={() => { setAuthState("entering-openai"); setAuthError(""); setApiKeyInput(""); }}
+                  >
                     Use OpenAI API Key
                   </button>
-                  <div style={{ fontSize: 12, color: "#94a3b8" }}>or</div>
-                  <button style={secondaryBtnStyle} onClick={handleStartOAuth}>
+                  <div className="text-xs text-slate-400">or</div>
+                  <button className={authSecondaryBtnClass} onClick={handleStartOAuth}>
                     Sign in with OpenAI (OAuth)
                   </button>
                 </div>
@@ -263,26 +175,26 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
 
             {(authState === "entering-xai" || authState === "entering-openai") && (
               <>
-                <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 16 }}>
+                <div className="mb-4 text-lg font-bold">
                   {authState === "entering-xai" ? "xAI API Key" : "OpenAI API Key"}
                 </div>
                 <input
                   type="password"
-                  style={{ ...inputStyle, width: "100%", marginBottom: 12, boxSizing: "border-box" }}
+                  className={`${inputClass} mb-3 w-full`}
                   placeholder={authState === "entering-xai" ? "xai-..." : "sk-..."}
                   value={apiKeyInput}
                   onChange={(e) => setApiKeyInput(e.target.value)}
                   aria-label={authState === "entering-xai" ? "xAI API Key" : "OpenAI API Key"}
                 />
-                <div style={{ display: "flex", gap: 8 }}>
+                <div className="flex gap-2">
                   <button
-                    style={secondaryBtnStyle}
+                    className={authSecondaryBtnClass}
                     onClick={() => { setAuthState("unauthenticated"); setAuthError(""); setApiKeyInput(""); }}
                   >
                     Back
                   </button>
                   <button
-                    style={apiKeyInput.trim() ? authBtnStyle : { ...authBtnStyle, opacity: 0.5, cursor: "not-allowed" }}
+                    className={authPrimaryBtnClass}
                     disabled={!apiKeyInput.trim()}
                     onClick={handleSaveKey}
                   >
@@ -294,27 +206,21 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
 
             {authState === "oauth" && (
               <>
-                <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 16 }}>OpenAI Sign In</div>
+                <div className="mb-4 text-lg font-bold">OpenAI Sign In</div>
                 {oauthInfo.user_code ? (
                   <div>
-                    <div style={{ fontSize: 13, color: "#64748b", marginBottom: 8 }}>
-                      Enter this code at the verification page:
-                    </div>
-                    <div style={{ fontSize: 24, fontWeight: 700, letterSpacing: 2, marginBottom: 12 }}>
-                      {oauthInfo.user_code}
-                    </div>
+                    <div className="mb-2 text-[13px] text-slate-500">Enter this code at the verification page:</div>
+                    <div className="mb-3 text-2xl font-bold tracking-widest">{oauthInfo.user_code}</div>
                     {oauthInfo.verification_uri && (
-                      <div style={{ fontSize: 12, color: "#6366f1", marginBottom: 16, wordBreak: "break-all" }}>
-                        {oauthInfo.verification_uri}
-                      </div>
+                      <div className="mb-4 break-all text-xs text-indigo-600">{oauthInfo.verification_uri}</div>
                     )}
-                    <div style={{ fontSize: 12, color: "#94a3b8" }}>Waiting for confirmation...</div>
+                    <div className="text-xs text-slate-400">Waiting for confirmation...</div>
                   </div>
                 ) : (
-                  <div style={{ color: "#94a3b8", fontSize: 14 }}>Starting OAuth flow...</div>
+                  <div className="text-sm text-slate-400">Starting OAuth flow...</div>
                 )}
                 <button
-                  style={{ ...secondaryBtnStyle, marginTop: 16 }}
+                  className={`${authSecondaryBtnClass} mt-4`}
                   onClick={() => {
                     if (pollRef.current) clearInterval(pollRef.current)
                     pollRef.current = null
@@ -329,7 +235,7 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
             )}
 
             {authError && (
-              <div style={{ color: "#dc2626", fontSize: 13, marginTop: 12 }}>{authError}</div>
+              <div className="mt-3 text-[13px] text-rose-600">{authError}</div>
             )}
           </div>
         </div>
@@ -339,64 +245,40 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
 
   // Authenticated chat UI
   return (
-    <div style={containerStyle}>
-      <div style={headerStyle}>
-        <span>{headerText}</span>
-        <span style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <ContextRing used={tokensUsed} limit={tokensLimit} />
-          <button style={signOutStyle} onClick={handleSignOut}>Sign out</button>
-        </span>
-      </div>
-      <div style={messageListStyle} data-testid="message-list">
+    <div className="flex h-full flex-col bg-white text-slate-900">
+      {headerRow}
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4" data-testid="message-list">
         {messages.length === 0 && (
-          <div style={{ color: "#94a3b8", fontSize: 13 }}>
-            No messages yet. Start a conversation.
-          </div>
+          <div className="text-[13px] text-slate-400">No messages yet. Start a conversation.</div>
         )}
         {messages.map((msg: ChatMessage, i: number) => (
           <div
             key={i}
-            style={msg.role === "user" ? userMsgStyle : assistantMsgStyle}
+            className={
+              msg.role === "user"
+                ? "max-w-[80%] self-end rounded-xl border border-indigo-200 bg-indigo-50 px-3 py-2"
+                : "max-w-[80%] self-start rounded-xl border border-slate-200 bg-slate-50 px-3 py-2"
+            }
           >
-            <div
-              style={{
-                fontSize: 10,
-                fontWeight: 700,
-                color: "#64748b",
-                marginBottom: 4,
-                textTransform: "uppercase",
-              }}
-            >
-              {msg.role}
-            </div>
-            <div style={{ fontSize: 13, lineHeight: 1.45 }}>{msg.content}</div>
-            <div style={{ fontSize: 10, color: "#94a3b8", marginTop: 4 }}>
-              {msg.timestamp}
-            </div>
+            <div className="mb-1 text-[10px] font-bold uppercase text-slate-500">{msg.role}</div>
+            <div className="text-[13px] leading-snug">{msg.content}</div>
+            <div className="mt-1 text-[10px] text-slate-400">{msg.timestamp}</div>
           </div>
         ))}
         <div ref={messagesEndRef} />
       </div>
-      <form onSubmit={handleSubmit} style={inputRowStyle}>
+      <form onSubmit={handleSubmit} className="flex gap-2 border-t border-slate-200 bg-white px-4 py-3">
         <input
-          style={inputStyle}
+          className={inputClass}
           value={inputText}
           onChange={(e) => setInputText(e.target.value)}
           placeholder="Type a message..."
           aria-label="Chat input"
         />
-        <button
-          type="submit"
-          style={canSend ? btnStyle : disabledBtnStyle}
-          disabled={!canSend}
-        >
+        <button type="submit" className={primaryBtnClass} disabled={!canSend}>
           Send
         </button>
-        <button
-          type="button"
-          style={clearBtnStyle}
-          onClick={clear}
-        >
+        <button type="button" className={clearBtnClass} onClick={clear}>
           Clear session
         </button>
       </form>

--- a/src/index.css
+++ b/src/index.css
@@ -16,9 +16,12 @@ html.dark .bg-white\/95 { background-color: #0a0a0a !important; }
 html.dark .bg-slate-50,
 html.dark .bg-slate-50\/40,
 html.dark .bg-slate-50\/60,
-html.dark .bg-slate-50\/70 { background-color: #000 !important; }
+html.dark .bg-slate-50\/70,
+html.dark .bg-slate-50\/80 { background-color: #000 !important; }
 html.dark .bg-slate-100,
 html.dark .bg-slate-100\/80 { background-color: #141414 !important; }
+html.dark .bg-slate-200,
+html.dark .bg-slate-200\/60 { background-color: #1f1f1f !important; }
 
 /* Gradients flatten to black */
 html.dark .from-slate-50 { --tw-gradient-from: #000 !important; }
@@ -27,6 +30,7 @@ html.dark .to-white { --tw-gradient-to: #0a0a0a !important; }
 /* Borders / rings: subtle hairlines */
 html.dark .border-slate-100,
 html.dark .border-slate-200,
+html.dark .border-slate-200\/70,
 html.dark .border-slate-200\/80 { border-color: #1f1f1f !important; }
 html.dark .divide-slate-100 > :not([hidden]) ~ :not([hidden]) { border-color: #1f1f1f !important; }
 html.dark .ring-slate-100,
@@ -50,6 +54,7 @@ html.dark .hover\:text-slate-700:hover { color: #e4e4e7 !important; }
 /* Accent: bright blue instead of indigo/violet */
 html.dark .bg-indigo-50 { background-color: rgb(59 130 246 / 0.12) !important; }
 html.dark .bg-indigo-50\/30 { background-color: rgb(59 130 246 / 0.08) !important; }
+html.dark .bg-indigo-50\/40 { background-color: rgb(59 130 246 / 0.10) !important; }
 html.dark .bg-indigo-50\/50 { background-color: rgb(59 130 246 / 0.15) !important; }
 html.dark .bg-indigo-100 { background-color: rgb(59 130 246 / 0.2) !important; }
 html.dark .bg-indigo-600 { background-color: #3b82f6 !important; }
@@ -70,14 +75,17 @@ html.dark .via-violet-600 { --tw-gradient-from: #3b82f6 !important; --tw-gradien
 html.dark .to-violet-600,
 html.dark .to-fuchsia-600 { --tw-gradient-to: #2563eb !important; }
 
-/* Amber / rose / emerald soft badges remain readable */
+/* Amber / rose / emerald soft badges remain readable.
+   Low-opacity warm tint keeps the card visibly "warning" without reading
+   as rust/red under bright yellow text. */
 html.dark .bg-amber-50,
-html.dark .bg-amber-50\/40 { background-color: rgb(120 53 15 / 0.35) !important; }
+html.dark .bg-amber-50\/40 { background-color: rgba(255, 193, 7, 0.08) !important; }
+html.dark .bg-amber-100 { background-color: rgba(255, 193, 7, 0.14) !important; }
 html.dark .text-amber-700,
-html.dark .text-amber-800 { color: rgb(252 211 77) !important; }
+html.dark .text-amber-800 { color: rgb(251 191 36) !important; }
 html.dark .border-amber-100,
-html.dark .border-amber-200 { border-color: rgb(180 83 9 / 0.5) !important; }
-html.dark .ring-amber-200 { --tw-ring-color: rgb(180 83 9 / 0.6) !important; }
+html.dark .border-amber-200 { border-color: rgba(180, 83, 9, 0.4) !important; }
+html.dark .ring-amber-200 { --tw-ring-color: rgba(180, 83, 9, 0.5) !important; }
 
 html.dark .bg-rose-50 { background-color: rgb(136 19 55 / 0.35) !important; }
 html.dark .text-rose-600,


### PR DESCRIPTION
## What the user reported

1. **Chat panel doesn't go dark.** Toggle has no visible effect on the chat — stays bright white against a black page.
2. **\"Workspace empty\" card reads as yellow-on-red** in dark mode.
3. **Remove the decorative circle** in the top-right header — it does nothing.

## Root causes & fixes

### 1. Chat panel
[ChatPanel.tsx](src/components/annotate/ChatPanel.tsx) was drawn entirely with inline \`style={{...}}\` objects containing hardcoded light hex colors (\`#fff\`, \`#0f172a\`, \`#e2e8f0\`, \`#6366f1\`, ...). The Noir dark-mode CSS in [src/index.css](src/index.css) only overrides Tailwind utility classes via \`html.dark .bg-white { ... }\` selectors — inline styles have higher specificity and no way to know about the mode.

**Fix:** converted the component to Tailwind classes. The existing dark-mode CSS now applies automatically; no \`dark:\` variants or component-level mode awareness needed.

### 2. Amber card
The Noir rule mapped \`bg-amber-50\` to \`rgb(120 53 15 / 0.35)\` — a saturated warm brown. Under the bright yellow \`text-amber-700\` (mapped to \`rgb(252 211 77)\`), the card skewed rust/red on most displays.

**Fix:** re-tuned to a low-opacity warm-yellow tint (\`rgba(255, 193, 7, 0.08)\`) with amber-400 text. Still reads \"warning\" — no rust cast.

### 3. Orphan circle
\`<div className=\"h-7 w-7 rounded-full bg-gradient-to-br from-amber-200 to-rose-300 ring-2 ring-white\" />\` at [ParseUI.tsx:1767](src/ParseUI.tsx:1767) — decorative placeholder with no behavior, no meaning. Removed.

## Also in this PR (smaller dark-mode gaps surfaced while testing)

- Added Noir coverage for Tailwind opacity variants previously missed:
  - \`bg-slate-50/80\` → the minimized chat bar (was staying bright white in dark mode despite user's \"chat dark mode\" complaint)
  - \`bg-slate-200/60\` → hover surfaces
  - \`bg-indigo-50/40\` → accent tint
  - \`border-slate-200/70\` → subtle borders
- Tightened the \`useChatSession.ts\` error path to funnel \`status.result\` through \`extractAssistantContent()\` so the widened type from merged [#68](https://github.com/ArdeleanLucas/PARSE/pull/68) doesn't regress the TS build (\`status.result\` can now be a dict, not just a string).

## Verification

Taken live in the preview:

| Check | Result |
|---|---|
| Dark mode screenshot — workspace-empty card | subtle amber tint, readable text, no red cast |
| Dark mode screenshot — minimized chat bar | dark background matches page (previously bright white) |
| Dark mode screenshot — expanded \"Connect PARSE AI\" panel | renders cleanly, dark blue-tinted bg, readable provider cards |
| Light mode screenshot | unchanged from before |
| Circle in header | gone |
| \`npx vitest run\` | **146 passed** |
| \`tsc --noEmit\` | clean |
| Console errors after toggle | none |

The ChatPanel refactor (262 lines of inline styles → ~65 lines of class-based JSX) is the biggest diff but entirely mechanical — no logic changed, and existing tests (text selectors, \`data-testid=\"message-list\"\`, button labels) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)