### PR TITLE
fix(auth): fix OAuth token exchange and restore auth state on page load

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -12,7 +12,7 @@ import {
   Sun, Moon, XCircle
 } from 'lucide-react';
 import type { AnnotationInterval, AnnotationRecord, Tag as StoreTag } from './api/types';
-import { getLingPyExport, saveApiKey, getAuthStatus, startAuthFlow, startSTT, startCompute, startNormalize, pollSTT, pollNormalize, pollCompute } from './api/client';
+import { getLingPyExport, saveApiKey, getAuthStatus, pollAuth, startAuthFlow, startSTT, startCompute, startNormalize, pollSTT, pollNormalize, pollCompute } from './api/client';
 import { useChatSession, type UseChatSessionResult } from './hooks/useChatSession';
 import { useSpectrogram } from './hooks/useSpectrogram';
 import { useWaveSurfer } from './hooks/useWaveSurfer';
@@ -336,8 +336,36 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
     setTestMessage('');
   };
 
-  // Cleanup OAuth poll on unmount
+  // Restore auth state on mount and cleanup poll on unmount.
   useEffect(() => {
+    getAuthStatus().then(s => {
+      if (s.authenticated) {
+        setProvider('openai');
+        setView('connected');
+      } else if (s.flow_active) {
+        // OAuth was started before this mount (page reload mid-flow) — resume.
+        setOauthCode(s.user_code ?? '');
+        setOauthUri(s.verification_uri ?? '');
+        setOauthPending(true);
+        oauthPollRef.current = setInterval(async () => {
+          try {
+            const result = await pollAuth();
+            if (result.status === 'complete') {
+              if (oauthPollRef.current) clearInterval(oauthPollRef.current);
+              oauthPollRef.current = null;
+              setOauthPending(false);
+              setProvider('openai');
+              setView('connected');
+            } else if (result.status === 'expired' || result.status === 'error') {
+              if (oauthPollRef.current) clearInterval(oauthPollRef.current);
+              oauthPollRef.current = null;
+              setOauthPending(false);
+              setTestMessage(result.error ?? (result.status === 'expired' ? 'Login code expired — try again' : 'OAuth failed'));
+            }
+          } catch { /* keep polling */ }
+        }, 5000);
+      }
+    }).catch(() => { /* leave view at welcome */ });
     return () => { if (oauthPollRef.current) clearInterval(oauthPollRef.current); };
   }, []);
 
@@ -355,13 +383,18 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
       }
       oauthPollRef.current = setInterval(async () => {
         try {
-          const s = await getAuthStatus();
-          if (s.authenticated) {
+          const result = await pollAuth();
+          if (result.status === 'complete') {
             if (oauthPollRef.current) clearInterval(oauthPollRef.current);
             oauthPollRef.current = null;
             setOauthPending(false);
             setProvider('openai');
             setView('connected');
+          } else if (result.status === 'expired' || result.status === 'error') {
+            if (oauthPollRef.current) clearInterval(oauthPollRef.current);
+            oauthPollRef.current = null;
+            setOauthPending(false);
+            setTestMessage(result.error ?? (result.status === 'expired' ? 'Login code expired — try again' : 'OAuth failed'));
           }
         } catch { /* keep polling */ }
       }, 5000);


### PR DESCRIPTION
## Summary

Three bugs in `ParseUI.tsx` that caused API keys and OAuth sessions to appear lost:

- **Wrong polling endpoint** — `handleCodexSignIn` called `getAuthStatus()` (read-only) in its interval instead of `pollAuth()`, which is the endpoint that actually POSTs to OpenAI to exchange the device code for a token. The token was never fetched, so the UI stayed on "Waiting for sign-in…" indefinitely.

- **No mount-time restore** — on every page reload `view` reset to `'welcome'` even when the backend had a valid saved key or active OAuth flow. The mount `useEffect` now calls `getAuthStatus()` on startup and transitions directly to `'connected'` (saved key/token) or resumes the `pollAuth()` interval (`flow_active`) without the user re-entering anything.

- **`pollAuth` not imported** — added to the import line.

## Test plan

- [ ] Save an API key, reload page — confirm "Connected to OpenAI/xAI" is restored immediately without re-entering the key
- [ ] Start Codex OAuth, reload page mid-flow — confirm the device code reappears and authorization completes without restarting
- [ ] Start Codex OAuth, authorize on OpenAI's site — confirm the UI transitions to connected within ~5 s
- [ ] Confirm expired/errored flows show an error message and return to the welcome view

🤖 Generated with [Claude Code](https://claude.com/claude-code)