### PR TITLE
feat: MCP server adapter — expose ParseChatTools for third-party agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ python/
   adapters/
     mcp_adapter.py      -- MCP server adapter (exposes ParseChatTools over stdio MCP)
   ai/                   -- AI provider layer
-    chat_tools.py       -- ParseChatTools — AI assistant tool interface (10 tools)
+    chat_tools.py       -- ParseChatTools — AI assistant tool interface (11 tools)
     chat_orchestrator.py-- Chat session management
     stt_pipeline.py     -- Whisper STT pipeline
     ipa_transcribe.py   -- IPA via wav2vec2 + epitran
@@ -382,7 +382,7 @@ All tools from `ParseChatTools` are available over MCP with the same semantics a
 | `cognate_compute_preview` | Compute cognate/similarity preview from annotations (read-only) |
 | `cross_speaker_match_preview` | Cross-speaker match candidates from STT output |
 | `spectrogram_preview` | Spectrogram preview for a time-bounded segment |
-| `contact_lexeme_lookup` | Fetch reference forms from third-party sources (CLDF, ASJP, Wikidata, etc.) |
+| `contact_lexeme_lookup` | Preview reference forms from third-party sources (CLDF, ASJP, Wikidata, etc.); read-only — does not write to sil_contact_languages.json |
 | `stt_start` | Start STT background job on an audio file |
 | `stt_status` | Poll status/progress of an STT job |
 | `import_tag_csv` | Import a CSV file as a custom tag list (dry-run first) |

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ src/
                            enrichmentStore, playbackStore, tagStore, uiStore)
 python/
   server.py             -- Backend API server + built-frontend static serving (port 8766)
+  adapters/
+    mcp_adapter.py      -- MCP server adapter (exposes ParseChatTools over stdio MCP)
   ai/                   -- AI provider layer
     chat_tools.py       -- ParseChatTools — AI assistant tool interface (10 tools)
     chat_orchestrator.py-- Chat session management
@@ -337,6 +339,56 @@ The AI chat assistant uses `ParseChatTools` (`python/ai/chat_tools.py`) as its p
 |---|---|
 | `prepare_tag_import` | Validate and preview a tag CSV before import |
 | `import_tag_csv` | Import tags from a prepared CSV file |
+
+---
+
+## MCP Server Mode
+
+PARSE can run as an **MCP (Model Context Protocol) server**, exposing all of its AI chat tools over the standard MCP protocol. This lets third-party agents — Claude Code, Cursor, Codex, Windsurf, or any MCP-compatible client — call PARSE tools programmatically without going through the browser UI.
+
+```bash
+python python/adapters/mcp_adapter.py                          # auto-detect project root
+python python/adapters/mcp_adapter.py --project-root /path/to  # explicit root
+python python/adapters/mcp_adapter.py --verbose                # debug logging
+```
+
+### Client Configuration
+
+Add PARSE as an MCP server in your client config. Example for Claude Desktop (`claude_desktop_config.json`):
+
+```json
+{
+    "mcpServers": {
+        "parse": {
+            "command": "python",
+            "args": ["/path/to/parse/python/adapters/mcp_adapter.py"],
+            "env": {
+                "PARSE_PROJECT_ROOT": "/path/to/your/parse/project"
+            }
+        }
+    }
+}
+```
+
+### Exposed Tools
+
+All tools from `ParseChatTools` are available over MCP with the same semantics as the built-in AI chat dock:
+
+| Tool | Description |
+|---|---|
+| `project_context_read` | Project metadata, source index, annotation inventory, enrichments summary |
+| `annotation_read` | Read speaker annotation data with optional concept/tier filtering |
+| `read_csv_preview` | Preview CSV files (columns, row count, sample rows) |
+| `cognate_compute_preview` | Compute cognate/similarity preview from annotations (read-only) |
+| `cross_speaker_match_preview` | Cross-speaker match candidates from STT output |
+| `spectrogram_preview` | Spectrogram preview for a time-bounded segment |
+| `contact_lexeme_lookup` | Fetch reference forms from third-party sources (CLDF, ASJP, Wikidata, etc.) |
+| `stt_start` | Start STT background job on an audio file |
+| `stt_status` | Poll status/progress of an STT job |
+| `import_tag_csv` | Import a CSV file as a custom tag list (dry-run first) |
+| `prepare_tag_import` | Create/update a tag with concept IDs (dry-run first) |
+
+> **Requires:** `pip install 'mcp[cli]'`
 
 ---
 

--- a/python/adapters/__init__.py
+++ b/python/adapters/__init__.py
@@ -1,0 +1,1 @@
+# PARSE adapters package

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -107,13 +107,10 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         ),
     )
 
-    # Available tool names from the current ParseChatTools instance
-    _available_tools = set(tools.tool_names())
-
     # -- Register each ParseChatTools tool as an MCP tool --------------------
-    # Tools are registered unconditionally; the execute() call validates names
-    # at runtime, so if a tool isn't in the current ParseChatTools build it
-    # returns a clear validation error rather than a silent failure.
+    # The cross-check test in python/adapters/test_mcp_adapter.py enforces
+    # that every @mcp.tool() below maps to a name in tools.tool_names(), so
+    # phantom registrations fail in CI rather than at runtime.
 
     @mcp.tool()
     def project_context_read(
@@ -281,16 +278,21 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         languages: Optional[list] = None,
         conceptIds: Optional[list] = None,
         providers: Optional[list] = None,
-        overwrite: Optional[bool] = None,
+        maxConcepts: Optional[int] = None,
     ) -> str:
-        """Fetch reference forms (IPA) for contact/comparison languages from third-party sources.
-        Results are merged into sil_contact_languages.json.
+        """Preview reference forms (IPA) for contact/comparison languages. Read-only —
+        returns fetched forms without writing to sil_contact_languages.json. To
+        persist results, run the contact-lexemes compute job from the Compare UI.
 
         Args:
-            languages: ISO 639 language codes, e.g. ["ar", "fa", "ckb"]
-            conceptIds: Project concept IDs or English labels to look up (defaults to all)
-            providers: Provider priority order (csv_override, lingpy_wordlist, pycldf, pylexibank, asjp, cldf, wikidata, wiktionary, grokipedia, literature)
-            overwrite: If true, re-fetch even if forms already exist
+            languages: ISO 639 language codes registered in sil_contact_languages.json
+                (e.g. ["ar", "fa", "ckb"]). Defaults to all configured languages.
+            conceptIds: Concept labels matching the concept_en column in concepts.csv.
+                Defaults to all concepts.
+            providers: Provider priority order (csv_override, lingpy_wordlist, pycldf,
+                pylexibank, asjp, cldf, wikidata, wiktionary, grokipedia, literature).
+            maxConcepts: Cap on concepts processed this call (1–200). Prevents runaway
+                fetches for sessions that only want a small sample.
         """
         args: Dict[str, Any] = {}
         if languages is not None:
@@ -299,8 +301,8 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             args["conceptIds"] = conceptIds
         if providers is not None:
             args["providers"] = providers
-        if overwrite is not None:
-            args["overwrite"] = overwrite
+        if maxConcepts is not None:
+            args["maxConcepts"] = maxConcepts
         result = tools.execute("contact_lexeme_lookup", args)
         return json.dumps(result, indent=2, ensure_ascii=False)
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""PARSE MCP Server — expose ParseChatTools as MCP tools for third-party agents.
+
+Starts a stdio MCP server that lets any MCP client (Claude Code, Cursor, Codex,
+Windsurf, etc.) call PARSE's linguistic analysis tools programmatically.
+
+Tools exposed (11):
+  project_context_read, annotation_read, read_csv_preview,
+  cognate_compute_preview, cross_speaker_match_preview, spectrogram_preview,
+  contact_lexeme_lookup, stt_start, stt_status,
+  import_tag_csv, prepare_tag_import
+
+Usage:
+    python python/adapters/mcp_adapter.py
+    python python/adapters/mcp_adapter.py --project-root /path/to/project
+    python python/adapters/mcp_adapter.py --verbose
+
+MCP client config (e.g. claude_desktop_config.json):
+    {
+        "mcpServers": {
+            "parse": {
+                "command": "python",
+                "args": ["python/adapters/mcp_adapter.py"],
+                "env": {
+                    "PARSE_PROJECT_ROOT": "/path/to/your/parse/project"
+                }
+            }
+        }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("parse.mcp_adapter")
+
+# ---------------------------------------------------------------------------
+# Ensure the python/ package is importable
+# ---------------------------------------------------------------------------
+
+_ADAPTER_DIR = Path(__file__).resolve().parent
+_PYTHON_DIR = _ADAPTER_DIR.parent
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+# ---------------------------------------------------------------------------
+# Lazy MCP SDK import
+# ---------------------------------------------------------------------------
+
+_MCP_AVAILABLE = False
+try:
+    from mcp.server.fastmcp import FastMCP
+    _MCP_AVAILABLE = True
+except ImportError:
+    FastMCP = None  # type: ignore[assignment,misc]
+
+
+# ---------------------------------------------------------------------------
+# Server creation
+# ---------------------------------------------------------------------------
+
+def _resolve_project_root(cli_root: Optional[str] = None) -> Path:
+    """Resolve PARSE project root from CLI arg, env var, or cwd."""
+    if cli_root:
+        return Path(cli_root).expanduser().resolve()
+    env_root = os.environ.get("PARSE_PROJECT_ROOT")
+    if env_root:
+        return Path(env_root).expanduser().resolve()
+    # Fallback: assume the repo root is 2 levels up from this file
+    candidate = _ADAPTER_DIR.parent.parent
+    if (candidate / "python" / "ai" / "chat_tools.py").exists():
+        return candidate
+    return Path.cwd()
+
+
+def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
+    """Create and return the PARSE MCP server with all tools registered.
+
+    Wraps ParseChatTools so every tool available to the built-in AI chat
+    is also available over MCP for third-party agents.
+    """
+    if not _MCP_AVAILABLE:
+        raise ImportError(
+            "MCP server requires the 'mcp' package. "
+            "Install with: pip install 'mcp[cli]'"
+        )
+
+    from ai.chat_tools import ParseChatTools
+
+    root = _resolve_project_root(project_root)
+    logger.info("PARSE MCP server starting with project root: %s", root)
+
+    tools = ParseChatTools(project_root=root)
+
+    mcp = FastMCP(
+        "parse",
+        instructions=(
+            "PARSE — Phonetic Analysis & Review Source Explorer. "
+            "Linguistic fieldwork tools for annotation, cross-speaker comparison, "
+            "cognate analysis, STT pipeline control, and contact-language lookup."
+        ),
+    )
+
+    # Available tool names from the current ParseChatTools instance
+    _available_tools = set(tools.tool_names())
+
+    # -- Register each ParseChatTools tool as an MCP tool --------------------
+    # Tools are registered unconditionally; the execute() call validates names
+    # at runtime, so if a tool isn't in the current ParseChatTools build it
+    # returns a clear validation error rather than a silent failure.
+
+    @mcp.tool()
+    def project_context_read(
+        include: Optional[list] = None,
+        maxSpeakers: Optional[int] = None,
+    ) -> str:
+        """Read high-level PARSE project context (project metadata, source index summary,
+        annotation inventory, and enrichment summary). Read-only.
+
+        Args:
+            include: Sections to include (project, source_index, annotation_inventory, enrichments_summary, ai_config, constraints)
+            maxSpeakers: Maximum number of speakers to include in summaries
+        """
+        args: Dict[str, Any] = {}
+        if include is not None:
+            args["include"] = include
+        if maxSpeakers is not None:
+            args["maxSpeakers"] = maxSpeakers
+        result = tools.execute("project_context_read", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def annotation_read(
+        speaker: str,
+        conceptIds: Optional[list] = None,
+        includeTiers: Optional[list] = None,
+        maxIntervals: Optional[int] = None,
+    ) -> str:
+        """Read one speaker's annotation data with optional concept/tier filtering. Read-only.
+
+        Args:
+            speaker: Speaker name (filename stem from annotations/)
+            conceptIds: Filter to specific concept IDs
+            includeTiers: Filter to specific tiers (ipa, ortho, concept, speaker)
+            maxIntervals: Maximum number of intervals to return
+        """
+        args: Dict[str, Any] = {"speaker": speaker}
+        if conceptIds is not None:
+            args["conceptIds"] = conceptIds
+        if includeTiers is not None:
+            args["includeTiers"] = includeTiers
+        if maxIntervals is not None:
+            args["maxIntervals"] = maxIntervals
+        result = tools.execute("annotation_read", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def read_csv_preview(
+        csvPath: Optional[str] = None,
+        maxRows: Optional[int] = None,
+    ) -> str:
+        """Read first N rows of a CSV file. Defaults to concepts.csv. Read-only.
+
+        Args:
+            csvPath: Path to CSV file (relative to project root, or absolute)
+            maxRows: Maximum rows to return (default 20, max 200)
+        """
+        args: Dict[str, Any] = {}
+        if csvPath is not None:
+            args["csvPath"] = csvPath
+        if maxRows is not None:
+            args["maxRows"] = maxRows
+        result = tools.execute("read_csv_preview", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def cognate_compute_preview(
+        speakers: Optional[list] = None,
+        conceptIds: Optional[list] = None,
+        threshold: Optional[float] = None,
+        contactLanguages: Optional[list] = None,
+        includeSimilarity: Optional[bool] = None,
+        maxConcepts: Optional[int] = None,
+    ) -> str:
+        """Compute a read-only cognate/similarity preview from annotations.
+        Does not write parse-enrichments.json.
+
+        Args:
+            speakers: Filter to specific speakers
+            conceptIds: Filter to specific concept IDs
+            threshold: Similarity threshold (0.01–2.0)
+            contactLanguages: ISO 639 codes for contact languages to compare against
+            includeSimilarity: Include pairwise similarity scores
+            maxConcepts: Maximum concepts to process
+        """
+        args: Dict[str, Any] = {}
+        if speakers is not None:
+            args["speakers"] = speakers
+        if conceptIds is not None:
+            args["conceptIds"] = conceptIds
+        if threshold is not None:
+            args["threshold"] = threshold
+        if contactLanguages is not None:
+            args["contactLanguages"] = contactLanguages
+        if includeSimilarity is not None:
+            args["includeSimilarity"] = includeSimilarity
+        if maxConcepts is not None:
+            args["maxConcepts"] = maxConcepts
+        result = tools.execute("cognate_compute_preview", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def cross_speaker_match_preview(
+        speaker: Optional[str] = None,
+        sttJobId: Optional[str] = None,
+        sttSegments: Optional[list] = None,
+        topK: Optional[int] = None,
+        minConfidence: Optional[float] = None,
+        maxConcepts: Optional[int] = None,
+    ) -> str:
+        """Compute read-only cross-speaker match candidates from STT output
+        and existing annotations.
+
+        Args:
+            speaker: Target speaker to find matches for
+            sttJobId: ID of a completed STT job to use as input
+            sttSegments: Inline STT segments (alternative to sttJobId)
+            topK: Number of top candidates per concept (1–20)
+            minConfidence: Minimum confidence threshold (0.0–1.0)
+            maxConcepts: Maximum concepts to process
+        """
+        args: Dict[str, Any] = {}
+        if speaker is not None:
+            args["speaker"] = speaker
+        if sttJobId is not None:
+            args["sttJobId"] = sttJobId
+        if sttSegments is not None:
+            args["sttSegments"] = sttSegments
+        if topK is not None:
+            args["topK"] = topK
+        if minConfidence is not None:
+            args["minConfidence"] = minConfidence
+        if maxConcepts is not None:
+            args["maxConcepts"] = maxConcepts
+        result = tools.execute("cross_speaker_match_preview", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def spectrogram_preview(
+        sourceWav: str,
+        startSec: float,
+        endSec: float,
+        windowSize: Optional[int] = None,
+    ) -> str:
+        """Generate spectrogram preview for a segment. Read-only.
+
+        Args:
+            sourceWav: Path to the source WAV file
+            startSec: Start time in seconds
+            endSec: End time in seconds
+            windowSize: FFT window size (256, 512, 1024, 2048, or 4096)
+        """
+        args: Dict[str, Any] = {
+            "sourceWav": sourceWav,
+            "startSec": startSec,
+            "endSec": endSec,
+        }
+        if windowSize is not None:
+            args["windowSize"] = windowSize
+        result = tools.execute("spectrogram_preview", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def contact_lexeme_lookup(
+        languages: Optional[list] = None,
+        conceptIds: Optional[list] = None,
+        providers: Optional[list] = None,
+        overwrite: Optional[bool] = None,
+    ) -> str:
+        """Fetch reference forms (IPA) for contact/comparison languages from third-party sources.
+        Results are merged into sil_contact_languages.json.
+
+        Args:
+            languages: ISO 639 language codes, e.g. ["ar", "fa", "ckb"]
+            conceptIds: Project concept IDs or English labels to look up (defaults to all)
+            providers: Provider priority order (csv_override, lingpy_wordlist, pycldf, pylexibank, asjp, cldf, wikidata, wiktionary, grokipedia, literature)
+            overwrite: If true, re-fetch even if forms already exist
+        """
+        args: Dict[str, Any] = {}
+        if languages is not None:
+            args["languages"] = languages
+        if conceptIds is not None:
+            args["conceptIds"] = conceptIds
+        if providers is not None:
+            args["providers"] = providers
+        if overwrite is not None:
+            args["overwrite"] = overwrite
+        result = tools.execute("contact_lexeme_lookup", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def stt_start(
+        speaker: str,
+        sourceWav: str,
+        language: Optional[str] = None,
+    ) -> str:
+        """Start a bounded STT background job for a project audio file.
+        Returns a jobId for polling with stt_status.
+
+        Args:
+            speaker: Speaker name
+            sourceWav: Path to source WAV file (relative to audio/)
+            language: Language code hint for the STT model
+        """
+        args: Dict[str, Any] = {"speaker": speaker, "sourceWav": sourceWav}
+        if language is not None:
+            args["language"] = language
+        result = tools.execute("stt_start", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def stt_status(
+        jobId: str,
+        includeSegments: Optional[bool] = None,
+        maxSegments: Optional[int] = None,
+    ) -> str:
+        """Read status/progress of an existing STT job.
+
+        Args:
+            jobId: The job ID returned by stt_start
+            includeSegments: Include transcribed segments in response
+            maxSegments: Maximum segments to return (1–300)
+        """
+        args: Dict[str, Any] = {"jobId": jobId}
+        if includeSegments is not None:
+            args["includeSegments"] = includeSegments
+        if maxSegments is not None:
+            args["maxSegments"] = maxSegments
+        result = tools.execute("stt_status", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def import_tag_csv(
+        dryRun: bool,
+        csvPath: Optional[str] = None,
+        tagName: Optional[str] = None,
+        color: Optional[str] = None,
+        labelColumn: Optional[str] = None,
+    ) -> str:
+        """Import a CSV file as a custom tag list. Use dryRun=true first to preview,
+        then dryRun=false after user confirmation.
+
+        Args:
+            dryRun: If true, returns preview without writing. Always use true first.
+            csvPath: Path to the CSV file
+            tagName: Name for the new tag
+            color: Hex color code (e.g. #FF0000)
+            labelColumn: Column name containing concept labels
+        """
+        args: Dict[str, Any] = {"dryRun": dryRun}
+        if csvPath is not None:
+            args["csvPath"] = csvPath
+        if tagName is not None:
+            args["tagName"] = tagName
+        if color is not None:
+            args["color"] = color
+        if labelColumn is not None:
+            args["labelColumn"] = labelColumn
+        result = tools.execute("import_tag_csv", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def prepare_tag_import(
+        tagName: str,
+        conceptIds: list,
+        dryRun: bool,
+        color: Optional[str] = None,
+    ) -> str:
+        """Create or update a tag with a list of concept IDs and write to parse-tags.json.
+        Use dryRun=true first to preview, then dryRun=false after user confirmation.
+
+        Args:
+            tagName: Name for the tag
+            conceptIds: List of concept IDs to assign to this tag
+            dryRun: If true, returns preview without writing
+            color: Hex color code (e.g. #FF0000)
+        """
+        args: Dict[str, Any] = {
+            "tagName": tagName,
+            "conceptIds": conceptIds,
+            "dryRun": dryRun,
+        }
+        if color is not None:
+            args["color"] = color
+        result = tools.execute("prepare_tag_import", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Start the PARSE MCP server on stdio."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="PARSE MCP Server")
+    parser.add_argument(
+        "--project-root",
+        default=None,
+        help="Path to PARSE project root (default: $PARSE_PROJECT_ROOT or auto-detect)",
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable debug logging on stderr",
+    )
+    args = parser.parse_args()
+
+    if not _MCP_AVAILABLE:
+        print(
+            "Error: MCP server requires the 'mcp' package.\n"
+            "Install with: pip install 'mcp[cli]'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+    else:
+        logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    server = create_mcp_server(project_root=args.project_root)
+
+    import asyncio
+
+    async def _run():
+        await server.run_stdio_async()
+
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -1,0 +1,61 @@
+"""Cross-check MCP tool registrations against ParseChatTools.
+
+Prevents phantom-tool regressions — the MCP adapter forwards every call
+through ParseChatTools.execute(), so registering an MCP tool that isn't
+in the allowlist produces a runtime ChatToolValidationError on the
+client side. A test at import time catches that before shipping.
+"""
+import pathlib
+import sys
+
+import pytest
+
+_HERE = pathlib.Path(__file__).resolve().parent
+_PYTHON_DIR = _HERE.parent
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+from ai.chat_tools import ParseChatTools
+
+
+def _has_mcp() -> bool:
+    try:
+        import mcp.server.fastmcp  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
+def test_every_mcp_tool_is_allowlisted_in_parse_chat_tools(tmp_path) -> None:
+    import asyncio
+
+    from adapters.mcp_adapter import create_mcp_server
+
+    # Minimal project root — the tools only need the path to exist; individual
+    # tool calls exercise filesystem paths but this test only lists tools.
+    server = create_mcp_server(str(tmp_path))
+    mcp_tools = asyncio.run(server.list_tools())
+    mcp_names = {t.name for t in mcp_tools}
+
+    chat_names = set(ParseChatTools(project_root=tmp_path).tool_names())
+
+    phantom = mcp_names - chat_names
+    assert not phantom, (
+        "MCP tools that are NOT in ParseChatTools.tool_names() will raise "
+        "ChatToolValidationError at runtime. Phantom tools: {0}".format(sorted(phantom))
+    )
+
+
+def test_contact_lexeme_lookup_is_allowlisted(tmp_path) -> None:
+    """contact_lexeme_lookup specifically — the bug that motivated this test."""
+    tools = ParseChatTools(project_root=tmp_path)
+    assert "contact_lexeme_lookup" in tools.tool_names()
+
+
+def test_contact_lexeme_lookup_is_read_only_via_schema(tmp_path) -> None:
+    """Tool should be schema-clean and not expose an 'overwrite' mutation lever."""
+    tools = ParseChatTools(project_root=tmp_path)
+    spec = tools._tool_specs["contact_lexeme_lookup"]
+    assert "overwrite" not in spec.parameters.get("properties", {})
+    assert spec.parameters.get("additionalProperties") is False

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -467,6 +467,51 @@ class ParseChatTools:
                     },
                 },
             ),
+            "contact_lexeme_lookup": ChatToolSpec(
+                name="contact_lexeme_lookup",
+                description=(
+                    "Preview reference forms (IPA) for contact/comparison languages from "
+                    "third-party providers (ASJP, Wiktionary, Wikidata, etc.). Read-only — "
+                    "returns fetched forms without writing to sil_contact_languages.json. "
+                    "Use the Compare UI's contact-lexeme fetch to persist results."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "languages": {
+                            "type": "array",
+                            "maxItems": 20,
+                            "items": {"type": "string", "minLength": 2, "maxLength": 16},
+                        },
+                        "conceptIds": {
+                            "type": "array",
+                            "maxItems": 200,
+                            "items": {"type": "string", "minLength": 1, "maxLength": 64},
+                        },
+                        "providers": {
+                            "type": "array",
+                            "maxItems": 10,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "csv_override",
+                                    "lingpy_wordlist",
+                                    "pycldf",
+                                    "pylexibank",
+                                    "asjp",
+                                    "cldf",
+                                    "wikidata",
+                                    "wiktionary",
+                                    "grokipedia",
+                                    "literature",
+                                ],
+                            },
+                        },
+                        "maxConcepts": {"type": "integer", "minimum": 1, "maximum": 200},
+                    },
+                },
+            ),
             "prepare_tag_import": ChatToolSpec(
                 name="prepare_tag_import",
                 description=(
@@ -1486,6 +1531,125 @@ class ParseChatTools:
             "conceptIds": concept_ids,
             "dryRun": False,
         })
+
+    def _tool_contact_lexeme_lookup(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Preview contact-language reference forms without writing to the sil config.
+
+        Calls the ProviderRegistry directly (not fetch_and_merge) so the filesystem
+        stays untouched — the caller gets a structured summary of what the
+        registered providers returned. To persist results, run the contact-lexemes
+        compute job from the Compare UI.
+        """
+        import csv as _csv
+        import json as _json
+
+        if not self.sil_config_path.exists():
+            return {
+                "ok": False,
+                "error": "sil_contact_languages.json not found at {0}".format(self.sil_config_path),
+            }
+
+        try:
+            with open(self.sil_config_path, encoding="utf-8") as f:
+                sil_config = _json.load(f)
+        except (OSError, _json.JSONDecodeError) as exc:
+            return {"ok": False, "error": "Failed to read sil config: {0}".format(exc)}
+
+        language_meta = {k: v for k, v in sil_config.items() if isinstance(v, dict)}
+        all_languages = [k for k in language_meta.keys() if "name" in language_meta[k]]
+
+        requested_langs_raw = args.get("languages")
+        if isinstance(requested_langs_raw, list) and requested_langs_raw:
+            requested_langs = [str(x).strip() for x in requested_langs_raw if str(x).strip()]
+            unknown = [lc for lc in requested_langs if lc not in language_meta]
+            if unknown:
+                return {
+                    "ok": False,
+                    "error": "Unknown language codes (not in sil config): {0}".format(", ".join(unknown)),
+                    "known": sorted(all_languages),
+                }
+            languages = requested_langs
+        else:
+            languages = all_languages
+
+        if not languages:
+            return {"ok": False, "error": "No languages available to look up"}
+
+        concepts_path = self.project_root / "concepts.csv"
+        if not concepts_path.exists():
+            return {"ok": False, "error": "concepts.csv not found at {0}".format(concepts_path)}
+
+        try:
+            with open(concepts_path, newline="", encoding="utf-8") as f:
+                reader = _csv.DictReader(f)
+                all_concepts = [
+                    (row.get("concept_en") or "").strip()
+                    for row in reader
+                    if (row.get("concept_en") or "").strip()
+                ]
+        except OSError as exc:
+            return {"ok": False, "error": "Failed to read concepts.csv: {0}".format(exc)}
+
+        requested_concepts_raw = args.get("conceptIds")
+        if isinstance(requested_concepts_raw, list) and requested_concepts_raw:
+            requested_concepts = {str(x).strip() for x in requested_concepts_raw if str(x).strip()}
+            # Match by English label or stripped ID — concepts.csv is keyed on concept_en
+            concepts_list = [c for c in all_concepts if c in requested_concepts]
+            if not concepts_list:
+                return {
+                    "ok": False,
+                    "error": "None of the requested conceptIds matched concepts.csv",
+                    "hint": "conceptIds must match the concept_en column; first 10 available: {0}".format(
+                        ", ".join(all_concepts[:10])
+                    ),
+                }
+        else:
+            concepts_list = list(all_concepts)
+
+        max_concepts = args.get("maxConcepts")
+        if isinstance(max_concepts, int) and max_concepts > 0:
+            concepts_list = concepts_list[:max_concepts]
+
+        providers_raw = args.get("providers")
+        priority_order: Optional[List[str]] = None
+        if isinstance(providers_raw, list) and providers_raw:
+            priority_order = [str(p).strip() for p in providers_raw if str(p).strip()]
+
+        ai_config_path = self.project_root / "config" / "ai_config.json"
+        try:
+            with open(ai_config_path, encoding="utf-8") as f:
+                ai_config = _json.load(f)
+        except (OSError, _json.JSONDecodeError):
+            ai_config = {}
+
+        from ..compare.providers.registry import ProviderRegistry, PROVIDER_PRIORITY
+
+        registry = ProviderRegistry(ai_config)
+        fetched = registry.fetch_all(
+            concepts=concepts_list,
+            language_codes=languages,
+            language_meta=language_meta,
+            priority_order=priority_order,
+        )
+
+        filled_counts = {
+            lc: sum(1 for forms in fetched.get(lc, {}).values() if forms)
+            for lc in languages
+        }
+
+        return {
+            "ok": True,
+            "languages": languages,
+            "concepts": concepts_list,
+            "conceptCount": len(concepts_list),
+            "providerOrderUsed": priority_order or list(PROVIDER_PRIORITY),
+            "filledCounts": filled_counts,
+            "forms": fetched,
+            "note": (
+                "Preview only — no writes to sil_contact_languages.json. "
+                "To persist these results, run the contact-lexemes compute job."
+            ),
+        }
 
     def _tool_prepare_tag_import(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Create or update a named tag with concept IDs in parse-tags.json."""


### PR DESCRIPTION
## Summary

Adds an MCP (Model Context Protocol) server adapter that wraps all ParseChatTools as MCP tools over stdio transport. Any MCP-compatible client can now call PARSE tools programmatically without going through the browser UI.

## New Files

- `python/adapters/__init__.py`
- `python/adapters/mcp_adapter.py` — MCP server (FastMCP, stdio transport)

## Tools Exposed (11)

| Tool | Type |
|------|------|
| `project_context_read` | read-only |
| `annotation_read` | read-only |
| `read_csv_preview` | read-only |
| `cognate_compute_preview` | read-only |
| `cross_speaker_match_preview` | read-only |
| `spectrogram_preview` | read-only |
| `contact_lexeme_lookup` | write-allowed |
| `stt_start` | job-trigger |
| `stt_status` | job-poll |
| `import_tag_csv` | write-allowed |
| `prepare_tag_import` | write-allowed |

## Usage

```bash
python python/adapters/mcp_adapter.py --project-root /path/to/project
```

Or configure in any MCP client (Claude Desktop, Cursor, etc.):
```json
{
    "mcpServers": {
        "parse": {
            "command": "python",
            "args": ["/path/to/parse/python/adapters/mcp_adapter.py"],
            "env": { "PARSE_PROJECT_ROOT": "/path/to/project" }
        }
    }
}
```

## Verification

```
$ python -c 'import sys,asyncio; sys.path.insert(0,"python"); from adapters.mcp_adapter import create_mcp_server; s=create_mcp_server("."); print(len(asyncio.run(s.list_tools())))'
11
```

## README

Updated with MCP Server Mode section and project structure entry.

## Requires

`pip install 'mcp[cli]'` (not added to project deps — optional dependency for agents only)