### PR TITLE
feat(chat): show 'Thinking…' indicator while PARSE AI is processing

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -432,18 +432,32 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
         >
           <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">PARSE AI</span>
           <div className="h-4 w-px bg-slate-200"/>
-          <input
-            value={collapsedInput}
-            onChange={e => setCollapsedInput(e.target.value)}
-            onClick={e => e.stopPropagation()}
-            onFocus={() => onMinimize()}
-            placeholder={`Ask PARSE AI about ${conceptName} (#${conceptId})…`}
-            className="flex-1 bg-transparent text-[13px] text-slate-700 placeholder:text-slate-400 focus:outline-none"
-          />
+          {chatSession.sending ? (
+            <div
+              className="flex flex-1 items-center gap-1.5 text-[13px] text-slate-500"
+              aria-live="polite"
+              aria-label="PARSE AI is thinking"
+            >
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.3s]"/>
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.15s]"/>
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400"/>
+              <span className="ml-1.5 font-medium">Thinking…</span>
+            </div>
+          ) : (
+            <input
+              value={collapsedInput}
+              onChange={e => setCollapsedInput(e.target.value)}
+              onClick={e => e.stopPropagation()}
+              onFocus={() => onMinimize()}
+              placeholder={`Ask PARSE AI about ${conceptName} (#${conceptId})…`}
+              className="flex-1 bg-transparent text-[13px] text-slate-700 placeholder:text-slate-400 focus:outline-none"
+            />
+          )}
           <button
             type="submit"
             onClick={e => e.stopPropagation()}
-            className="grid h-8 w-8 place-items-center rounded-md text-slate-400 transition hover:bg-slate-200/60 hover:text-slate-700"
+            disabled={chatSession.sending}
+            className="grid h-8 w-8 place-items-center rounded-md text-slate-400 transition hover:bg-slate-200/60 hover:text-slate-700 disabled:opacity-40"
             title="Send"
           >
             <Send className="h-3.5 w-3.5"/>
@@ -759,6 +773,18 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
                   </div>
                 </div>
               ))}
+              {chatSession.sending &&
+                (chatSession.messages.length === 0 ||
+                  chatSession.messages[chatSession.messages.length - 1].role === 'user') && (
+                  <div className="flex justify-start" aria-live="polite" aria-label="PARSE AI is thinking">
+                    <div className="flex max-w-[78%] items-center gap-1.5 rounded-2xl bg-white px-4 py-3 ring-1 ring-slate-200/70 shadow-sm">
+                      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.3s]"/>
+                      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.15s]"/>
+                      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400"/>
+                      <span className="ml-1.5 text-[12px] font-medium text-slate-500">Thinking…</span>
+                    </div>
+                  </div>
+                )}
             </div>
           </div>
 

--- a/src/components/annotate/ChatPanel.tsx
+++ b/src/components/annotate/ChatPanel.tsx
@@ -321,6 +321,19 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
             <div className="mt-1 text-[10px] text-slate-400">{msg.timestamp}</div>
           </div>
         ))}
+        {sending && (messages.length === 0 || messages[messages.length - 1].role === "user") && (
+          <div
+            className="flex max-w-[80%] items-center gap-1.5 self-start rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5"
+            aria-live="polite"
+            aria-label="PARSE AI is thinking"
+            data-testid="thinking-indicator"
+          >
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.3s]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.15s]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400" />
+            <span className="ml-1.5 text-[12px] font-medium text-slate-500">Thinking…</span>
+          </div>
+        )}
         <div ref={messagesEndRef} />
       </div>
       <form onSubmit={handleSubmit} className="flex gap-2 border-t border-slate-200 bg-white px-4 py-3">


### PR DESCRIPTION
## Summary

Previously, after sending a chat message there was no visible feedback until the first token streamed back — on slow models or tool-heavy turns, this was often several seconds of silent UI. The only existing indicator was a blinking cursor *after* the assistant message had already appeared.

Adds an animated three-dot **"Thinking…"** indicator that renders while \`chatSession.sending === true\` AND the last message is from the user (or there are no messages yet).

Patched in all three chat surfaces:

- **\`ParseUI.tsx\` expanded chat drawer** — a full bubble matching the existing assistant-message style
- **\`ParseUI.tsx\` minimized command bar** — inline dots + "Thinking…" replacing the input while sending; send button disabled
- **\`components/annotate/ChatPanel.tsx\` per-concept side panel** — same bubble style as the expanded drawer

\`aria-live="polite"\` + \`aria-label="PARSE AI is thinking"\` so screen readers announce the state change.

## Test plan

Verified live in the running preview by submitting a message and polling the DOM — \`[aria-label*="thinking"]\` element is present within ~100 ms of submit and remains visible until the first assistant token arrives.

- [ ] Send a message in the expanded drawer — dots appear below your message, disappear when response starts
- [ ] Send a message from the minimized bar — input is replaced by "Thinking…" dots, send button greys out
- [ ] Send a message from the per-concept chat panel — dots appear in the message list

🤖 Generated with [Claude Code](https://claude.com/claude-code)