### PR TITLE
feat(jobs): show ETA alongside progress on running jobs

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -19,7 +19,7 @@ import { useWaveSurfer } from './hooks/useWaveSurfer';
 import { useAnnotationStore } from './stores/annotationStore';
 import { useAnnotationSync } from './hooks/useAnnotationSync';
 import { useComputeJob } from './hooks/useComputeJob';
-import { useActionJob } from './hooks/useActionJob';
+import { useActionJob, formatEta } from './hooks/useActionJob';
 import type { PollResult } from './hooks/useActionJob';
 import { useConfigStore } from './stores/configStore';
 import { useEnrichmentStore } from './stores/enrichmentStore';
@@ -1726,6 +1726,11 @@ export function ParseUI() {
                           />
                         </div>
                         <span className="tabular-nums text-slate-400">{Math.round(job.state.progress * 100)}%</span>
+                        {job.state.etaMs !== null && job.state.etaMs > 0 && (
+                          <span className="tabular-nums text-slate-400" title="Estimated time remaining">
+                            · ~{formatEta(job.state.etaMs)} left
+                          </span>
+                        )}
                       </>
                     )}
                     {job.state.status === 'complete' && (
@@ -2205,7 +2210,12 @@ export function ParseUI() {
                     </button>
                   </div>
                   {computeJobState.status === 'running' && (
-                    <div className="mt-1 text-[10px] text-indigo-600">Running… {Math.round(computeJobState.progress * 100)}%</div>
+                    <div className="mt-1 text-[10px] text-indigo-600">
+                      Running… {Math.round(computeJobState.progress * 100)}%
+                      {computeJobState.etaMs !== null && computeJobState.etaMs > 0 && (
+                        <span className="text-slate-400"> · ~{formatEta(computeJobState.etaMs)} left</span>
+                      )}
+                    </div>
                   )}
                   {computeJobState.status === 'error' && (
                     <div className="mt-1 text-[10px] text-rose-600">{computeJobState.error}</div>

--- a/src/hooks/__tests__/useActionJob.test.ts
+++ b/src/hooks/__tests__/useActionJob.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { useActionJob } from "../useActionJob";
+import { useActionJob, projectEtaMs, formatEta } from "../useActionJob";
 
 describe("useActionJob", () => {
   beforeEach(() => {
@@ -30,6 +30,7 @@ describe("useActionJob", () => {
       progress: 0,
       error: null,
       label: null,
+      etaMs: null,
     });
   });
 
@@ -197,6 +198,7 @@ describe("useActionJob", () => {
       progress: 0,
       error: null,
       label: null,
+      etaMs: null,
     });
   });
 
@@ -276,7 +278,36 @@ describe("useActionJob", () => {
       progress: 0,
       error: "Start failed",
       label: "Running action…",
+      etaMs: null,
     });
     expect(poll).not.toHaveBeenCalled();
+  });
+});
+
+describe("projectEtaMs / formatEta", () => {
+  it("returns null below the 5% progress threshold", () => {
+    expect(projectEtaMs(0.03, 10_000)).toBeNull();
+  });
+
+  it("returns null below the 1.5s elapsed threshold (noisy early estimates)", () => {
+    expect(projectEtaMs(0.3, 500)).toBeNull();
+  });
+
+  it("returns 0 when progress is 1", () => {
+    expect(projectEtaMs(1, 5_000)).toBe(0);
+  });
+
+  it("projects remaining time from elapsed and progress", () => {
+    // 25% done in 5s → 75% remaining, projected at the same rate → 15s
+    expect(projectEtaMs(0.25, 5_000)).toBe(15_000);
+  });
+
+  it("formats sub-second / second / minute / hour ranges", () => {
+    expect(formatEta(400)).toBe("<1s");
+    expect(formatEta(2_600)).toBe("3s");
+    expect(formatEta(45_000)).toBe("45s");
+    expect(formatEta(90_000)).toBe("1m 30s");
+    expect(formatEta(600_000)).toBe("10m");
+    expect(formatEta(4_500_000)).toBe("1h 15m");
   });
 });

--- a/src/hooks/useActionJob.ts
+++ b/src/hooks/useActionJob.ts
@@ -12,6 +12,32 @@ export interface ActionJobState {
   progress: number;
   error: string | null;
   label: string | null;
+  /** ms remaining, projected from elapsed time and current progress. null until the projection is stable. */
+  etaMs: number | null;
+}
+
+const MIN_PROGRESS_FOR_ETA = 0.05
+const MIN_ELAPSED_MS_FOR_ETA = 1500
+
+export function projectEtaMs(progress: number, elapsedMs: number): number | null {
+  if (!Number.isFinite(progress) || !Number.isFinite(elapsedMs)) return null
+  if (progress < MIN_PROGRESS_FOR_ETA) return null
+  if (elapsedMs < MIN_ELAPSED_MS_FOR_ETA) return null
+  if (progress >= 1) return 0
+  const remaining = (elapsedMs / progress) * (1 - progress)
+  if (!Number.isFinite(remaining) || remaining < 0) return null
+  return Math.round(remaining)
+}
+
+export function formatEta(ms: number): string {
+  if (ms < 1000) return "<1s"
+  const totalSeconds = Math.round(ms / 1000)
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 60) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${minutes % 60}m`
 }
 
 export interface ActionJobConfig {
@@ -34,6 +60,7 @@ const IDLE_STATE: ActionJobState = {
   progress: 0,
   error: null,
   label: null,
+  etaMs: null,
 };
 
 function toErrorMessage(error: unknown, fallback: string): string {
@@ -74,6 +101,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
   const jobIdRef = useRef<string | null>(null);
   const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeRunIdRef = useRef(0);
+  const startedAtRef = useRef<number | null>(null);
 
   const setStateIfMounted = useCallback((nextState: SetStateAction<ActionJobState>) => {
     if (!mountedRef.current) {
@@ -138,6 +166,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
             progress,
             error: toErrorMessage(error, `${config.label} follow-up failed`),
             label: config.label,
+            etaMs: null,
           });
           return;
         }
@@ -151,6 +180,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
           progress: 1,
           error: null,
           label: config.label,
+          etaMs: 0,
         });
 
         if (config.autoDismissMs !== 0) {
@@ -170,14 +200,18 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
           progress,
           error: poll.message ?? poll.error ?? "Job failed",
           label: config.label,
+          etaMs: null,
         });
         return;
       }
 
+      const elapsed = startedAtRef.current === null ? 0 : Date.now() - startedAtRef.current;
+      const etaMs = projectEtaMs(progress, elapsed);
       setStateIfMounted((prev) => ({
         ...prev,
         status: "running",
         progress,
+        etaMs,
       }));
     } catch (error) {
       if (activeRunIdRef.current !== runId) {
@@ -189,6 +223,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
         progress: 0,
         error: toErrorMessage(error, "Job polling failed"),
         label: config.label,
+        etaMs: null,
       });
     } finally {
       pollInFlightRef.current = false;
@@ -205,7 +240,8 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
 
     startInFlightRef.current = true;
     stopPolling();
-    setStateIfMounted({ status: "running", progress: 0, error: null, label: config.label });
+    startedAtRef.current = Date.now();
+    setStateIfMounted({ status: "running", progress: 0, error: null, label: config.label, etaMs: null });
 
     try {
       const job = await config.start();
@@ -232,6 +268,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
         progress: 0,
         error: toErrorMessage(error, "Job start failed"),
         label: config.label,
+        etaMs: null,
       });
     } finally {
       if (activeRunIdRef.current === runId) {

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -112,7 +112,7 @@ export function useChatSession(): UseChatSessionResult {
                 ) {
                   resolve(extractAssistantContent(status.result))
                 } else if (status.status === "error") {
-                  reject(new Error(status.error ?? status.result ?? "Chat error"))
+                  reject(new Error(status.error ?? extractAssistantContent(status.result) ?? "Chat error"))
                 } else if (polls >= MAX_POLLS) {
                   reject(new Error("Chat timed out"))
                 } else {


### PR DESCRIPTION
## What this adds

Progress bars previously reported only a percentage. Now they also show a **projected time remaining**:

\`\`\`
↻ Importing speakers  [████░░░░░░] 40% · ~22s left
Running… 60% · ~1m 15s left
\`\`\`

Wired into the two most visible surfaces: the topbar active-jobs row ([ParseUI.tsx:1714](src/ParseUI.tsx:1714), used by STT / IPA / compute / normalize) and the inline compute status under the Run button. Other progress-bar consumers (SpeakerImport, ContactLexeme) are unchanged for now — separate wiring work, easy to do later by reading the new \`state.etaMs\` field from \`useActionJob\`.

## How the projection works

\`projectEtaMs(progress, elapsedMs)\` returns:

- **null** if progress < 5% — avoids noisy near-zero divisions
- **null** if elapsed < 1.5s — avoids wild early estimates before the work hits steady-state
- **0** when progress reaches 1
- otherwise **(elapsed / progress) × (1 − progress)**, rounded to ms

\`formatEta(ms)\` renders compact units: \`<1s\`, \`45s\`, \`1m 30s\`, \`1h 15m\`.

\`useActionJob\` holds a \`startedAtRef\` and recomputes \`etaMs\` on every poll; the consumer reads it from \`state.etaMs\`. Complete / error / idle states set \`etaMs\` to \`0\` / \`null\` as appropriate.

## Piggybacking a tsc fix

While validating, TypeScript flagged a pre-existing error in \`useChatSession.ts:115\` — after PR #68 widened \`ChatStatus.result\` to \`string | Record<string, unknown>\`, the chat-error path still did \`status.error ?? status.result ?? \"Chat error\"\`, which the Error constructor rejected. Routed through the existing \`extractAssistantContent\` helper (one-line change). This overlaps with PR [#69](https://github.com/ArdeleanLucas/PARSE/pull/69) which applied the same fix; whichever merges first, the other will have a trivial conflict on that line.

## Test plan

| Check | Result |
|---|---|
| \`vitest run src/hooks/__tests__/useActionJob.test.ts\` | **16 passed** — 3 updated for new \`etaMs\` field + 5 new projection/format tests |
| \`vitest run\` (full) | **151 passed** |
| \`tsc --noEmit\` | clean |
| Live preview | \`formatEta\` / \`projectEtaMs\` exported correctly; in-browser module import confirms samples (\`<1s\`, \`3s\`, \`1m 30s\`, \`null\` under threshold, \`15000ms\` for 0.25 at 5s) |

## Tradeoff the user should know

Projection is linear — if the backend work has a ramp (e.g. STT gets faster once buffers warm, or slower at the tail), the ETA will lag reality. The thresholds (5% / 1.5s) soften early jitter but don't compensate for non-linear rates. Good enough for "is this going to be ~10 more seconds or ~10 more minutes"; not a guarantee. If we want tighter estimates, we could exponentially-smooth the rate — follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)