### PR TITLE
feat(scripts): parse-run survives diverged main via rebase-autostash fallback

### DIFF
--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -15,6 +15,15 @@
 #   PARSE_API_PORT   API server port (default: 8766)
 #   PARSE_VITE_PORT  Vite dev server port (default: 5173)
 #   PARSE_SKIP_PULL  Set to 1 to skip `git pull` (default: 0)
+#   PARSE_PULL_MODE  How to integrate origin/main (default: "auto")
+#                      auto   — try fast-forward; on divergence fall back
+#                               to `rebase --autostash`; warn and continue
+#                               only if both fail
+#                      ff     — fast-forward only; warn and continue on
+#                               divergence (previous behavior)
+#                      rebase — always `rebase --autostash`
+#                      reset  — hard-reset local main to origin/main
+#                               (destructive — drops local commits)
 #
 # WSL + Windows python.exe note
 # -----------------------------
@@ -34,6 +43,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${PARSE_API_PORT:=8766}"
 : "${PARSE_VITE_PORT:=5173}"
 : "${PARSE_SKIP_PULL:=0}"
+: "${PARSE_PULL_MODE:=auto}"
 
 API_STDOUT_LOG="/tmp/parse_api_stdout.log"
 API_STDERR_LOG="/tmp/parse_api_stderr.log"
@@ -119,7 +129,7 @@ pull_main() {
     log "PARSE_SKIP_PULL=1 — skipping git pull"
     return 0
   fi
-  log "Pulling latest main..."
+  log "Pulling latest main (mode: ${PARSE_PULL_MODE})..."
   (
     cd "${PARSE_ROOT}" || return 1
     # Only stash if there are actual modifications — avoids empty-stash churn.
@@ -127,14 +137,49 @@ pull_main() {
     if ! git diff --quiet || ! git diff --cached --quiet; then
       git stash push -q -m "parse-run autostash $(date +%Y-%m-%d_%H:%M:%S)" && stashed=1
     fi
-    if git pull origin main --ff-only; then
-      [ "${stashed}" = "1" ] && git stash pop -q 2>/dev/null || true
-      return 0
-    else
-      log "WARNING: git pull failed — running on current checkout"
-      [ "${stashed}" = "1" ] && git stash pop -q 2>/dev/null || true
-      return 0
-    fi
+    local pop=0
+    [ "${stashed}" = "1" ] && pop=1
+
+    # Always fetch so the chosen strategy has a current view of origin/main.
+    git fetch origin main --quiet 2>/dev/null || true
+
+    case "${PARSE_PULL_MODE}" in
+      reset)
+        if git reset --hard origin/main; then
+          log "Local main reset to origin/main (destructive)"
+          [ "${pop}" = "1" ] && git stash pop -q 2>/dev/null || true
+          return 0
+        fi
+        ;;
+      rebase)
+        if git pull origin main --rebase --autostash; then
+          [ "${pop}" = "1" ] && git stash pop -q 2>/dev/null || true
+          return 0
+        fi
+        ;;
+      ff)
+        if git pull origin main --ff-only; then
+          [ "${pop}" = "1" ] && git stash pop -q 2>/dev/null || true
+          return 0
+        fi
+        ;;
+      auto|*)
+        if git pull origin main --ff-only 2>/dev/null; then
+          [ "${pop}" = "1" ] && git stash pop -q 2>/dev/null || true
+          return 0
+        fi
+        log "Fast-forward not possible — trying rebase --autostash"
+        if git pull origin main --rebase --autostash; then
+          [ "${pop}" = "1" ] && git stash pop -q 2>/dev/null || true
+          return 0
+        fi
+        log "Rebase also failed — inspect local commits or set PARSE_PULL_MODE=reset"
+        ;;
+    esac
+
+    log "WARNING: git pull failed — running on current checkout"
+    [ "${pop}" = "1" ] && git stash pop -q 2>/dev/null || true
+    return 0
   )
 }
 


### PR DESCRIPTION
## Context

Notes: [scripts/parse-run.sh](scripts/parse-run.sh) already existed (214-line WSL-aware launcher), so this PR *hardens* it rather than adding it from scratch.

One user (Lucas, on WSL) recently hit \"Not possible to fast-forward, aborting\" when running their hand-rolled \`~/.bash_aliases\` launcher after #71 and #72 merged — their local main had drifted from origin. The repo's own \`scripts/parse-run.sh\` had the same failure mode: it called \`git pull origin main --ff-only\` and, on divergence, logged a warning and continued on the stale checkout. Quiet failure, launcher keeps running, nothing visibly broken until the next time something depends on the latest main.

## What changes

Adds \`PARSE_PULL_MODE\` with four settings, defaulting to a new resilient \`auto\`:

| mode | behavior |
|---|---|
| **auto** (new default) | try \`--ff-only\`; on divergence fall back to \`--rebase --autostash\`; only warn on total failure |
| ff | previous behavior — fast-forward only, warn on divergence |
| rebase | always \`rebase --autostash\` |
| reset | hard-reset local main to \`origin/main\` — destructive, drops local commits; intended for launchers that never expect local work |

Also adds a \`git fetch origin main\` before the mode dispatch so every strategy has a current view of origin.

## Why default to auto

The common user scenario (small local commits on top of main — e.g. a WIP on a branch, accidental commits, squash-merge history that looks divergent to the local fast-forward check) is now handled without user intervention. Users who specifically want the old strict behavior can set \`PARSE_PULL_MODE=ff\`.

## Verification

Synthesized two diverged-repo scenarios (local has an extra commit, origin has an extra commit):

**auto mode:**
\`\`\`
[parse-run] Pulling latest main (mode: auto)...
[parse-run] Fast-forward not possible — trying rebase --autostash
Rebasing (1/1) Successfully rebased and updated refs/heads/main.
\`\`\`
Local commit preserved on top of origin's new commit ✓

**reset mode:**
\`\`\`
[parse-run] Pulling latest main (mode: reset)...
HEAD is now at f817818 origin-2
[parse-run] Local main reset to origin/main (destructive)
\`\`\`
Local main snaps to origin exactly ✓

\`bash -n scripts/parse-run.sh\` clean.

## What this enables for the user

They can replace their \`~/.bash_aliases\` launcher with:

\`\`\`bash
alias parse-run='\"\$HOME/gh/ardeleanlucas/parse/scripts/parse-run.sh\"'
\`\`\`

and get divergence-tolerant \`git pull\` for free, plus the WSL-side \`taskkill.exe\` handling for zombie \`python.exe\` processes the repo script already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)