### PR TITLE
feat(chat): allow bounded markdown/text preview from configured docs root

### DIFF
--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -44,6 +44,7 @@ WRITE_ALLOWED_TOOL_NAMES = frozenset({
     "import_tag_csv",
     "prepare_tag_import",
 })
+TEXT_PREVIEW_EXTENSIONS = frozenset({".md", ".markdown", ".txt", ".rst"})
 
 
 class ChatToolError(Exception):
@@ -239,11 +240,13 @@ class ParseChatTools:
         self,
         project_root: Path,
         config_path: Optional[Path] = None,
+        docs_root: Optional[Path] = None,
         start_stt_job: Optional[Callable[[str, str, Optional[str]], str]] = None,
         get_job_snapshot: Optional[Callable[[str], Optional[Dict[str, Any]]]] = None,
     ) -> None:
         self.project_root = Path(project_root).expanduser().resolve()
         self.config_path = (Path(config_path).expanduser().resolve() if config_path else self.project_root / "config" / "ai_config.json")
+        self.docs_root = Path(docs_root).expanduser().resolve() if docs_root else None
 
         self.annotations_dir = self.project_root / "annotations"
         self.audio_dir = self.project_root / "audio"
@@ -448,6 +451,24 @@ class ParseChatTools:
                     "properties": {
                         "csvPath": {"type": "string", "maxLength": 512},
                         "maxRows": {"type": "integer", "minimum": 1, "maximum": 200, "default": 20},
+                    },
+                },
+            ),
+            "read_text_preview": ChatToolSpec(
+                name="read_text_preview",
+                description=(
+                    "Read a Markdown/text file preview from workspace or docs root. "
+                    "Allowed extensions: .md, .markdown, .txt, .rst. Read-only."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["path"],
+                    "properties": {
+                        "path": {"type": "string", "minLength": 1, "maxLength": 1024},
+                        "startLine": {"type": "integer", "minimum": 1, "maximum": 200000, "default": 1},
+                        "maxLines": {"type": "integer", "minimum": 1, "maximum": 400, "default": 120},
+                        "maxChars": {"type": "integer", "minimum": 200, "maximum": 50000, "default": 12000},
                     },
                 },
             ),
@@ -1708,6 +1729,89 @@ class ParseChatTools:
             }
         except Exception as exc:
             return {"ok": False, "error": str(exc)}
+
+    def _tool_read_text_preview(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Read a bounded Markdown/text preview from workspace/docs root."""
+        raw_path = str(args.get("path") or "").strip()
+        start_line = int(args.get("startLine") or 1)
+        max_lines = int(args.get("maxLines") or 120)
+        max_chars = int(args.get("maxChars") or 12000)
+
+        allowed_roots = [self.project_root]
+        if self.docs_root is not None:
+            allowed_roots.append(self.docs_root)
+
+        candidate = Path(raw_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = self.project_root / candidate
+        text_path = candidate.resolve()
+
+        root_allowed = False
+        for root in allowed_roots:
+            try:
+                text_path.relative_to(root.resolve())
+                root_allowed = True
+                break
+            except ValueError:
+                continue
+
+        if not root_allowed:
+            return {
+                "ok": False,
+                "error": "Path is outside allowed roots",
+            }
+
+        extension = text_path.suffix.lower()
+        if extension not in TEXT_PREVIEW_EXTENSIONS:
+            return {
+                "ok": False,
+                "error": "Unsupported file type: {0}. Allowed: {1}".format(
+                    extension or "(none)", ", ".join(sorted(TEXT_PREVIEW_EXTENSIONS))
+                ),
+            }
+
+        if not text_path.exists() or not text_path.is_file():
+            return {"ok": False, "error": "File not found: {0}".format(text_path)}
+
+        try:
+            lines = text_path.read_text(encoding="utf-8").splitlines()
+        except Exception as exc:
+            return {"ok": False, "error": "Failed to read text file: {0}".format(exc)}
+
+        if start_line < 1:
+            start_line = 1
+
+        start_idx = start_line - 1
+        if start_idx >= len(lines):
+            return {
+                "ok": True,
+                "path": str(text_path),
+                "lineStart": start_line,
+                "lineEnd": start_line,
+                "totalLines": len(lines),
+                "truncated": False,
+                "content": "",
+                "message": "startLine is beyond end-of-file",
+            }
+
+        selected = lines[start_idx:start_idx + max_lines]
+        content = "\n".join(selected)
+        truncated = False
+        if len(content) > max_chars:
+            content = content[:max_chars]
+            truncated = True
+        if (start_idx + max_lines) < len(lines):
+            truncated = True
+
+        return {
+            "ok": True,
+            "path": str(text_path),
+            "lineStart": start_line,
+            "lineEnd": start_line + max(0, len(selected) - 1),
+            "totalLines": len(lines),
+            "truncated": truncated,
+            "content": content,
+        }
 
     def _tool_import_tag_csv(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Match CSV rows to project concept IDs and optionally create a tag."""

--- a/python/ai/test_read_text_preview_tool.py
+++ b/python/ai/test_read_text_preview_tool.py
@@ -1,0 +1,71 @@
+"""Tests for read_text_preview chat tool."""
+
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ai.chat_tools import ParseChatTools
+
+
+def _build_project(tmp_path: Path) -> Path:
+    (tmp_path / "config").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "config" / "ai_config.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "annotations").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "audio").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_read_text_preview_in_allowlist(tmp_path: Path) -> None:
+    project = _build_project(tmp_path)
+    tools = ParseChatTools(project_root=project)
+
+    assert "read_text_preview" in tools.tool_names()
+    schemas = tools.openai_tool_schemas()
+    names = [item["function"]["name"] for item in schemas]
+    assert "read_text_preview" in names
+
+
+def test_read_text_preview_reads_markdown_in_project_root(tmp_path: Path) -> None:
+    project = _build_project(tmp_path)
+    md_path = project / "notes.md"
+    md_path.write_text("# Title\n\nLine one\nLine two\n", encoding="utf-8")
+
+    tools = ParseChatTools(project_root=project)
+    result = tools.execute("read_text_preview", {"path": "notes.md", "startLine": 1, "maxLines": 3})
+
+    assert result["ok"] is True
+    inner = result["result"]
+    assert inner["ok"] is True
+    assert inner["path"].endswith("notes.md")
+    assert "# Title" in inner["content"]
+
+
+def test_read_text_preview_reads_markdown_from_docs_root(tmp_path: Path) -> None:
+    project = _build_project(tmp_path / "proj")
+    docs = tmp_path / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+    doc_file = docs / "methodology.md"
+    doc_file.write_text("## Methods\nSome text\n", encoding="utf-8")
+
+    tools = ParseChatTools(project_root=project, docs_root=docs)
+    result = tools.execute("read_text_preview", {"path": str(doc_file)})
+
+    assert result["ok"] is True
+    inner = result["result"]
+    assert inner["ok"] is True
+    assert "## Methods" in inner["content"]
+
+
+def test_read_text_preview_rejects_non_text_extension(tmp_path: Path) -> None:
+    project = _build_project(tmp_path)
+    bad_path = project / "data.json"
+    bad_path.write_text('{"a": 1}', encoding="utf-8")
+
+    tools = ParseChatTools(project_root=project)
+    result = tools.execute("read_text_preview", {"path": "data.json"})
+
+    assert result["ok"] is True
+    inner = result["result"]
+    assert inner["ok"] is False
+    assert "Unsupported file type" in inner["error"]

--- a/python/server.py
+++ b/python/server.py
@@ -1354,6 +1354,21 @@ def _chat_get_job_snapshot(job_id: str) -> Optional[Dict[str, Any]]:
     return _get_job_snapshot(job_id)
 
 
+def _chat_docs_root() -> Optional[pathlib.Path]:
+    raw = str(os.environ.get("PARSE_CHAT_DOCS_ROOT") or "").strip()
+    if not raw:
+        return None
+
+    root = pathlib.Path(raw).expanduser()
+    if not root.is_absolute():
+        root = _project_root() / root
+
+    try:
+        return root.resolve()
+    except Exception:
+        return root
+
+
 def _get_chat_runtime() -> Tuple[ParseChatTools, ChatOrchestrator]:
     global _chat_tools_runtime
     global _chat_orchestrator_runtime
@@ -1363,6 +1378,7 @@ def _get_chat_runtime() -> Tuple[ParseChatTools, ChatOrchestrator]:
             _chat_tools_runtime = ParseChatTools(
                 project_root=_project_root(),
                 config_path=_config_path(),
+                docs_root=_chat_docs_root(),
                 start_stt_job=_chat_start_stt_job,
                 get_job_snapshot=_chat_get_job_snapshot,
             )

--- a/python/test_chat_docs_root.py
+++ b/python/test_chat_docs_root.py
@@ -1,0 +1,53 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+class _DummyTools:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _DummyOrchestrator:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_chat_docs_root_relative_to_project_root(monkeypatch, tmp_path) -> None:
+    project = (tmp_path / "workspace").resolve()
+    docs_rel = "docs/chat"
+
+    monkeypatch.setattr(server, "_project_root", lambda: project)
+    monkeypatch.setenv("PARSE_CHAT_DOCS_ROOT", docs_rel)
+
+    resolved = server._chat_docs_root()
+    assert resolved == (project / docs_rel).resolve()
+
+
+def test_get_chat_runtime_passes_docs_root(monkeypatch, tmp_path) -> None:
+    project = (tmp_path / "workspace").resolve()
+    docs = (tmp_path / "notes").resolve()
+
+    captured = {}
+
+    def _fake_tools_ctor(**kwargs):
+        captured.update(kwargs)
+        return _DummyTools(**kwargs)
+
+    monkeypatch.setattr(server, "ParseChatTools", _fake_tools_ctor)
+    monkeypatch.setattr(server, "ChatOrchestrator", lambda **kwargs: _DummyOrchestrator(**kwargs))
+    monkeypatch.setattr(server, "_project_root", lambda: project)
+    monkeypatch.setattr(server, "_config_path", lambda: project / "config" / "ai_config.json")
+    monkeypatch.setattr(server, "_chat_start_stt_job", lambda *args, **kwargs: "job-1")
+    monkeypatch.setattr(server, "_chat_get_job_snapshot", lambda job_id: None)
+    monkeypatch.setattr(server, "_chat_docs_root", lambda: docs)
+
+    server._chat_tools_runtime = None
+    server._chat_orchestrator_runtime = None
+
+    server._get_chat_runtime()
+
+    assert captured["project_root"] == project
+    assert captured["docs_root"] == docs

--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -12,6 +12,8 @@
 # ---------------------
 #   PARSE_PY         Python interpreter (default: python3, or $PARSE_PY if set)
 #   PARSE_ROOT       Repo root (default: auto-detected from script location)
+#   PARSE_WORKSPACE_ROOT  Data workspace root for backend chat/tools (default: PARSE_ROOT)
+#   PARSE_CHAT_DOCS_ROOT  Optional docs root for chat markdown/text preview (default: PARSE_WORKSPACE_ROOT)
 #   PARSE_API_PORT   API server port (default: 8766)
 #   PARSE_VITE_PORT  Vite dev server port (default: 5173)
 #   PARSE_SKIP_PULL  Set to 1 to skip `git pull` (default: 0)
@@ -39,6 +41,8 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${PARSE_ROOT:=$(cd "${SCRIPT_DIR}/.." && pwd)}"
+: "${PARSE_WORKSPACE_ROOT:=${PARSE_ROOT}}"
+: "${PARSE_CHAT_DOCS_ROOT:=${PARSE_WORKSPACE_ROOT}}"
 : "${PARSE_PY:=python3}"
 : "${PARSE_API_PORT:=8766}"
 : "${PARSE_VITE_PORT:=5173}"
@@ -187,10 +191,13 @@ pull_main() {
 
 start_api() {
   log "Starting Python API server on :${PARSE_API_PORT}..."
+  log "Backend workspace root: ${PARSE_WORKSPACE_ROOT}"
+  log "Chat docs root: ${PARSE_CHAT_DOCS_ROOT}"
   # -u = unbuffered stdout (so logs appear immediately; critical for remote debugging).
   (
-    cd "${PARSE_ROOT}" || exit 1
-    "${PARSE_PY}" -u python/server.py \
+    cd "${PARSE_WORKSPACE_ROOT}" || exit 1
+    PARSE_CHAT_DOCS_ROOT="${PARSE_CHAT_DOCS_ROOT}" \
+      "${PARSE_PY}" -u "${PARSE_ROOT}/python/server.py" \
       >"${API_STDOUT_LOG}" 2>"${API_STDERR_LOG}"
   ) &
   API_PID=$!
@@ -243,12 +250,19 @@ print_banner() {
   log "  React UI:  http://localhost:${PARSE_VITE_PORT}/"
   log "  Compare:   http://localhost:${PARSE_VITE_PORT}/compare"
   log "  API:       http://localhost:${PARSE_API_PORT}/api/config"
+  log "  Workspace: ${PARSE_WORKSPACE_ROOT}"
+  log "  Chat docs: ${PARSE_CHAT_DOCS_ROOT}"
   log "════════════════════════════════════════"
 }
 
 # ---------- Main ---------------------------------------------------------
 
 main() {
+  if [ ! -d "${PARSE_WORKSPACE_ROOT}" ]; then
+    log "ERROR: PARSE_WORKSPACE_ROOT does not exist: ${PARSE_WORKSPACE_ROOT}"
+    return 1
+  fi
+
   pull_main
   stop_servers
   start_api || return 1


### PR DESCRIPTION
## Summary
- adds a new allowlisted chat tool `read_text_preview` for bounded `.md/.markdown/.txt/.rst` previews
- wires optional docs root into chat runtime via `PARSE_CHAT_DOCS_ROOT`
- updates `scripts/parse-run.sh` to support separate backend workspace root and chat docs root env wiring
- adds focused tests for tool behavior and docs-root runtime wiring

## Why
The assistant previously overclaimed about markdown availability when only structured project context was accessible. This adds an explicit, bounded, read-only path for document preview.

## Validation
- `python3 -m pytest -q python/ai/test_read_text_preview_tool.py python/test_chat_docs_root.py python/ai/test_contact_lexeme_tool.py python/test_server_chat_policy.py`
- `bash -n scripts/parse-run.sh`
- `python3 -m py_compile python/ai/chat_tools.py python/server.py`

## Notes
- no arbitrary filesystem access added
- tool remains bounded by allowlisted extensions and root constraints
