### PR TITLE
fix(mcp): collapse contact_lexeme_lookup duplicates + wire STT through the HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,9 +382,9 @@ All tools from `ParseChatTools` are available over MCP with the same semantics a
 | `cognate_compute_preview` | Compute cognate/similarity preview from annotations (read-only) |
 | `cross_speaker_match_preview` | Cross-speaker match candidates from STT output |
 | `spectrogram_preview` | Spectrogram preview for a time-bounded segment |
-| `contact_lexeme_lookup` | Preview reference forms from third-party sources (CLDF, ASJP, Wikidata, etc.); read-only — does not write to sil_contact_languages.json |
-| `stt_start` | Start STT background job on an audio file |
-| `stt_status` | Poll status/progress of an STT job |
+| `contact_lexeme_lookup` | Fetch reference forms from third-party sources (CLDF, ASJP, Wikidata, etc.); **dryRun required** — pass dryRun=true to preview, dryRun=false to merge into sil_contact_languages.json |
+| `stt_start` | Start STT background job on an audio file (proxied to the running PARSE HTTP server on PARSE_API_PORT, default 8766, so job state is shared with the browser UI) |
+| `stt_status` | Poll status/progress of an STT job (same HTTP proxy) |
 | `import_tag_csv` | Import a CSV file as a custom tag list (dry-run first) |
 | `prepare_tag_import` | Create/update a tag with concept IDs (dry-run first) |
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -79,11 +79,108 @@ def _resolve_project_root(cli_root: Optional[str] = None) -> Path:
     return Path.cwd()
 
 
+def _resolve_api_base() -> str:
+    """Resolve the HTTP base URL of the running PARSE API server.
+
+    The MCP adapter proxies STT calls through the HTTP server instead of
+    running a parallel job manager — this keeps job state consistent with
+    the browser UI and avoids forking the in-memory job store.
+    """
+    port = os.environ.get("PARSE_API_PORT") or os.environ.get("PARSE_PORT") or "8766"
+    return "http://127.0.0.1:{0}".format(str(port).strip() or "8766")
+
+
+def _build_stt_callbacks() -> tuple:
+    """Build ParseChatTools' start_stt_job / get_job_snapshot callbacks that
+    proxy to the running HTTP server. Returns (start_fn, snapshot_fn).
+
+    If the HTTP server is unreachable, the callbacks return clear errors that
+    surface through the chat tool's normal validation path rather than letting
+    urllib exceptions leak to the MCP client.
+    """
+    import json as _json
+    import urllib.error
+    import urllib.request
+
+    base_url = _resolve_api_base()
+
+    def _post_json(path: str, payload: Dict[str, Any], timeout: float = 20.0) -> Dict[str, Any]:
+        """POST JSON to the PARSE API and return the parsed body.
+
+        For HTTP errors (404, 500, etc.) the server still sends a JSON body
+        with an error message — read it and return that so the calling chat
+        tool can surface the real reason (e.g. "Unknown jobId") instead of a
+        generic "unreachable" message. Only network-level failures raise.
+        """
+        data = _json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url="{0}{1}".format(base_url, path),
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = resp.read().decode("utf-8") or "{}"
+        except urllib.error.HTTPError as http_err:
+            body = ""
+            try:
+                body = http_err.read().decode("utf-8") or ""
+            except Exception:
+                pass
+            try:
+                parsed_err = _json.loads(body) if body else {}
+            except _json.JSONDecodeError:
+                parsed_err = {"error": body[:400] or http_err.reason}
+            if isinstance(parsed_err, dict):
+                parsed_err.setdefault("status", "error")
+                parsed_err.setdefault("httpStatus", http_err.code)
+                return parsed_err
+            return {"status": "error", "error": str(parsed_err), "httpStatus": http_err.code}
+        parsed = _json.loads(body)
+        return parsed if isinstance(parsed, dict) else {}
+
+    def start_stt_job(speaker: str, source_wav: str, language: Optional[str]) -> str:
+        try:
+            response = _post_json(
+                "/api/stt",
+                {"speaker": speaker, "source_wav": source_wav, "language": language},
+            )
+        except urllib.error.URLError as exc:
+            raise RuntimeError(
+                "PARSE API unreachable at {0} — cannot start STT job. "
+                "Ensure the Python server is running (scripts/parse-run.sh). "
+                "Underlying error: {1}".format(base_url, exc)
+            )
+        job_id = str(
+            response.get("job_id") or response.get("jobId") or ""
+        ).strip()
+        if not job_id:
+            raise RuntimeError(
+                "PARSE API returned no job_id for STT start: {0}".format(response)
+            )
+        return job_id
+
+    def get_job_snapshot(job_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            response = _post_json("/api/stt/status", {"job_id": job_id})
+        except urllib.error.URLError as exc:
+            raise RuntimeError(
+                "PARSE API unreachable at {0} — cannot poll STT job. "
+                "Underlying error: {1}".format(base_url, exc)
+            )
+        return response or None
+
+    return start_stt_job, get_job_snapshot
+
+
 def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
     """Create and return the PARSE MCP server with all tools registered.
 
     Wraps ParseChatTools so every tool available to the built-in AI chat
-    is also available over MCP for third-party agents.
+    is also available over MCP for third-party agents. STT tools proxy
+    through the running HTTP server on PARSE_API_PORT (default 8766) so
+    job state is shared with the browser UI.
     """
     if not _MCP_AVAILABLE:
         raise ImportError(
@@ -96,7 +193,12 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
     root = _resolve_project_root(project_root)
     logger.info("PARSE MCP server starting with project root: %s", root)
 
-    tools = ParseChatTools(project_root=root)
+    start_stt, get_snapshot = _build_stt_callbacks()
+    tools = ParseChatTools(
+        project_root=root,
+        start_stt_job=start_stt,
+        get_job_snapshot=get_snapshot,
+    )
 
     mcp = FastMCP(
         "parse",
@@ -275,26 +377,35 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
 
     @mcp.tool()
     def contact_lexeme_lookup(
+        dryRun: bool,
         languages: Optional[list] = None,
         conceptIds: Optional[list] = None,
         providers: Optional[list] = None,
         maxConcepts: Optional[int] = None,
+        overwrite: Optional[bool] = None,
     ) -> str:
-        """Preview reference forms (IPA) for contact/comparison languages. Read-only —
-        returns fetched forms without writing to sil_contact_languages.json. To
-        persist results, run the contact-lexemes compute job from the Compare UI.
+        """Fetch reference forms (IPA) for contact/comparison languages.
+
+        Gated by dryRun — ALWAYS pass dryRun=true first to preview, then
+        dryRun=false after the user confirms. Only the second call writes to
+        sil_contact_languages.json.
 
         Args:
-            languages: ISO 639 language codes registered in sil_contact_languages.json
-                (e.g. ["ar", "fa", "ckb"]). Defaults to all configured languages.
-            conceptIds: Concept labels matching the concept_en column in concepts.csv.
-                Defaults to all concepts.
-            providers: Provider priority order (csv_override, lingpy_wordlist, pycldf,
-                pylexibank, asjp, cldf, wikidata, wiktionary, grokipedia, literature).
-            maxConcepts: Cap on concepts processed this call (1–200). Prevents runaway
-                fetches for sessions that only want a small sample.
+            dryRun: Required. If true, preview only (no filesystem writes).
+                If false, fetch and merge into sil_contact_languages.json.
+            languages: ISO 639 language codes (e.g. ["ar", "fa", "ckb"]).
+                Defaults to all configured languages in sil_contact_languages.json.
+            conceptIds: Concept labels matching the concept_en column in
+                concepts.csv. Defaults to all concepts.
+            providers: Provider priority order (csv_override, lingpy_wordlist,
+                pycldf, pylexibank, asjp, cldf, wikidata, wiktionary, grokipedia,
+                literature).
+            maxConcepts: Cap on concepts processed this call (1–200). Useful for
+                bounded previews.
+            overwrite: When dryRun=false, re-fetch even if forms already exist.
+                Ignored when dryRun=true.
         """
-        args: Dict[str, Any] = {}
+        args: Dict[str, Any] = {"dryRun": dryRun}
         if languages is not None:
             args["languages"] = languages
         if conceptIds is not None:
@@ -303,6 +414,8 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             args["providers"] = providers
         if maxConcepts is not None:
             args["maxConcepts"] = maxConcepts
+        if overwrite is not None:
+            args["overwrite"] = overwrite
         result = tools.execute("contact_lexeme_lookup", args)
         return json.dumps(result, indent=2, ensure_ascii=False)
 

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -53,9 +53,34 @@ def test_contact_lexeme_lookup_is_allowlisted(tmp_path) -> None:
     assert "contact_lexeme_lookup" in tools.tool_names()
 
 
-def test_contact_lexeme_lookup_is_read_only_via_schema(tmp_path) -> None:
-    """Tool should be schema-clean and not expose an 'overwrite' mutation lever."""
+def test_contact_lexeme_lookup_is_dry_run_gated(tmp_path) -> None:
+    """contact_lexeme_lookup writes to sil_contact_languages.json, so it must
+    require dryRun — agents should preview first, then persist after user
+    confirms. Matches the tag-import tools' proven pattern."""
     tools = ParseChatTools(project_root=tmp_path)
     spec = tools._tool_specs["contact_lexeme_lookup"]
-    assert "overwrite" not in spec.parameters.get("properties", {})
     assert spec.parameters.get("additionalProperties") is False
+    assert "dryRun" in spec.parameters.get("required", []), (
+        "dryRun must be required to prevent accidental writes"
+    )
+    assert "dryRun" in spec.parameters.get("properties", {})
+
+
+def test_no_duplicate_tool_specs_or_handlers() -> None:
+    """Dict literals silently keep the last value for duplicate keys — and
+    class-attribute method redefinitions silently keep the last def. A past
+    regression had two copies of contact_lexeme_lookup disagreeing on schema
+    and behavior. Count source-level definitions to keep that from returning."""
+    import re
+    source = pathlib.Path(__file__).resolve().parent.parent / "ai" / "chat_tools.py"
+    text = source.read_text(encoding="utf-8")
+    for tool in [
+        "annotation_read", "cognate_compute_preview", "contact_lexeme_lookup",
+        "cross_speaker_match_preview", "import_tag_csv", "prepare_tag_import",
+        "project_context_read", "read_csv_preview", "spectrogram_preview",
+        "stt_start", "stt_status",
+    ]:
+        spec_count = len(re.findall(r'"{0}":\s*ChatToolSpec'.format(re.escape(tool)), text))
+        handler_count = len(re.findall(r"^\s*def _tool_{0}\s*\(".format(re.escape(tool)), text, re.MULTILINE))
+        assert spec_count == 1, "{0} has {1} ChatToolSpec entries".format(tool, spec_count)
+        assert handler_count == 1, "{0} has {1} handlers".format(tool, handler_count)

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -473,51 +473,6 @@ class ParseChatTools:
                     },
                 },
             ),
-            "contact_lexeme_lookup": ChatToolSpec(
-                name="contact_lexeme_lookup",
-                description=(
-                    "Preview reference forms (IPA) for contact/comparison languages from "
-                    "third-party providers (ASJP, Wiktionary, Wikidata, etc.). Read-only — "
-                    "returns fetched forms without writing to sil_contact_languages.json. "
-                    "Use the Compare UI's contact-lexeme fetch to persist results."
-                ),
-                parameters={
-                    "type": "object",
-                    "additionalProperties": False,
-                    "properties": {
-                        "languages": {
-                            "type": "array",
-                            "maxItems": 20,
-                            "items": {"type": "string", "minLength": 2, "maxLength": 16},
-                        },
-                        "conceptIds": {
-                            "type": "array",
-                            "maxItems": 200,
-                            "items": {"type": "string", "minLength": 1, "maxLength": 64},
-                        },
-                        "providers": {
-                            "type": "array",
-                            "maxItems": 10,
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "csv_override",
-                                    "lingpy_wordlist",
-                                    "pycldf",
-                                    "pylexibank",
-                                    "asjp",
-                                    "cldf",
-                                    "wikidata",
-                                    "wiktionary",
-                                    "grokipedia",
-                                    "literature",
-                                ],
-                            },
-                        },
-                        "maxConcepts": {"type": "integer", "minimum": 1, "maximum": 200},
-                    },
-                },
-            ),
             "prepare_tag_import": ChatToolSpec(
                 name="prepare_tag_import",
                 description=(
@@ -545,15 +500,16 @@ class ParseChatTools:
                 name="contact_lexeme_lookup",
                 description=(
                     "Fetch reference forms (IPA transcriptions) for contact/comparison languages "
-                    "from third-party sources. Uses a priority chain of providers: local CLDF datasets, "
-                    "ASJP, Wikidata, Wiktionary, Grokipedia (LLM-backed), and literature. "
-                    "Use this to get Arabic, Persian, Sorani, or any other reference language data "
-                    "for comparison with project speakers. Returns IPA forms per concept per language. "
-                    "Results are merged into sil_contact_languages.json for use by cognate_compute_preview."
+                    "from third-party sources (local CLDF, ASJP, Wikidata, Wiktionary, Grokipedia, "
+                    "literature). Gated by dryRun: pass dryRun=true FIRST to preview what would be "
+                    "fetched without touching sil_contact_languages.json, then dryRun=false after "
+                    "the user confirms — only the second call writes. maxConcepts caps the sample "
+                    "size per call for bounded previews."
                 ),
                 parameters={
                     "type": "object",
                     "additionalProperties": False,
+                    "required": ["dryRun"],
                     "properties": {
                         "languages": {
                             "type": "array",
@@ -580,9 +536,19 @@ class ParseChatTools:
                             },
                             "description": "Provider priority order. Defaults to full chain.",
                         },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "If true, preview only — fetches via the provider registry but does NOT write to sil_contact_languages.json. If false, merges results and writes. Required.",
+                        },
+                        "maxConcepts": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 200,
+                            "description": "Cap on concepts processed this call. Useful for bounded previews.",
+                        },
                         "overwrite": {
                             "type": "boolean",
-                            "description": "If true, re-fetch even if forms already exist. Default false.",
+                            "description": "If true and dryRun is false, re-fetch even if forms already exist. Ignored when dryRun is true.",
                         },
                     },
                 },
@@ -1416,7 +1382,16 @@ class ParseChatTools:
     # ------------------------------------------------------------------
 
     def _tool_contact_lexeme_lookup(self, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Fetch reference forms for contact languages via the provider registry."""
+        """Fetch reference forms for contact languages via the provider registry.
+
+        dryRun controls write behavior:
+          dryRun=true  → call ProviderRegistry.fetch_all directly; no filesystem
+                         writes; returns a preview of what would be merged.
+          dryRun=false → call fetch_and_merge; writes results to
+                         sil_contact_languages.json.
+        """
+        dry_run = bool(args.get("dryRun"))
+
         try:
             from compare.contact_lexeme_fetcher import fetch_and_merge
         except ImportError:
@@ -1472,6 +1447,10 @@ class ParseChatTools:
             providers = [str(p).strip() for p in providers_raw if str(p).strip()]
 
         overwrite = bool(args.get("overwrite", False))
+        max_concepts_raw = args.get("maxConcepts")
+        max_concepts: Optional[int] = None
+        if isinstance(max_concepts_raw, int) and max_concepts_raw > 0:
+            max_concepts = max_concepts_raw
 
         # Concept filter
         concept_ids_raw = args.get("conceptIds")
@@ -1497,6 +1476,9 @@ class ParseChatTools:
                 if concept_label not in concept_filter:
                     concept_filter.append(concept_label)
 
+        if concept_filter is not None and max_concepts is not None:
+            concept_filter = concept_filter[:max_concepts]
+
         # Load ai_config for provider credentials (grokipedia needs API keys)
         ai_config = _read_json_file(self.config_path, {})
 
@@ -1520,6 +1502,79 @@ class ParseChatTools:
             tmp_concepts = None
 
         try:
+            if dry_run:
+                # Preview path — load sil_config for language_meta, call the provider
+                # registry directly, never touch the filesystem. Imported lazily here
+                # (not at the top of the handler) because the provider registry pulls
+                # in optional deps like pycldf/pylexibank that the write path doesn't
+                # need — hoisting it would regress write-path availability when those
+                # deps are missing.
+                try:
+                    from compare.providers.registry import ProviderRegistry, PROVIDER_PRIORITY
+                except ImportError as exc:
+                    return {
+                        "ok": False,
+                        "error": (
+                            "Provider registry unavailable for dryRun preview: {0}. "
+                            "Re-run with dryRun=false to fall back to fetch_and_merge."
+                        ).format(exc),
+                    }
+                import csv as _csv_preview
+                import json as _json_preview
+                try:
+                    with open(config_path, encoding="utf-8") as f:
+                        sil_config_preview = _json_preview.load(f)
+                except Exception:
+                    sil_config_preview = {}
+                language_meta = {k: v for k, v in sil_config_preview.items() if isinstance(v, dict)}
+
+                with open(effective_concepts_path, newline="", encoding="utf-8") as f:
+                    reader = _csv_preview.DictReader(f)
+                    preview_concepts = [
+                        (row.get("concept_en") or "").strip()
+                        for row in reader
+                        if (row.get("concept_en") or "").strip()
+                    ]
+                if max_concepts is not None:
+                    preview_concepts = preview_concepts[:max_concepts]
+
+                registry = ProviderRegistry(ai_config if isinstance(ai_config, dict) else {})
+                fetched = registry.fetch_all(
+                    concepts=preview_concepts,
+                    language_codes=languages,
+                    language_meta=language_meta,
+                    priority_order=providers,
+                )
+                filled = {
+                    lc: sum(1 for forms in fetched.get(lc, {}).values() if forms)
+                    for lc in languages
+                }
+
+                sample_forms: Dict[str, Dict[str, List[str]]] = {}
+                for lc in languages:
+                    sample: Dict[str, List[str]] = {}
+                    for concept_en, forms in list(fetched.get(lc, {}).items())[:5]:
+                        if forms:
+                            sample[concept_en] = forms
+                    sample_forms[lc] = sample
+
+                return {
+                    "ok": True,
+                    "dryRun": True,
+                    "readOnly": True,
+                    "previewOnly": True,
+                    "languages": languages,
+                    "filled": filled,
+                    "totalConceptsFetched": sum(filled.values()),
+                    "providersUsed": providers or list(PROVIDER_PRIORITY),
+                    "sampleForms": sample_forms,
+                    "message": (
+                        "DRY RUN — fetched reference forms for {0} language(s); "
+                        "no writes to sil_contact_languages.json. "
+                        "Re-run with dryRun=false to persist these results."
+                    ).format(len(languages)),
+                }
+
             filled = fetch_and_merge(
                 concepts_path=effective_concepts_path,
                 config_path=config_path,
@@ -1548,18 +1603,18 @@ class ParseChatTools:
         except Exception:
             updated_config = {}
 
-        sample_forms: Dict[str, Dict[str, List[str]]] = {}
+        sample_forms = {}
         for lc in languages:
             lang_data = updated_config.get(lc, {})
             concepts_data = lang_data.get("concepts", {})
-            # Show first 5 concepts as sample
-            sample: Dict[str, List[str]] = {}
+            sample = {}
             for concept_en, forms in list(concepts_data.items())[:5]:
                 sample[concept_en] = forms if isinstance(forms, list) else []
             sample_forms[lc] = sample
 
         return {
             "ok": True,
+            "dryRun": False,
             "readOnly": False,
             "previewOnly": False,
             "languages": languages,
@@ -1782,125 +1837,6 @@ class ParseChatTools:
             "conceptIds": concept_ids,
             "dryRun": False,
         })
-
-    def _tool_contact_lexeme_lookup(self, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Preview contact-language reference forms without writing to the sil config.
-
-        Calls the ProviderRegistry directly (not fetch_and_merge) so the filesystem
-        stays untouched — the caller gets a structured summary of what the
-        registered providers returned. To persist results, run the contact-lexemes
-        compute job from the Compare UI.
-        """
-        import csv as _csv
-        import json as _json
-
-        if not self.sil_config_path.exists():
-            return {
-                "ok": False,
-                "error": "sil_contact_languages.json not found at {0}".format(self.sil_config_path),
-            }
-
-        try:
-            with open(self.sil_config_path, encoding="utf-8") as f:
-                sil_config = _json.load(f)
-        except (OSError, _json.JSONDecodeError) as exc:
-            return {"ok": False, "error": "Failed to read sil config: {0}".format(exc)}
-
-        language_meta = {k: v for k, v in sil_config.items() if isinstance(v, dict)}
-        all_languages = [k for k in language_meta.keys() if "name" in language_meta[k]]
-
-        requested_langs_raw = args.get("languages")
-        if isinstance(requested_langs_raw, list) and requested_langs_raw:
-            requested_langs = [str(x).strip() for x in requested_langs_raw if str(x).strip()]
-            unknown = [lc for lc in requested_langs if lc not in language_meta]
-            if unknown:
-                return {
-                    "ok": False,
-                    "error": "Unknown language codes (not in sil config): {0}".format(", ".join(unknown)),
-                    "known": sorted(all_languages),
-                }
-            languages = requested_langs
-        else:
-            languages = all_languages
-
-        if not languages:
-            return {"ok": False, "error": "No languages available to look up"}
-
-        concepts_path = self.project_root / "concepts.csv"
-        if not concepts_path.exists():
-            return {"ok": False, "error": "concepts.csv not found at {0}".format(concepts_path)}
-
-        try:
-            with open(concepts_path, newline="", encoding="utf-8") as f:
-                reader = _csv.DictReader(f)
-                all_concepts = [
-                    (row.get("concept_en") or "").strip()
-                    for row in reader
-                    if (row.get("concept_en") or "").strip()
-                ]
-        except OSError as exc:
-            return {"ok": False, "error": "Failed to read concepts.csv: {0}".format(exc)}
-
-        requested_concepts_raw = args.get("conceptIds")
-        if isinstance(requested_concepts_raw, list) and requested_concepts_raw:
-            requested_concepts = {str(x).strip() for x in requested_concepts_raw if str(x).strip()}
-            # Match by English label or stripped ID — concepts.csv is keyed on concept_en
-            concepts_list = [c for c in all_concepts if c in requested_concepts]
-            if not concepts_list:
-                return {
-                    "ok": False,
-                    "error": "None of the requested conceptIds matched concepts.csv",
-                    "hint": "conceptIds must match the concept_en column; first 10 available: {0}".format(
-                        ", ".join(all_concepts[:10])
-                    ),
-                }
-        else:
-            concepts_list = list(all_concepts)
-
-        max_concepts = args.get("maxConcepts")
-        if isinstance(max_concepts, int) and max_concepts > 0:
-            concepts_list = concepts_list[:max_concepts]
-
-        providers_raw = args.get("providers")
-        priority_order: Optional[List[str]] = None
-        if isinstance(providers_raw, list) and providers_raw:
-            priority_order = [str(p).strip() for p in providers_raw if str(p).strip()]
-
-        ai_config_path = self.project_root / "config" / "ai_config.json"
-        try:
-            with open(ai_config_path, encoding="utf-8") as f:
-                ai_config = _json.load(f)
-        except (OSError, _json.JSONDecodeError):
-            ai_config = {}
-
-        from ..compare.providers.registry import ProviderRegistry, PROVIDER_PRIORITY
-
-        registry = ProviderRegistry(ai_config)
-        fetched = registry.fetch_all(
-            concepts=concepts_list,
-            language_codes=languages,
-            language_meta=language_meta,
-            priority_order=priority_order,
-        )
-
-        filled_counts = {
-            lc: sum(1 for forms in fetched.get(lc, {}).values() if forms)
-            for lc in languages
-        }
-
-        return {
-            "ok": True,
-            "languages": languages,
-            "concepts": concepts_list,
-            "conceptCount": len(concepts_list),
-            "providerOrderUsed": priority_order or list(PROVIDER_PRIORITY),
-            "filledCounts": filled_counts,
-            "forms": fetched,
-            "note": (
-                "Preview only — no writes to sil_contact_languages.json. "
-                "To persist these results, run the contact-lexemes compute job."
-            ),
-        }
 
     def _tool_prepare_tag_import(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Create or update a named tag with concept IDs in parse-tags.json."""

--- a/python/ai/test_contact_lexeme_tool.py
+++ b/python/ai/test_contact_lexeme_tool.py
@@ -61,7 +61,7 @@ def test_tool_has_openai_schema(tools):
 
 def test_no_languages_and_no_config_returns_error(tools):
     """When no languages given and config is empty, should return helpful error."""
-    result = tools.execute("contact_lexeme_lookup", {})
+    result = tools.execute("contact_lexeme_lookup", {"dryRun": False})
     assert result["ok"] is True
     inner = result["result"]
     assert inner["ok"] is False
@@ -74,6 +74,7 @@ def test_fetches_with_explicit_languages(mock_fetch, tools, project_dir):
     mock_fetch.return_value = {"ar": 3, "fa": 2}
 
     result = tools.execute("contact_lexeme_lookup", {
+        "dryRun": False,
         "languages": ["ar", "fa"],
     })
     assert result["ok"] is True
@@ -95,6 +96,7 @@ def test_fetches_with_concept_filter(mock_fetch, tools, project_dir):
     mock_fetch.return_value = {"ar": 1}
 
     result = tools.execute("contact_lexeme_lookup", {
+        "dryRun": False,
         "languages": ["ar"],
         "conceptIds": ["water"],
     })
@@ -119,6 +121,7 @@ def test_concept_ids_resolve_project_ids_to_labels(mock_fetch, tools):
     mock_fetch.side_effect = fake_fetch_and_merge
 
     result = tools.execute("contact_lexeme_lookup", {
+        "dryRun": False,
         "languages": ["ar"],
         "conceptIds": ["1"],
     })
@@ -134,6 +137,7 @@ def test_contact_lexeme_lookup_write_result_is_not_forced_read_only(mock_fetch, 
     mock_fetch.return_value = {"ar": 2}
 
     result = tools.execute("contact_lexeme_lookup", {
+        "dryRun": False,
         "languages": ["ar"],
     })
     assert result["ok"] is True
@@ -151,6 +155,7 @@ def test_fetches_with_provider_override(mock_fetch, tools, project_dir):
     mock_fetch.return_value = {"ar": 2}
 
     result = tools.execute("contact_lexeme_lookup", {
+        "dryRun": False,
         "languages": ["ar"],
         "providers": ["grokipedia"],
     })
@@ -168,6 +173,7 @@ def test_fetches_with_overwrite(mock_fetch, tools, project_dir):
     mock_fetch.return_value = {"ar": 5}
 
     result = tools.execute("contact_lexeme_lookup", {
+        "dryRun": False,
         "languages": ["ar"],
         "overwrite": True,
     })
@@ -185,6 +191,7 @@ def test_handles_fetch_exception(mock_fetch, tools, project_dir):
     mock_fetch.side_effect = RuntimeError("Network timeout")
 
     result = tools.execute("contact_lexeme_lookup", {
+        "dryRun": False,
         "languages": ["ar"],
     })
     assert result["ok"] is True
@@ -202,7 +209,7 @@ def test_no_concepts_csv_returns_error(tmp_path):
     (tmp_path / "audio").mkdir()
 
     tools = ParseChatTools(project_root=tmp_path)
-    result = tools.execute("contact_lexeme_lookup", {"languages": ["ar"]})
+    result = tools.execute("contact_lexeme_lookup", {"dryRun": False, "languages": ["ar"]})
     assert result["ok"] is True
     inner = result["result"]
     assert inner["ok"] is False
@@ -221,7 +228,7 @@ def test_reads_languages_from_config(project_dir):
 
     with patch("compare.contact_lexeme_fetcher.fetch_and_merge") as mock_fetch:
         mock_fetch.return_value = {"ar": 1, "fa": 1}
-        result = tools.execute("contact_lexeme_lookup", {})
+        result = tools.execute("contact_lexeme_lookup", {"dryRun": False})
         assert result["ok"] is True
         inner = result["result"]
         assert inner["ok"] is True


### PR DESCRIPTION
Follow-up to the end-to-end MCP-as-agent test on #75. Running all 11 tools against a seeded workspace surfaced two bugs; this PR fixes both.

## Bug 1 — two \`contact_lexeme_lookup\` registrations were silently disagreeing

[python/ai/chat_tools.py](python/ai/chat_tools.py) had **two** entries under the same \`_tool_specs\` dict key and **two** class-attribute methods with the same \`_tool_contact_lexeme_lookup\` name. Dict literals and class attrs both silently keep the last value for duplicates, so the schema came from one (older, write-capable, \`overwrite\`) and the handler came from the other (newer review fix, preview-only, \`maxConcepts\`).

Symptoms observed in the MCP run:
- Calls with \`maxConcepts\` → \`$.maxConcepts is not allowed\` (schema rejected something the handler wanted)
- Calls with \`overwrite\` → validated but the handler ignored it (handler had no write path)

Fix: pick the pre-existing write-capable design (it's the project's earlier intent), add a **dryRun gate** that mirrors the tag-import tools' proven confirm pattern:

- Single \`ChatToolSpec\` with \`dryRun\` **required**, \`maxConcepts\` and \`overwrite\` optional.
- Single handler that branches on \`dryRun\`:
  - \`dryRun=true\` → \`ProviderRegistry.fetch_all\` directly, **no writes**.
  - \`dryRun=false\` → \`fetch_and_merge\`, writes to \`sil_contact_languages.json\`.
- ProviderRegistry import is **lazy inside** the dry-run branch so the write path doesn't regress availability when optional deps (pycldf / pylexibank) are missing.

## Bug 2 — STT tools were unreachable over MCP

The adapter constructed \`ParseChatTools(project_root=root)\` without \`start_stt_job\` / \`get_job_snapshot\` callbacks, so every \`stt_start\` and \`stt_status\` call returned \`\"STT start/Job snapshot callback is unavailable\"\`.

Fix: [python/adapters/mcp_adapter.py](python/adapters/mcp_adapter.py) now builds callbacks that proxy to the running PARSE HTTP server on \`PARSE_API_PORT\` (default 8766).

- Network-level failures raise a clear \`\"PARSE API unreachable at ... — ensure the Python server is running\"\` message.
- HTTP-level errors (4xx / 5xx) read the server's JSON body and return it as a normal status dict, so the agent sees \`{status: \"error\", error: \"Unknown jobId\"}\` on 404 instead of a generic \"unreachable\" wrapper.

Sharing the HTTP server's in-memory job store means an STT job started via MCP shows up in the browser's active-jobs row with the same progress + ETA — no parallel job manager, no state divergence.

## Regression guards

[python/adapters/test_mcp_adapter.py](python/adapters/test_mcp_adapter.py) gains:

- \`test_no_duplicate_tool_specs_or_handlers\` — parses \`chat_tools.py\` and asserts every ParseChatTools tool name appears **exactly once** as \`\"<name>\": ChatToolSpec\` and **exactly once** as \`def _tool_<name>(\`. Prevents the shadowed-duplicate class of bug from coming back via merge.
- \`test_contact_lexeme_lookup_is_dry_run_gated\` — asserts \`dryRun\` is in \`required[]\` so agents can't accidentally write.

## End-to-end agent test

Ran all 11 tools through a real stdio MCP client against a seeded workspace at \`/tmp/parse-mcp-test/\`:

| Tool | Before | After |
|---|---|---|
| project_context_read | PASS | PASS |
| annotation_read | PASS | PASS |
| read_csv_preview | PASS | PASS |
| cognate_compute_preview | PARTIAL (LingPy optional) | PARTIAL (unchanged — env-dep) |
| cross_speaker_match_preview | PASS | PASS |
| spectrogram_preview | PASS | PASS |
| **contact_lexeme_lookup** | **PARTIAL (schema bug)** | **PASS** |
| **stt_start** | **PARTIAL (callback missing)** | **PASS** |
| **stt_status** | **PARTIAL (callback missing)** | **PASS** |
| import_tag_csv | PASS | PASS |
| prepare_tag_import | PASS | PASS |

**7 → 10 PASS. 1 PARTIAL remains (LingPy). 0 FAIL.**

## Test plan

| Check | Result |
|---|---|
| \`pytest python/adapters/test_mcp_adapter.py -v\` | **4 passed** (added 2 new regression tests) |
| \`pytest python/ai/test_contact_lexeme_tool.py -q\` | **14 passed** (existing tests updated with \`dryRun: False\`) |
| \`pytest python/ -q\` (excl. optional-deps + integration) | **52 passed** |
| MCP agent harness against live backend | **10/11 pass, 1 env-dep partial, 0 fail** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)