### PR TITLE
fix(auth): resume OAuth poll on mount if flow is in-progress

### DIFF
--- a/src/components/annotate/ChatPanel.tsx
+++ b/src/components/annotate/ChatPanel.tsx
@@ -44,7 +44,35 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
     const tryFetch = () => {
       getAuthStatus()
         .then((s: AuthStatus) => {
-          if (!cancelled) setAuthState(s.authenticated ? "authenticated" : "unauthenticated")
+          if (cancelled) return
+          if (s.authenticated) {
+            setAuthState("authenticated")
+          } else if (s.flow_active) {
+            // OAuth device flow was started before this mount (e.g. HMR reload).
+            // Resume polling so the token is picked up without re-entering the code.
+            setOauthInfo({ user_code: s.user_code, verification_uri: s.verification_uri })
+            setAuthState("oauth")
+            if (!pollRef.current) {
+              pollRef.current = setInterval(async () => {
+                try {
+                  const result = await pollAuth()
+                  if (result.status === "complete") {
+                    if (pollRef.current) clearInterval(pollRef.current)
+                    pollRef.current = null
+                    setAuthState("authenticated")
+                  } else if (result.status === "expired" || result.status === "error") {
+                    if (pollRef.current) clearInterval(pollRef.current)
+                    pollRef.current = null
+                    setAuthState("unauthenticated")
+                    setAuthError(result.error ?? (result.status === "expired" ? "Login code expired — try again" : "OAuth failed"))
+                    setOauthInfo({})
+                  }
+                } catch { /* transient — keep polling */ }
+              }, 5000)
+            }
+          } else {
+            setAuthState("unauthenticated")
+          }
         })
         .catch(() => {
           if (cancelled) return


### PR DESCRIPTION
## Summary

Follow-up to #78.

If `ChatPanel` unmounts mid-OAuth (HMR reload, page refresh, screenshot, etc.) the `setInterval` calling `pollAuth()` is cleared by React cleanup and never restarted. The component re-mounts, calls `getAuthStatus()`, sees `{authenticated: false, flow_active: true}`, and was previously setting state to `"unauthenticated"` — leaving the UI stuck on "Waiting for confirmation…" even after OpenAI had already issued the token. The user had to start the whole flow over.

**Fix:** the mount `useEffect` now checks `s.flow_active` in the auth status response. If true, it restores the `"oauth"` UI state, re-displays the device code, and restarts the `pollAuth()` interval so the token is picked up automatically.

## Test plan

- [ ] Start an OAuth Codex flow, then hard-refresh the page before authorizing — confirm the device code re-appears and authorization still completes without restarting
- [ ] Authorize successfully, then hard-refresh — confirm the UI immediately shows authenticated (covered by #78)
- [ ] Confirm direct API key flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)