### PR TITLE
fix(auth): Codex device-flow never completed — restore pollAuth driver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ All `src/api/client.ts` helpers have matching routes in `python/server.py`:
 | `updateConfig()` | `PUT /api/config` | ✅ |
 | `getAuthStatus()` | `GET /api/auth/status` | ✅ |
 | `startAuthFlow()` | `POST /api/auth/start` | ✅ |
-| ~~`pollAuth()`~~ | `POST /api/auth/poll` | ✅ (server route exists; client helper removed — use `getAuthStatus()`) |
+| `pollAuth()` | `POST /api/auth/poll` | ✅ (required to drive Codex device-token exchange; `getAuthStatus` only reads cached state) |
 | `saveApiKey()` | `POST /api/auth/key` | ✅ |
 | `logoutAuth()` | `POST /api/auth/logout` | ✅ |
 | `startSTT()` | `POST /api/stt` | ✅ |

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -149,6 +149,25 @@ export async function startAuthFlow(): Promise<void> {
   await apiFetch<void>("/api/auth/start", { method: "POST" });
 }
 
+export interface AuthPollResult {
+  status: "pending" | "complete" | "expired" | "error";
+  error?: string;
+}
+
+export async function pollAuth(): Promise<AuthPollResult> {
+  const payload = await apiFetch<unknown>("/api/auth/poll", { method: "POST" });
+  if (payload && typeof payload === "object") {
+    const p = payload as Record<string, unknown>;
+    const status = typeof p.status === "string" ? p.status : "pending";
+    const normalized: AuthPollResult["status"] =
+      status === "complete" || status === "expired" || status === "error" ? status : "pending";
+    const result: AuthPollResult = { status: normalized };
+    if (typeof p.error === "string" && p.error) result.error = p.error;
+    return result;
+  }
+  return { status: "pending" };
+}
+
 export async function saveApiKey(key: string, provider: string): Promise<AuthStatus> {
   return apiFetch<AuthStatus>("/api/auth/key", {
     method: "POST",

--- a/src/components/annotate/ChatPanel.tsx
+++ b/src/components/annotate/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react"
 import { useChatSession } from "../../hooks/useChatSession"
 import type { ChatMessage } from "../../hooks/useChatSession"
-import { getAuthStatus, startAuthFlow, saveApiKey, logoutAuth } from "../../api/client"
+import { getAuthStatus, startAuthFlow, pollAuth, saveApiKey, logoutAuth } from "../../api/client"
 import type { AuthStatus } from "../../api/types"
 import { ContextRing } from "../shared/ContextRing"
 
@@ -88,14 +88,25 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
       }
       pollRef.current = setInterval(async () => {
         try {
-          const s = await getAuthStatus()
-          if (s.authenticated) {
+          // pollAuth drives the actual OpenAI device-token exchange.
+          // getAuthStatus alone only reads cached server state, so without
+          // this call _auth_state.status stays "pending" forever.
+          const result = await pollAuth()
+          if (result.status === "complete") {
             if (pollRef.current) clearInterval(pollRef.current)
             pollRef.current = null
             setAuthState("authenticated")
+            return
+          }
+          if (result.status === "expired" || result.status === "error") {
+            if (pollRef.current) clearInterval(pollRef.current)
+            pollRef.current = null
+            setAuthState("unauthenticated")
+            setAuthError(result.error ?? (result.status === "expired" ? "Login code expired — try again" : "OAuth failed"))
+            setOauthInfo({})
           }
         } catch {
-          // keep polling
+          // keep polling — transient network failures shouldn't abort the flow
         }
       }, 5000)
     } catch (err) {


### PR DESCRIPTION
## Symptom

User reported signing in successfully at \`auth.openai.com/codex/device\` (entered the code, got \"Connected\"), but the PARSE UI stayed on \"Waiting for confirmation…\" until the device code expired.

## Root cause

Commit \`21ff2a0\` \"[MC-313] chore: remove dead pollAuth helper and mock (audit cleanup)\" removed the \`pollAuth()\` client helper. The AGENTS.md table was updated to say \"server route exists; client helper removed — use \`getAuthStatus()\`\" — but that substitution **doesn't actually work**:

- \`get_auth_status()\` ([python/ai/openai_auth.py:308](python/ai/openai_auth.py:308)) reads \`_auth_state\` — it's a **passive** status check.
- \`poll_device_auth()\` ([python/ai/openai_auth.py:215](python/ai/openai_auth.py:215)) is what actually hits OpenAI's \`/token\` endpoint to ask \"has the user approved yet?\" and transitions \`_auth_state.status\` from \`\"pending\"\` → \`\"complete\"\`.

With the helper removed, the frontend's 5s polling loop ([ChatPanel.tsx handleStartOAuth](src/components/annotate/ChatPanel.tsx)) only called \`getAuthStatus()\`. Nothing ever called \`poll_device_auth()\`, so \`_auth_state.status\` stayed \`\"pending\"\` forever. The login link worked, OpenAI was ready to hand over a token, but PARSE never asked for it.

## Changes

- [**src/api/client.ts**](src/api/client.ts) — re-adds \`pollAuth()\` hitting \`POST /api/auth/poll\`. Typed \`AuthPollResult\` with normalized \`status: \"pending\" | \"complete\" | \"expired\" | \"error\"\`.
- [**src/components/annotate/ChatPanel.tsx**](src/components/annotate/ChatPanel.tsx) — \`handleStartOAuth\`'s \`setInterval\` now calls \`pollAuth()\`. On \`complete\` → authenticated. On \`expired\` / \`error\` → back to unauthenticated with an actionable message. Transient network errors swallowed so the loop keeps trying.
- [**AGENTS.md**](AGENTS.md) — remove the misleading \"dead helper\" note.

## Verification

| Check | Result |
|---|---|
| \`tsc --noEmit\` | clean |
| \`vitest run src/api/client.test.ts src/components/annotate/ChatPanel.test.tsx\` | **6 passed** |
| Live backend: \`POST /api/auth/poll\` without an active flow | returns \`{status: \"error\", error: \"No active auth flow…\"}\` (expected — error branch clears interval + shows message) |
| Browser-side import of \`pollAuth\` | exports correctly, hits \`/api/auth/poll\`, returns normalized shape |

## Follow-ups

- Might be worth a tiny test that simulates the \"pending → complete\" transition (mock \`pollAuth\` mock-resolve sequence, assert \`setAuthState(\"authenticated\")\` fires). Left as a follow-up since the handler path is shallow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)