### PR TITLE
fix: persist API key across backend restarts and launch-dir changes

### DIFF
--- a/python/ai/openai_auth.py
+++ b/python/ai/openai_auth.py
@@ -44,7 +44,9 @@ _auth_lock = threading.Lock()
 
 def _config_dir() -> pathlib.Path:
     """Return the config directory, creating it if needed."""
-    d = pathlib.Path.cwd() / "config"
+    # Anchor to the repo root (python/ai/ -> python/ -> repo root) so the path
+    # is stable regardless of the working directory when the server is launched.
+    d = pathlib.Path(__file__).resolve().parents[2] / "config"
     d.mkdir(exist_ok=True)
     return d
 

--- a/src/components/annotate/ChatPanel.tsx
+++ b/src/components/annotate/ChatPanel.tsx
@@ -35,11 +35,28 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
-    getAuthStatus()
-      .then((s: AuthStatus) => {
-        setAuthState(s.authenticated ? "authenticated" : "unauthenticated")
-      })
-      .catch(() => setAuthState("unauthenticated"))
+    // Retry up to ~10 s so a brief backend restart during a code update
+    // doesn't incorrectly drop a persisted API key.
+    let attempt = 0
+    const delays = [500, 1000, 2000, 3000, 4000]
+    let cancelled = false
+
+    const tryFetch = () => {
+      getAuthStatus()
+        .then((s: AuthStatus) => {
+          if (!cancelled) setAuthState(s.authenticated ? "authenticated" : "unauthenticated")
+        })
+        .catch(() => {
+          if (cancelled) return
+          if (attempt < delays.length) {
+            setTimeout(tryFetch, delays[attempt++])
+          } else {
+            setAuthState("unauthenticated")
+          }
+        })
+    }
+    tryFetch()
+    return () => { cancelled = true }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **`python/ai/openai_auth.py`** — `_config_dir()` used `Path.cwd()` to locate `auth_tokens.json`, so the token file landed in different locations depending on where the server was launched. Changed to `Path(__file__).resolve().parents[2] / "config"` so it's always `<repo>/config/auth_tokens.json` regardless of launch directory.

- **`src/components/annotate/ChatPanel.tsx`** — `getAuthStatus()` was called once on mount with no retry. If the Python backend was briefly unavailable during a code update / hot-reload, the catch immediately set auth state to `"unauthenticated"` and never recovered — even though the key was still on disk. Now retries up to ~10 s (500 → 1000 → 2000 → 3000 → 4000 ms backoff) before giving up.

## Test plan

- [ ] Save an xAI or OpenAI API key — confirm it shows as authenticated
- [ ] Kill and restart the Python backend; confirm the UI recovers to authenticated within ~10 s without re-entering the key
- [ ] Start the Python server from a non-repo directory; confirm `auth_tokens.json` is still written to `<repo>/config/`
- [ ] Confirm `config/auth_tokens.json` remains gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)