### PR TITLE
feat(chat): give PARSE AI bounded access to local WAV and CSV files

### DIFF
--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -435,12 +435,28 @@ class ParseChatTools:
                     },
                 },
             ),
+            "read_audio_info": ChatToolSpec(
+                name="read_audio_info",
+                description=(
+                    "Read metadata for a WAV file in the project audio directory: duration, "
+                    "sample rate, channels, sample width, frame count, and file size. "
+                    "Read-only; does not return audio samples."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["sourceWav"],
+                    "properties": {
+                        "sourceWav": {"type": "string", "minLength": 1, "maxLength": 512},
+                    },
+                },
+            ),
             "read_csv_preview": ChatToolSpec(
                 name="read_csv_preview",
                 description=(
                     "Read first N rows of any CSV file and return column names, delimiter, "
                     "total row count, and a sample. Defaults to concepts.csv in project root "
-                    "if no path given. Read-only."
+                    "if no path given. Path must stay within the project root. Read-only."
                 ),
                 parameters={
                     "type": "object",
@@ -1658,17 +1674,54 @@ class ParseChatTools:
             pass
         return concepts
 
+    def _tool_read_audio_info(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Return WAV metadata (duration, sample rate, channels) via stdlib wave."""
+        import wave as _wave
+
+        source_wav = str(args.get("sourceWav") or "").strip()
+        if not source_wav:
+            raise ChatToolValidationError("sourceWav is required")
+
+        safe_audio = self._resolve_project_path(source_wav, allowed_roots=[self.audio_dir])
+
+        if not safe_audio.exists() or not safe_audio.is_file():
+            return {"ok": False, "error": "File not found: {0}".format(safe_audio)}
+
+        if safe_audio.suffix.lower() != ".wav":
+            return {"ok": False, "error": "Not a .wav file: {0}".format(safe_audio.name)}
+
+        try:
+            with _wave.open(str(safe_audio), "rb") as wav:
+                channels = wav.getnchannels()
+                sample_width = wav.getsampwidth()
+                frame_rate = wav.getframerate()
+                n_frames = wav.getnframes()
+        except _wave.Error as exc:
+            return {"ok": False, "error": "Invalid WAV file: {0}".format(exc)}
+        except Exception as exc:
+            return {"ok": False, "error": "Failed to read audio file: {0}".format(exc)}
+
+        duration_sec = (n_frames / frame_rate) if frame_rate > 0 else 0.0
+
+        return {
+            "ok": True,
+            "path": str(safe_audio.relative_to(self.project_root)),
+            "channels": channels,
+            "sampleWidthBytes": sample_width,
+            "sampleRateHz": frame_rate,
+            "numFrames": n_frames,
+            "durationSec": round(duration_sec, 3),
+            "fileSizeBytes": safe_audio.stat().st_size,
+        }
+
     def _tool_read_csv_preview(self, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Read first N rows of a CSV file."""
+        """Read first N rows of a CSV file, sandboxed to the project root."""
         import csv as _csv
         raw_path = str(args.get("csvPath") or "").strip()
         max_rows = int(args.get("maxRows") or 20)
 
         if raw_path:
-            csv_path = Path(raw_path).expanduser()
-            if not csv_path.is_absolute():
-                csv_path = self.project_root / csv_path
-            csv_path = csv_path.resolve()
+            csv_path = self._resolve_project_path(raw_path, allowed_roots=[self.project_root])
         else:
             csv_path = self.project_root / "concepts.csv"
 

--- a/python/ai/test_read_audio_info_tool.py
+++ b/python/ai/test_read_audio_info_tool.py
@@ -1,0 +1,120 @@
+"""Tests for read_audio_info chat tool and read_csv_preview path sandboxing."""
+
+import sys
+import wave
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ai.chat_tools import ParseChatTools, ChatToolValidationError
+
+
+def _build_project(tmp_path: Path) -> Path:
+    (tmp_path / "config").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "config" / "ai_config.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "annotations").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "audio").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _write_wav(path: Path, *, frame_rate: int = 16000, channels: int = 1,
+               sample_width: int = 2, duration_sec: float = 0.5) -> None:
+    n_frames = int(frame_rate * duration_sec)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(channels)
+        w.setsampwidth(sample_width)
+        w.setframerate(frame_rate)
+        w.writeframes(b"\x00" * n_frames * sample_width * channels)
+
+
+def test_read_audio_info_returns_metadata(tmp_path: Path) -> None:
+    project = _build_project(tmp_path)
+    wav_path = project / "audio" / "clip.wav"
+    _write_wav(wav_path, frame_rate=22050, channels=2, duration_sec=1.25)
+
+    tools = ParseChatTools(project_root=project)
+    result = tools.execute("read_audio_info", {"sourceWav": "audio/clip.wav"})
+
+    assert result["ok"] is True
+    inner = result["result"]
+    assert inner["ok"] is True
+    assert inner["channels"] == 2
+    assert inner["sampleRateHz"] == 22050
+    assert inner["durationSec"] == 1.25
+    assert inner["numFrames"] == int(22050 * 1.25)
+    assert inner["path"] == "audio/clip.wav"
+
+
+def test_read_audio_info_rejects_path_outside_audio_dir(tmp_path: Path) -> None:
+    project = _build_project(tmp_path)
+    stray = project / "stray.wav"
+    _write_wav(stray)
+
+    tools = ParseChatTools(project_root=project)
+    with pytest.raises(ChatToolValidationError):
+        tools.execute("read_audio_info", {"sourceWav": "stray.wav"})
+
+
+def test_read_audio_info_rejects_traversal(tmp_path: Path) -> None:
+    project = _build_project(tmp_path / "proj")
+    outside = tmp_path / "outside.wav"
+    _write_wav(outside)
+
+    tools = ParseChatTools(project_root=project)
+    with pytest.raises(ChatToolValidationError):
+        tools.execute("read_audio_info", {"sourceWav": "../outside.wav"})
+
+
+def test_read_audio_info_rejects_non_wav(tmp_path: Path) -> None:
+    project = _build_project(tmp_path)
+    fake = project / "audio" / "clip.mp3"
+    fake.write_bytes(b"ID3\x00\x00\x00\x00")
+
+    tools = ParseChatTools(project_root=project)
+    result = tools.execute("read_audio_info", {"sourceWav": "audio/clip.mp3"})
+
+    assert result["ok"] is True
+    inner = result["result"]
+    assert inner["ok"] is False
+    assert ".wav" in inner["error"]
+
+
+def test_read_audio_info_rejects_corrupt_wav(tmp_path: Path) -> None:
+    project = _build_project(tmp_path)
+    bad = project / "audio" / "bad.wav"
+    bad.write_bytes(b"not a real wav header")
+
+    tools = ParseChatTools(project_root=project)
+    result = tools.execute("read_audio_info", {"sourceWav": "audio/bad.wav"})
+
+    assert result["ok"] is True
+    inner = result["result"]
+    assert inner["ok"] is False
+    assert "Invalid WAV" in inner["error"] or "Failed to read" in inner["error"]
+
+
+def test_read_csv_preview_rejects_traversal(tmp_path: Path) -> None:
+    project = _build_project(tmp_path / "proj")
+    outside = tmp_path / "secret.csv"
+    outside.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    tools = ParseChatTools(project_root=project)
+    with pytest.raises(ChatToolValidationError):
+        tools.execute("read_csv_preview", {"csvPath": "../secret.csv"})
+
+
+def test_read_csv_preview_still_works_for_valid_path(tmp_path: Path) -> None:
+    project = _build_project(tmp_path)
+    csv_path = project / "data.csv"
+    csv_path.write_text("id,label\n1,one\n2,two\n", encoding="utf-8")
+
+    tools = ParseChatTools(project_root=project)
+    result = tools.execute("read_csv_preview", {"csvPath": "data.csv"})
+
+    assert result["ok"] is True
+    inner = result["result"]
+    assert inner["ok"] is True
+    assert inner["totalRows"] == 2
+    assert inner["columns"] == ["id", "label"]


### PR DESCRIPTION
## Summary

Gives PARSE AI first-class, sandboxed read access to the two local file types the linguistic analysis actually depends on: **WAV** (audio metadata) and **CSV** (tabular data). Complements #81 (markdown/text preview).

- **New tool \`read_audio_info\`** — returns duration, sample rate, channels, sample width, frame count, and file size for a WAV in the project audio directory. Uses stdlib \`wave\`; no audio samples are returned. Sandboxed to \`self.audio_dir\` via the existing \`_resolve_project_path\` helper.

- **Hardens \`read_csv_preview\`** — the previous implementation resolved any user-supplied path without a containment check, letting a prompt traverse outside the project root (e.g. \`../../Users/.../secrets.csv\`). Now uses \`_resolve_project_path\` with \`allowed_roots=[self.project_root]\` so \`..\`-style escapes raise a validation error before any file I/O.

## Why not just read the WAV bytes directly?

- Returning audio samples to the model is ~0 useful — it can't analyze raw PCM.
- Metadata (duration, sample rate, channels) is what the model actually reasons about when deciding whether a clip is well-formed or comparing recordings across speakers.
- The existing \`spectrogram_preview\` tool is the path for visual-style analysis; this fills the metadata gap.

## Test plan

Added \`python/ai/test_read_audio_info_tool.py\` (7 cases, all pass):

- [x] \`read_audio_info\` returns correct metadata for a valid WAV
- [x] Rejects a path outside \`audio/\` (e.g. a \`.wav\` in project root)
- [x] Rejects \`..\`-style traversal
- [x] Rejects non-\`.wav\` extension
- [x] Rejects a corrupt WAV with a helpful error (not a crash)
- [x] \`read_csv_preview\` rejects \`..\`-style traversal (previously accepted silently)
- [x] \`read_csv_preview\` still works for a valid in-project path

Full suite: \`21 passed in 0.07s\`.

## Notes

- No new configuration or env vars.
- No mutating capability added; both tools remain read-only.
- Zero new dependencies — stdlib \`wave\` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)