### PR TITLE
feat(chat): restore #85 chat-write + memory tools; add workspace init script

### DIFF
--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -4,11 +4,12 @@
 Starts a stdio MCP server that lets any MCP client (Claude Code, Cursor, Codex,
 Windsurf, etc.) call PARSE's linguistic analysis tools programmatically.
 
-Tools exposed (11):
+Tools exposed (14):
   project_context_read, annotation_read, read_csv_preview,
   cognate_compute_preview, cross_speaker_match_preview, spectrogram_preview,
   contact_lexeme_lookup, stt_start, stt_status,
-  import_tag_csv, prepare_tag_import
+  import_tag_csv, prepare_tag_import,
+  onboard_speaker_import, parse_memory_read, parse_memory_upsert_section
 
 Usage:
     python python/adapters/mcp_adapter.py
@@ -22,7 +23,9 @@ MCP client config (e.g. claude_desktop_config.json):
                 "command": "python",
                 "args": ["python/adapters/mcp_adapter.py"],
                 "env": {
-                    "PARSE_PROJECT_ROOT": "/path/to/your/parse/project"
+                    "PARSE_PROJECT_ROOT": "/path/to/your/parse/project",
+                    "PARSE_EXTERNAL_READ_ROOTS": "/mnt/c/Users/Lucas/Thesis",
+                    "PARSE_CHAT_MEMORY_PATH": "/path/to/parse-memory.md"
                 }
             }
         }
@@ -174,13 +177,158 @@ def _build_stt_callbacks() -> tuple:
     return start_stt_job, get_job_snapshot
 
 
+def _resolve_external_read_roots() -> list:
+    """Parse PARSE_EXTERNAL_READ_ROOTS from env into a list of Paths.
+
+    Mirrors server._chat_external_read_roots so MCP clients and the in-process
+    chat runtime share the same sandbox roots.
+    """
+    raw = str(os.environ.get("PARSE_EXTERNAL_READ_ROOTS") or "").strip()
+    if not raw:
+        return []
+    sep = ";" if os.name == "nt" or ";" in raw else os.pathsep
+    roots: list = []
+    for piece in raw.split(sep):
+        piece = piece.strip()
+        if not piece:
+            continue
+        candidate = Path(piece).expanduser()
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            continue
+        if resolved not in roots:
+            roots.append(resolved)
+    return roots
+
+
+def _resolve_memory_path(project_root_path: Path) -> Path:
+    raw = str(os.environ.get("PARSE_CHAT_MEMORY_PATH") or "").strip()
+    if raw:
+        candidate = Path(raw).expanduser()
+        if not candidate.is_absolute():
+            candidate = project_root_path / candidate
+        try:
+            return candidate.resolve()
+        except Exception:
+            return candidate
+    return (project_root_path / "parse-memory.md").resolve()
+
+
+def _build_onboard_callback() -> Optional[object]:
+    """Return a callback that proxies onboard_speaker_import through the HTTP API.
+
+    The MCP adapter runs out-of-process from the PARSE server, so we can't call
+    the in-process job worker directly. Instead, POST the source files as
+    multipart/form-data to /api/onboard/speaker and block on the resulting job
+    until it completes. Returns None if the API is unreachable when invoked.
+    """
+    import email.generator
+    import mimetypes
+    import time
+    import urllib.error
+    import urllib.request
+    import uuid
+
+    base_url = _resolve_api_base()
+
+    def onboard(speaker: str, source_wav: Path, source_csv: Optional[Path], is_primary: bool) -> Dict[str, Any]:
+        boundary = "----parse-mcp-{0}".format(uuid.uuid4().hex)
+        crlf = b"\r\n"
+        parts: list = []
+
+        def add_field(name: str, value: str) -> None:
+            parts.append(
+                (
+                    "--{0}\r\nContent-Disposition: form-data; name=\"{1}\"\r\n\r\n{2}\r\n"
+                    .format(boundary, name, value)
+                ).encode("utf-8")
+            )
+
+        def add_file(name: str, path: Path) -> None:
+            mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+            header = (
+                "--{0}\r\nContent-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"\r\n"
+                "Content-Type: {3}\r\n\r\n".format(boundary, name, path.name, mime)
+            ).encode("utf-8")
+            parts.append(header)
+            parts.append(path.read_bytes())
+            parts.append(crlf)
+
+        add_field("speaker_id", speaker)
+        add_file("audio", source_wav)
+        if source_csv is not None:
+            add_file("csv", source_csv)
+        parts.append("--{0}--\r\n".format(boundary).encode("utf-8"))
+
+        body = b"".join(parts)
+        req = urllib.request.Request(
+            url="{0}/api/onboard/speaker".format(base_url),
+            data=body,
+            headers={"Content-Type": "multipart/form-data; boundary={0}".format(boundary)},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=120.0) as resp:
+                response = json.loads(resp.read().decode("utf-8") or "{}")
+        except urllib.error.URLError as exc:
+            raise RuntimeError(
+                "PARSE API unreachable at {0} — cannot onboard speaker. Underlying: {1}".format(
+                    base_url, exc
+                )
+            )
+
+        job_id = str(response.get("job_id") or response.get("jobId") or "").strip()
+        if not job_id:
+            raise RuntimeError("Onboard API did not return a job_id: {0}".format(response))
+
+        # Poll for completion (bounded).
+        status_req_body = json.dumps({"job_id": job_id}).encode("utf-8")
+        deadline = time.time() + 120.0
+        final: Dict[str, Any] = {}
+        while time.time() < deadline:
+            status_req = urllib.request.Request(
+                url="{0}/api/onboard/speaker/status".format(base_url),
+                data=status_req_body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(status_req, timeout=10.0) as sresp:
+                    final = json.loads(sresp.read().decode("utf-8") or "{}")
+            except urllib.error.URLError:
+                time.sleep(1.0)
+                continue
+            status = str(final.get("status") or "").lower()
+            if status in {"complete", "error"}:
+                break
+            time.sleep(1.0)
+
+        if str(final.get("status") or "").lower() != "complete":
+            raise RuntimeError(
+                "Onboarding failed for speaker {0!r}: {1}".format(speaker, final.get("error") or final)
+            )
+
+        result = final.get("result") if isinstance(final.get("result"), dict) else {}
+        return {
+            "jobId": job_id,
+            "annotationPath": result.get("annotationPath"),
+            "wavPath": result.get("wavPath"),
+            "csvPath": result.get("csvPath"),
+            "isPrimary": is_primary,
+        }
+
+    return onboard
+
+
 def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
     """Create and return the PARSE MCP server with all tools registered.
 
     Wraps ParseChatTools so every tool available to the built-in AI chat
-    is also available over MCP for third-party agents. STT tools proxy
-    through the running HTTP server on PARSE_API_PORT (default 8766) so
-    job state is shared with the browser UI.
+    is also available over MCP for third-party agents. STT and onboarding
+    tools proxy through the running HTTP server on PARSE_API_PORT
+    (default 8766) so job state is shared with the browser UI.
     """
     if not _MCP_AVAILABLE:
         raise ImportError(
@@ -191,13 +339,22 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
     from ai.chat_tools import ParseChatTools
 
     root = _resolve_project_root(project_root)
+    external_roots = _resolve_external_read_roots()
+    memory_path = _resolve_memory_path(root)
     logger.info("PARSE MCP server starting with project root: %s", root)
+    if external_roots:
+        logger.info("External read roots: %s", ", ".join(str(r) for r in external_roots))
+    logger.info("Chat memory path: %s", memory_path)
 
     start_stt, get_snapshot = _build_stt_callbacks()
+    onboard_callback = _build_onboard_callback()
     tools = ParseChatTools(
         project_root=root,
         start_stt_job=start_stt,
         get_job_snapshot=get_snapshot,
+        external_read_roots=external_roots,
+        memory_path=memory_path,
+        onboard_speaker=onboard_callback,
     )
 
     mcp = FastMCP(
@@ -514,6 +671,90 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         if color is not None:
             args["color"] = color
         result = tools.execute("prepare_tag_import", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def onboard_speaker_import(
+        speaker: str,
+        sourceWav: str,
+        dryRun: bool,
+        sourceCsv: Optional[str] = None,
+        isPrimary: Optional[bool] = None,
+    ) -> str:
+        """Import a new speaker from on-disk audio (and optional transcription CSV).
+
+        Copies the audio into audio/original/<speaker>/, scaffolds an annotation
+        record, and registers the speaker in source_index.json. sourceWav/sourceCsv
+        may be absolute paths under PARSE_EXTERNAL_READ_ROOTS or project-relative.
+        Use dryRun=true first to preview, then dryRun=false to execute.
+
+        Args:
+            speaker: Speaker ID (filename-safe, no path separators)
+            sourceWav: Path to the source audio file
+            dryRun: If true, preview only. Run false to perform the import.
+            sourceCsv: Optional path to a transcription CSV to store alongside
+            isPrimary: Flag this WAV as the speaker's primary source
+        """
+        args: Dict[str, Any] = {
+            "speaker": speaker,
+            "sourceWav": sourceWav,
+            "dryRun": dryRun,
+        }
+        if sourceCsv is not None:
+            args["sourceCsv"] = sourceCsv
+        if isPrimary is not None:
+            args["isPrimary"] = isPrimary
+        result = tools.execute("onboard_speaker_import", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def parse_memory_read(
+        section: Optional[str] = None,
+        maxBytes: Optional[int] = None,
+    ) -> str:
+        """Read the persistent chat memory markdown (parse-memory.md).
+
+        Records speaker provenance, file origins, user preferences, and session
+        context. Read-only. Returns the full document bounded by maxBytes, or a
+        specific `## Section` when section is provided.
+
+        Args:
+            section: Heading text (without leading `##`). If given, only that
+                section is returned.
+            maxBytes: Cap on bytes returned (min 512).
+        """
+        args: Dict[str, Any] = {}
+        if section is not None:
+            args["section"] = section
+        if maxBytes is not None:
+            args["maxBytes"] = maxBytes
+        result = tools.execute("parse_memory_read", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def parse_memory_upsert_section(
+        section: str,
+        body: str,
+        dryRun: bool,
+    ) -> str:
+        """Create or replace a `## Section` block in parse-memory.md.
+
+        Use for persisting user preferences, speaker notes, onboarding decisions,
+        and file provenance that should survive across chat turns. The existing
+        block under the same heading is overwritten; other sections are untouched.
+        Use dryRun=true first to preview, then dryRun=false to write.
+
+        Args:
+            section: Section heading (without leading `##`)
+            body: Markdown body for the section
+            dryRun: If true, returns preview without writing
+        """
+        args: Dict[str, Any] = {
+            "section": section,
+            "body": body,
+            "dryRun": dryRun,
+        }
+        result = tools.execute("parse_memory_upsert_section", args)
         return json.dumps(result, indent=2, ensure_ascii=False)
 
     return mcp

--- a/python/ai/chat_orchestrator.py
+++ b/python/ai/chat_orchestrator.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 """PARSE chat orchestration (OpenAI + strict PARSE-native tools).
 
-This orchestrator is intentionally read-only in MVP:
-- no annotation/config/enrichment writes
-- no arbitrary shell/file tools
-- no file attachments
+Read-only vs. write-enabled mode is driven by ``chat.read_only`` in
+``config/ai_config.json`` (override via ``PARSE_CHAT_READ_ONLY`` env). When
+read-only the orchestrator only permits allowlisted write-capable tools
+(``WRITE_ALLOWED_TOOL_NAMES`` in ``chat_tools``) and injects guard notices
+on mutation-intent requests. When write-enabled those guards are dropped
+and any allowlisted chat tool may mutate project state.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import re
 import uuid
 from pathlib import Path
@@ -17,6 +20,18 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from .chat_tools import ChatToolError, ParseChatTools, WRITE_ALLOWED_TOOL_NAMES
 from .provider import OpenAIChatRuntime
+
+
+def _resolve_read_only(config_value: Any) -> bool:
+    """Read-only resolution: env PARSE_CHAT_READ_ONLY wins over config.
+
+    Values like "0", "false", "no", "off" disable read-only mode.
+    Any other non-empty value enables it. Empty env falls back to config.
+    """
+    env_value = str(os.environ.get("PARSE_CHAT_READ_ONLY") or "").strip().lower()
+    if env_value:
+        return env_value not in {"0", "false", "no", "off"}
+    return bool(config_value)
 
 
 _MUTATION_REQUEST_RE = re.compile(
@@ -59,33 +74,44 @@ class ChatOrchestrator:
         self.max_tool_rounds = max(1, int(chat_config.get("max_tool_rounds", 4) or 4))
         self.max_history_messages = max(1, int(chat_config.get("max_history_messages", 24) or 24))
         self.max_tool_result_chars = max(1000, int(chat_config.get("max_tool_result_chars", 24000) or 24000))
-        self.read_only = bool(chat_config.get("read_only", True))
+        self.read_only = _resolve_read_only(chat_config.get("read_only", False))
         self.attachments_supported = bool(chat_config.get("attachments_supported", False))
-
-        # Chat MVP is intentionally locked to read-only + no attachments.
-        if not self.read_only:
-            self.read_only = True
-        if self.attachments_supported:
-            self.attachments_supported = False
 
         self._system_prompt = self._build_system_prompt()
 
     def _build_system_prompt(self) -> str:
         tool_lines = "\n".join(["- {0}".format(name) for name in self.tools.tool_names()])
+
+        if self.read_only:
+            constraints = (
+                "Hard constraints (must follow):\n"
+                "1) READ-ONLY MODE: do not mutate project state. No annotation writes, no config writes, no enrichments writes, no file overwrites.\n"
+                "   Exception: allowlisted write-capable tools (e.g. contact_lexeme_lookup, tag tools, onboard_speaker_import, parse_memory_upsert_section) may write their dedicated files.\n"
+                "2) Only use allowlisted PARSE-native tools. Never invent tools and never request shell access.\n"
+                "3) No file/context attachments are supported.\n"
+                "4) If asked to apply changes, state the environment is mostly read-only and provide a preview plan unless an allowlisted write-capable tool is the correct path.\n"
+                "5) Never imply a write happened unless an allowlisted write-capable tool explicitly reports a persisted write.\n"
+                "6) Be transparent: if a tool is placeholder/unavailable, say so clearly.\n"
+            )
+        else:
+            constraints = (
+                "Operating rules (must follow):\n"
+                "1) WRITE-ENABLED MODE: you may invoke any allowlisted tool, including ones that write project state (annotations, tags, contact-language config, source index, parse-memory.md).\n"
+                "2) Destructive or broad writes require a dry-run preview first. For any tool exposing a dryRun flag, call it with dryRun=true before dryRun=false.\n"
+                "3) Only use allowlisted PARSE-native tools. Never invent tools and never request shell access.\n"
+                "4) No file/context attachments are supported — pass external file paths via tool arguments (e.g. onboard_speaker_import sourceWav) and rely on PARSE_EXTERNAL_READ_ROOTS for bounded reads.\n"
+                "5) Never imply a write happened unless a tool explicitly reports a persisted write. When reporting writes, cite the tool name and the file(s) updated.\n"
+                "6) Be transparent: if a tool is placeholder/unavailable, say so clearly.\n"
+                "7) Keep parse-memory.md current: when the user shares file provenance, speaker context, preferences, or onboarding decisions, record it via parse_memory_upsert_section so future turns can recall it with parse_memory_read.\n"
+            )
+
         return (
             "You are the built-in PARSE AI toolbox assistant.\n"
             "\n"
-            "Hard constraints (must follow):\n"
-            "1) READ-ONLY MVP: do not mutate project state. No annotation writes, no config writes, no enrichments writes, no file overwrites.\n"
-            "   Exception: contact_lexeme_lookup and tag tools are allowed to write their respective data files.\n"
-            "2) Only use allowlisted PARSE-native tools. Never invent tools and never request shell access.\n"
-            "3) No file/context attachments are supported in this MVP.\n"
-            "4) If asked to apply changes, explicitly state the environment is mostly read-only and provide a preview plan unless an allowlisted write-capable tool is the correct path.\n"
-            "5) Never imply a write happened unless an allowlisted write-capable tool explicitly reports a persisted write.\n"
-            "6) Be transparent: if a tool is placeholder/unavailable, say so clearly.\n"
+            "{constraints}"
             "\n"
             "Available tools:\n"
-            "{0}\n"
+            "{tools}\n"
             "\n"
             "External data fetching:\n"
             "- contact_lexeme_lookup can fetch reference forms (IPA) for ANY language from third-party sources\n"
@@ -93,13 +119,25 @@ class ChatOrchestrator:
             "- Use it when the user needs Arabic, Persian, Sorani, or other reference language data\n"
             "- After fetching, use cognate_compute_preview with contactLanguages to compare\n"
             "\n"
+            "Persistent memory:\n"
+            "- parse_memory_read returns the project's parse-memory.md (user preferences, speaker provenance, onboarding notes).\n"
+            "- parse_memory_upsert_section creates or replaces a `## Section` block there. Prefer small, well-named sections over one sprawling blob.\n"
+            "\n"
             "Response style:\n"
             "- concise, technical, and accurate\n"
             "- when using tools, summarize what was checked\n"
-            "- keep read-only limitations explicit when relevant\n"
+            "- {mode_note}\n"
             "- Use readable Markdown with short headings, bullets, and blank lines between sections\n"
             "- Never wrap the entire reply in a code fence unless the user explicitly asked for raw copy-paste output\n"
-        ).format(tool_lines)
+        ).format(
+            constraints=constraints,
+            tools=tool_lines,
+            mode_note=(
+                "keep read-only limitations explicit when relevant"
+                if self.read_only
+                else "note any writes performed and reference the files updated"
+            ),
+        )
 
     def _history_messages(self, session_messages: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
         filtered: List[Dict[str, Any]] = []
@@ -195,22 +233,23 @@ class ChatOrchestrator:
         write_allowed_tool_used = bool(used_tools.intersection(WRITE_ALLOWED_TOOL_NAMES))
 
         if not text:
-            text = READ_ONLY_NOTICE
+            text = READ_ONLY_NOTICE if self.read_only else "I did not produce a response for this request."
 
-        if (
-            _WRITE_CLAIM_RE.search(text)
-            and not write_allowed_tool_used
-            and not self._contains_read_only_notice(text)
-        ):
-            text = "{0}\n\n{1}".format(text, READ_ONLY_NOTICE)
+        if self.read_only:
+            if (
+                _WRITE_CLAIM_RE.search(text)
+                and not write_allowed_tool_used
+                and not self._contains_read_only_notice(text)
+            ):
+                text = "{0}\n\n{1}".format(text, READ_ONLY_NOTICE)
 
-        if (
-            user_text
-            and _MUTATION_REQUEST_RE.search(user_text)
-            and not write_allowed_tool_used
-        ):
-            if not self._contains_read_only_notice(text):
-                text = "{0}\n\n{1}".format(READ_ONLY_NOTICE, text)
+            if (
+                user_text
+                and _MUTATION_REQUEST_RE.search(user_text)
+                and not write_allowed_tool_used
+            ):
+                if not self._contains_read_only_notice(text):
+                    text = "{0}\n\n{1}".format(READ_ONLY_NOTICE, text)
 
         if user_text and _ATTACHMENT_REQUEST_RE.search(user_text):
             if not self._contains_attachments_notice(text):
@@ -398,29 +437,32 @@ class ChatOrchestrator:
                 "toolTrace": tool_trace,
                 "model": runtime_meta.get("model", self.runtime.model),
                 "reasoning": runtime_meta,
-                "mode": "read-only",
+                "mode": "read-only" if self.read_only else "write-enabled",
                 "readOnly": self.read_only,
                 "attachmentsSupported": self.attachments_supported,
-                "readOnlyNotice": READ_ONLY_NOTICE,
+                "readOnlyNotice": READ_ONLY_NOTICE if self.read_only else "",
             }
+
+        fallback_text = (
+            "I hit the maximum tool-call rounds for this turn. "
+            "Please narrow the request and try again."
+        )
+        if self.read_only:
+            fallback_text = "{0}\n\n{1}".format(fallback_text, READ_ONLY_NOTICE)
 
         return {
             "sessionId": session_id,
             "assistant": {
                 "role": "assistant",
-                "content": (
-                    "I hit the maximum tool-call rounds for this turn. "
-                    "Please narrow the request and try again.\n\n"
-                    "{0}".format(READ_ONLY_NOTICE)
-                ),
+                "content": fallback_text,
             },
             "toolTrace": tool_trace,
             "model": runtime_meta.get("model", self.runtime.model),
             "reasoning": runtime_meta,
-            "mode": "read-only",
+            "mode": "read-only" if self.read_only else "write-enabled",
             "readOnly": self.read_only,
             "attachmentsSupported": self.attachments_supported,
-            "readOnlyNotice": READ_ONLY_NOTICE,
+            "readOnlyNotice": READ_ONLY_NOTICE if self.read_only else "",
         }
 
 

--- a/python/ai/chat_orchestrator.py
+++ b/python/ai/chat_orchestrator.py
@@ -22,6 +22,10 @@ from .chat_tools import ChatToolError, ParseChatTools, WRITE_ALLOWED_TOOL_NAMES
 from .provider import OpenAIChatRuntime
 
 
+_TURN_PRIMING_MEMORY_MAX_BYTES = 16 * 1024
+_TURN_PRIMING_SOURCE_INDEX_MAX_SPEAKERS = 40
+
+
 def _resolve_read_only(config_value: Any) -> bool:
     """Read-only resolution: env PARSE_CHAT_READ_ONLY wins over config.
 
@@ -120,8 +124,9 @@ class ChatOrchestrator:
             "- After fetching, use cognate_compute_preview with contactLanguages to compare\n"
             "\n"
             "Persistent memory:\n"
-            "- parse_memory_read returns the project's parse-memory.md (user preferences, speaker provenance, onboarding notes).\n"
-            "- parse_memory_upsert_section creates or replaces a `## Section` block there. Prefer small, well-named sections over one sprawling blob.\n"
+            "- A second system message each turn auto-injects the current `parse-memory.md` and a summary of `source_index.json`. Treat it as authoritative on-disk state.\n"
+            "- parse_memory_read returns the full file on demand (useful when auto-injected content was truncated).\n"
+            "- parse_memory_upsert_section creates or replaces a `## Section` block there. Updates are visible to the next turn and all future sessions. Prefer small, well-named sections over one sprawling blob.\n"
             "\n"
             "Response style:\n"
             "- concise, technical, and accurate\n"
@@ -138,6 +143,109 @@ class ChatOrchestrator:
                 else "note any writes performed and reference the files updated"
             ),
         )
+
+    def _build_turn_priming_block(self) -> str:
+        """Return a system message body auto-loaded at the start of every turn.
+
+        Pulls the current ``parse-memory.md`` and a compact ``source_index.json``
+        summary so the model sees persistent context without having to call
+        ``parse_memory_read`` / ``project_context_read`` itself. Empty string
+        when neither file has anything worth showing.
+        """
+        sections: List[str] = []
+
+        memory_path = getattr(self.tools, "memory_path", None)
+        if isinstance(memory_path, Path) and memory_path.exists():
+            try:
+                raw = memory_path.read_text(encoding="utf-8")
+            except Exception:
+                raw = ""
+
+            text = (raw or "").strip()
+            if text:
+                encoded = text.encode("utf-8")
+                truncated = len(encoded) > _TURN_PRIMING_MEMORY_MAX_BYTES
+                if truncated:
+                    text = encoded[:_TURN_PRIMING_MEMORY_MAX_BYTES].decode("utf-8", errors="ignore")
+                    text = text + "\n\n(truncated — call parse_memory_read for full content)"
+                sections.append(
+                    "## Persistent memory (parse-memory.md)\n"
+                    "This is the live on-disk content. Use parse_memory_upsert_section to update it.\n"
+                    "---\n"
+                    "{0}".format(text)
+                )
+
+        source_index_summary = self._source_index_summary()
+        if source_index_summary:
+            sections.append(
+                "## Source index summary\n"
+                "Speakers currently registered and their primary audio path. For full details "
+                "call project_context_read.\n"
+                "---\n"
+                "{0}".format(source_index_summary)
+            )
+
+        if not sections:
+            return ""
+
+        return (
+            "Auto-loaded PARSE context for this turn. Treat these as authoritative "
+            "snapshots of on-disk state — they reflect any writes from prior turns.\n"
+            "\n"
+            + "\n\n".join(sections)
+        )
+
+    def _source_index_summary(self) -> str:
+        """Compact `speaker: path (primary/secondary)` listing of source_index.json."""
+        path = getattr(self.tools, "source_index_path", None)
+        if not isinstance(path, Path) or not path.exists():
+            return ""
+
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return ""
+
+        if not isinstance(payload, dict):
+            return ""
+
+        speakers = payload.get("speakers") if isinstance(payload.get("speakers"), dict) else {}
+        if not speakers:
+            return ""
+
+        lines: List[str] = []
+        for speaker_name in sorted(speakers.keys())[:_TURN_PRIMING_SOURCE_INDEX_MAX_SPEAKERS]:
+            entry = speakers.get(speaker_name)
+            if not isinstance(entry, dict):
+                continue
+
+            source_wavs = entry.get("source_wavs") if isinstance(entry.get("source_wavs"), list) else []
+            primary = ""
+            extras = 0
+            for wav in source_wavs:
+                if not isinstance(wav, dict):
+                    continue
+                filename = str(wav.get("path") or wav.get("filename") or "").strip()
+                if wav.get("is_primary") and not primary:
+                    primary = filename
+                elif filename:
+                    extras += 1
+            if not primary and source_wavs:
+                first = source_wavs[0]
+                if isinstance(first, dict):
+                    primary = str(first.get("path") or first.get("filename") or "").strip()
+
+            suffix = " (+{0} more)".format(extras) if extras else ""
+            lines.append("- {0}: {1}{2}".format(speaker_name, primary or "(no primary wav)", suffix))
+
+        if len(speakers) > _TURN_PRIMING_SOURCE_INDEX_MAX_SPEAKERS:
+            lines.append(
+                "- …{0} more speakers truncated; call project_context_read for the full list.".format(
+                    len(speakers) - _TURN_PRIMING_SOURCE_INDEX_MAX_SPEAKERS
+                )
+            )
+
+        return "\n".join(lines)
 
     def _history_messages(self, session_messages: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
         filtered: List[Dict[str, Any]] = []
@@ -353,6 +461,11 @@ class ChatOrchestrator:
                 "content": self._system_prompt,
             }
         ]
+
+        priming_block = self._build_turn_priming_block()
+        if priming_block:
+            messages.append({"role": "system", "content": priming_block})
+
         messages.extend(self._history_messages(session_messages))
 
         tool_trace: List[Dict[str, Any]] = []

--- a/python/ai/chat_orchestrator.py
+++ b/python/ai/chat_orchestrator.py
@@ -124,9 +124,9 @@ class ChatOrchestrator:
             "- After fetching, use cognate_compute_preview with contactLanguages to compare\n"
             "\n"
             "Persistent memory:\n"
-            "- A second system message each turn auto-injects the current `parse-memory.md` and a summary of `source_index.json`. Treat it as authoritative on-disk state.\n"
-            "- parse_memory_read returns the full file on demand (useful when auto-injected content was truncated).\n"
-            "- parse_memory_upsert_section creates or replaces a `## Section` block there. Updates are visible to the next turn and all future sessions. Prefer small, well-named sections over one sprawling blob.\n"
+            "- On the session's first assistant turn a second system message auto-injects the current `parse-memory.md` and a summary of `source_index.json`. Treat it as authoritative on-disk state at session start.\n"
+            "- Subsequent turns in the same session inherit that context via conversation history — not re-read on every turn. If you wrote to `parse-memory.md` mid-session and want to reference the new content by file rather than by memory, call `parse_memory_read`.\n"
+            "- parse_memory_upsert_section creates or replaces a `## Section` block there. Updates persist across sessions; the next session you start will see them in its auto-injected context.\n"
             "\n"
             "Response style:\n"
             "- concise, technical, and accurate\n"
@@ -143,6 +143,20 @@ class ChatOrchestrator:
                 else "note any writes performed and reference the files updated"
             ),
         )
+
+    @staticmethod
+    def _session_has_assistant_turn(session_messages: Sequence[Mapping[str, Any]]) -> bool:
+        """True iff the session history already contains an assistant reply.
+
+        A fresh chat session arrives with only the user's opening message, so
+        this is False — the "session's first turn" signal used to decide
+        whether to auto-inject persistent-context priming.
+        """
+        for row in session_messages:
+            role = str(row.get("role") or "").strip().lower()
+            if role == "assistant":
+                return True
+        return False
 
     def _build_turn_priming_block(self) -> str:
         """Return a system message body auto-loaded at the start of every turn.
@@ -462,9 +476,15 @@ class ChatOrchestrator:
             }
         ]
 
-        priming_block = self._build_turn_priming_block()
-        if priming_block:
-            messages.append({"role": "system", "content": priming_block})
+        # Auto-prime persistent context (parse-memory.md + source_index.json)
+        # only on the session's first assistant turn. Subsequent turns inherit
+        # it through the conversation history, so we don't re-inject on every
+        # message — cheaper, and avoids "memory refresh" surprising the model
+        # mid-conversation if the user wrote to parse-memory.md out of band.
+        if not self._session_has_assistant_turn(session_messages):
+            priming_block = self._build_turn_priming_block()
+            if priming_block:
+                messages.append({"role": "system", "content": priming_block})
 
         messages.extend(self._history_messages(session_messages))
 

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -43,8 +43,13 @@ WRITE_ALLOWED_TOOL_NAMES = frozenset({
     "contact_lexeme_lookup",
     "import_tag_csv",
     "prepare_tag_import",
+    "onboard_speaker_import",
+    "parse_memory_upsert_section",
 })
 TEXT_PREVIEW_EXTENSIONS = frozenset({".md", ".markdown", ".txt", ".rst"})
+ONBOARD_AUDIO_EXTENSIONS = frozenset({".wav", ".flac", ".mp3", ".ogg", ".m4a"})
+MEMORY_MAX_BYTES = 256 * 1024  # 256 KB cap on parse-memory.md
+MEMORY_SECTION_SLUG_RE = re.compile(r"[^A-Za-z0-9 _./-]+")
 
 
 class ChatToolError(Exception):
@@ -243,10 +248,30 @@ class ParseChatTools:
         docs_root: Optional[Path] = None,
         start_stt_job: Optional[Callable[[str, str, Optional[str]], str]] = None,
         get_job_snapshot: Optional[Callable[[str], Optional[Dict[str, Any]]]] = None,
+        external_read_roots: Optional[Sequence[Path]] = None,
+        memory_path: Optional[Path] = None,
+        onboard_speaker: Optional[
+            Callable[[str, Path, Optional[Path], bool], Dict[str, Any]]
+        ] = None,
     ) -> None:
         self.project_root = Path(project_root).expanduser().resolve()
         self.config_path = (Path(config_path).expanduser().resolve() if config_path else self.project_root / "config" / "ai_config.json")
         self.docs_root = Path(docs_root).expanduser().resolve() if docs_root else None
+
+        self.external_read_roots: List[Path] = []
+        for raw_root in external_read_roots or []:
+            try:
+                resolved_root = Path(raw_root).expanduser().resolve()
+            except Exception:
+                continue
+            if resolved_root not in self.external_read_roots:
+                self.external_read_roots.append(resolved_root)
+
+        self.memory_path = (
+            Path(memory_path).expanduser().resolve()
+            if memory_path
+            else (self.project_root / "parse-memory.md").resolve()
+        )
 
         self.annotations_dir = self.project_root / "annotations"
         self.audio_dir = self.project_root / "audio"
@@ -260,6 +285,7 @@ class ParseChatTools:
 
         self._start_stt_job = start_stt_job
         self._get_job_snapshot = get_job_snapshot
+        self._onboard_speaker = onboard_speaker
 
         self._tool_specs: Dict[str, ChatToolSpec] = {
             "project_context_read": ChatToolSpec(
@@ -590,6 +616,85 @@ class ParseChatTools:
                     },
                 },
             ),
+            "onboard_speaker_import": ChatToolSpec(
+                name="onboard_speaker_import",
+                description=(
+                    "Import a new speaker from on-disk audio (and optional transcription CSV). "
+                    "Copies files into audio/original/<speaker>/, scaffolds an annotation record, "
+                    "and registers the speaker in source_index.json. sourceWav/sourceCsv may be "
+                    "absolute paths under PARSE_EXTERNAL_READ_ROOTS or paths under the project "
+                    "audio/ directory. Gated by dryRun: call dryRun=true first to preview planned "
+                    "copies/registrations, then dryRun=false after the user confirms."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["speaker", "sourceWav", "dryRun"],
+                    "properties": {
+                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "sourceWav": {"type": "string", "minLength": 1, "maxLength": 1024},
+                        "sourceCsv": {"type": "string", "maxLength": 1024},
+                        "isPrimary": {
+                            "type": "boolean",
+                            "description": "Flag this WAV as the speaker's primary source. Defaults to true when the speaker has no existing sources.",
+                        },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "If true, preview only — no file copies or source_index.json writes.",
+                        },
+                    },
+                },
+            ),
+            "parse_memory_read": ChatToolSpec(
+                name="parse_memory_read",
+                description=(
+                    "Read PARSE's persistent chat memory markdown (parse-memory.md). This is "
+                    "where speaker provenance, file origins, user preferences, and session "
+                    "context are recorded. Read-only. Returns the full document bounded by "
+                    "maxBytes, or a specific `## Section` when section is provided."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "section": {
+                            "type": "string",
+                            "maxLength": 200,
+                            "description": "Heading text (without leading `##`). If given, only that section is returned.",
+                        },
+                        "maxBytes": {
+                            "type": "integer",
+                            "minimum": 512,
+                            "maximum": MEMORY_MAX_BYTES,
+                            "description": "Cap on bytes returned. Defaults to full file (up to {0} bytes).".format(MEMORY_MAX_BYTES),
+                        },
+                    },
+                },
+            ),
+            "parse_memory_upsert_section": ChatToolSpec(
+                name="parse_memory_upsert_section",
+                description=(
+                    "Create or replace a `## Section` block in parse-memory.md. Use for "
+                    "persisting user preferences, speaker notes, onboarding decisions, and "
+                    "file provenance that should survive across chat turns. Gated by dryRun — "
+                    "call dryRun=true first to preview the resulting block, then dryRun=false "
+                    "after the user confirms. The existing block under the same heading is "
+                    "overwritten; other sections are left untouched."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["section", "body", "dryRun"],
+                    "properties": {
+                        "section": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "body": {"type": "string", "minLength": 1, "maxLength": 16000},
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "If true, return the rewritten file preview without writing.",
+                        },
+                    },
+                },
+            ),
         }
 
     def openai_tool_schemas(self) -> List[Dict[str, Any]]:
@@ -749,6 +854,45 @@ class ParseChatTools:
                 )
 
         return resolved
+
+    def _resolve_readable_path(self, raw_path: str, *, extra_roots: Sequence[Path] = ()) -> Path:
+        """Resolve an arbitrary read path against the project root or a configured external root.
+
+        Expanded allowed roots = [project_root, *external_read_roots, *extra_roots]. Paths may
+        be absolute (then must fall under one of the roots) or relative (resolved against
+        project_root). Raises ChatToolValidationError on escape.
+        """
+        value = str(raw_path or "").strip()
+        if not value:
+            raise ChatToolValidationError("Path is required")
+
+        allowed_roots: List[Path] = [self.project_root]
+        for root in self.external_read_roots:
+            if root not in allowed_roots:
+                allowed_roots.append(root)
+        for root in extra_roots:
+            resolved_extra = Path(root).expanduser().resolve()
+            if resolved_extra not in allowed_roots:
+                allowed_roots.append(resolved_extra)
+
+        candidate = Path(value).expanduser()
+        if not candidate.is_absolute():
+            candidate = self.project_root / candidate
+
+        resolved = candidate.resolve()
+
+        for root in allowed_roots:
+            try:
+                resolved.relative_to(root)
+                return resolved
+            except ValueError:
+                continue
+
+        raise ChatToolValidationError(
+            "Path is outside allowed read roots: {0}".format(
+                ", ".join([str(root) for root in allowed_roots])
+            )
+        )
 
     def _annotation_path_for_speaker(self, speaker: str) -> Optional[Path]:
         primary = (self.annotations_dir / "{0}{1}".format(speaker, ANNOTATION_FILENAME_SUFFIX)).resolve()
@@ -1695,6 +1839,13 @@ class ParseChatTools:
             pass
         return concepts
 
+    def _display_readable_path(self, path: Path) -> str:
+        """Return a project-relative path if possible, else the absolute path."""
+        try:
+            return str(path.relative_to(self.project_root))
+        except ValueError:
+            return str(path)
+
     def _tool_read_audio_info(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Return WAV metadata (duration, sample rate, channels) via stdlib wave."""
         import wave as _wave
@@ -1703,7 +1854,13 @@ class ParseChatTools:
         if not source_wav:
             raise ChatToolValidationError("sourceWav is required")
 
-        safe_audio = self._resolve_project_path(source_wav, allowed_roots=[self.audio_dir])
+        # Paths under audio/ may be relative; absolute paths must fall under
+        # the project root or a configured PARSE_EXTERNAL_READ_ROOTS entry.
+        candidate = Path(source_wav).expanduser()
+        if candidate.is_absolute() and self.external_read_roots:
+            safe_audio = self._resolve_readable_path(source_wav)
+        else:
+            safe_audio = self._resolve_project_path(source_wav, allowed_roots=[self.audio_dir])
 
         if not safe_audio.exists() or not safe_audio.is_file():
             return {"ok": False, "error": "File not found: {0}".format(safe_audio)}
@@ -1726,7 +1883,7 @@ class ParseChatTools:
 
         return {
             "ok": True,
-            "path": str(safe_audio.relative_to(self.project_root)),
+            "path": self._display_readable_path(safe_audio),
             "channels": channels,
             "sampleWidthBytes": sample_width,
             "sampleRateHz": frame_rate,
@@ -1736,13 +1893,13 @@ class ParseChatTools:
         }
 
     def _tool_read_csv_preview(self, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Read first N rows of a CSV file, sandboxed to the project root."""
+        """Read first N rows of a CSV file, sandboxed to project + external read roots."""
         import csv as _csv
         raw_path = str(args.get("csvPath") or "").strip()
         max_rows = int(args.get("maxRows") or 20)
 
         if raw_path:
-            csv_path = self._resolve_project_path(raw_path, allowed_roots=[self.project_root])
+            csv_path = self._resolve_readable_path(raw_path)
         else:
             csv_path = self.project_root / "concepts.csv"
 
@@ -1790,29 +1947,14 @@ class ParseChatTools:
         max_lines = int(args.get("maxLines") or 120)
         max_chars = int(args.get("maxChars") or 12000)
 
-        allowed_roots = [self.project_root]
+        extra_roots: List[Path] = []
         if self.docs_root is not None:
-            allowed_roots.append(self.docs_root)
+            extra_roots.append(self.docs_root)
 
-        candidate = Path(raw_path).expanduser()
-        if not candidate.is_absolute():
-            candidate = self.project_root / candidate
-        text_path = candidate.resolve()
-
-        root_allowed = False
-        for root in allowed_roots:
-            try:
-                text_path.relative_to(root.resolve())
-                root_allowed = True
-                break
-            except ValueError:
-                continue
-
-        if not root_allowed:
-            return {
-                "ok": False,
-                "error": "Path is outside allowed roots",
-            }
+        try:
+            text_path = self._resolve_readable_path(raw_path, extra_roots=extra_roots)
+        except ChatToolValidationError as exc:
+            return {"ok": False, "error": str(exc)}
 
         extension = text_path.suffix.lower()
         if extension not in TEXT_PREVIEW_EXTENSIONS:
@@ -2072,6 +2214,338 @@ class ParseChatTools:
             "assignedCount": len(concept_ids),
             "totalTagsInFile": len(tags),
             "message": "Tag {0!r} created with {1} concepts. Refresh Compare to see it.".format(tag_name, len(concept_ids)),
+        }
+
+    # ------------------------------------------------------------------
+    # Speaker onboarding via chat
+    # ------------------------------------------------------------------
+
+    def _resolve_onboard_source(self, raw_path: str, *, must_be_audio: bool) -> Path:
+        """Resolve a sourceWav/sourceCsv argument.
+
+        Accepts absolute paths under PARSE_EXTERNAL_READ_ROOTS, or absolute/relative
+        paths that land under the project root (typically under audio/). Ensures the
+        file exists and, for audio, has a supported extension.
+        """
+        resolved = self._resolve_readable_path(raw_path)
+
+        if not resolved.exists() or not resolved.is_file():
+            raise ChatToolValidationError("Source file not found: {0}".format(resolved))
+
+        if must_be_audio:
+            suffix = resolved.suffix.lower()
+            if suffix not in ONBOARD_AUDIO_EXTENSIONS:
+                raise ChatToolValidationError(
+                    "Unsupported audio format: {0} (allowed: {1})".format(
+                        suffix or "(none)", ", ".join(sorted(ONBOARD_AUDIO_EXTENSIONS))
+                    )
+                )
+        else:
+            if resolved.suffix.lower() != ".csv":
+                raise ChatToolValidationError("sourceCsv must have a .csv extension")
+
+        return resolved
+
+    def _tool_onboard_speaker_import(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        speaker = self._normalize_speaker(args.get("speaker"))
+
+        source_wav_raw = str(args.get("sourceWav") or "").strip()
+        if not source_wav_raw:
+            raise ChatToolValidationError("sourceWav is required")
+
+        wav_path = self._resolve_onboard_source(source_wav_raw, must_be_audio=True)
+
+        csv_path: Optional[Path] = None
+        source_csv_raw = str(args.get("sourceCsv") or "").strip()
+        if source_csv_raw:
+            csv_path = self._resolve_onboard_source(source_csv_raw, must_be_audio=False)
+
+        dry_run = bool(args.get("dryRun"))
+        is_primary_arg = args.get("isPrimary")
+
+        # Existing source index state — used for preview and to decide the default is_primary.
+        source_index = _read_json_file(self.source_index_path, {})
+        speakers_block = source_index.get("speakers") if isinstance(source_index, dict) else {}
+        existing_entry = speakers_block.get(speaker) if isinstance(speakers_block, dict) else None
+        existing_sources = (
+            existing_entry.get("source_wavs", [])
+            if isinstance(existing_entry, dict)
+            else []
+        )
+        existing_filenames = [
+            str(entry.get("filename", ""))
+            for entry in existing_sources
+            if isinstance(entry, dict)
+        ]
+        already_registered = wav_path.name in existing_filenames
+
+        if is_primary_arg is None:
+            is_primary = not existing_sources and not already_registered
+        else:
+            is_primary = bool(is_primary_arg)
+
+        target_dir = self.audio_dir / "original" / speaker
+        wav_dest = target_dir / wav_path.name
+        csv_dest = (target_dir / csv_path.name) if csv_path else None
+
+        plan: Dict[str, Any] = {
+            "speaker": speaker,
+            "sourceWav": str(wav_path),
+            "sourceCsv": str(csv_path) if csv_path else None,
+            "wavDest": self._display_readable_path(wav_dest),
+            "csvDest": self._display_readable_path(csv_dest) if csv_dest else None,
+            "isPrimary": is_primary,
+            "newSpeaker": not isinstance(existing_entry, dict),
+            "alreadyRegistered": already_registered,
+            "wavSizeBytes": wav_path.stat().st_size,
+            "csvSizeBytes": csv_path.stat().st_size if csv_path else None,
+        }
+
+        if dry_run:
+            return {
+                "ok": True,
+                "dryRun": True,
+                "plan": plan,
+                "message": (
+                    "Preview only. Run again with dryRun=false to copy the audio into "
+                    "audio/original/{speaker}/ and register it in source_index.json."
+                ).format(speaker=speaker),
+            }
+
+        if self._onboard_speaker is None:
+            return {
+                "ok": False,
+                "dryRun": False,
+                "error": (
+                    "Onboarding callback is not wired in this chat runtime — cannot "
+                    "write to the project. Run the PARSE server (scripts/parse-run.sh) "
+                    "and retry."
+                ),
+                "plan": plan,
+            }
+
+        try:
+            callback_result = self._onboard_speaker(speaker, wav_path, csv_path, is_primary)
+        except Exception as exc:
+            return {
+                "ok": False,
+                "dryRun": False,
+                "error": "Onboarding failed: {0}".format(exc),
+                "plan": plan,
+            }
+
+        out: Dict[str, Any] = {
+            "ok": True,
+            "dryRun": False,
+            "plan": plan,
+            "message": "Speaker {0!r} imported.".format(speaker),
+        }
+        if isinstance(callback_result, dict):
+            out.update(callback_result)
+        return out
+
+    # ------------------------------------------------------------------
+    # Persistent chat memory (parse-memory.md)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _memory_normalize_heading(raw: str) -> str:
+        return " ".join(str(raw or "").strip().split())
+
+    @classmethod
+    def _memory_match_section(cls, section: str, heading_line: str) -> bool:
+        stripped = heading_line.strip()
+        if not stripped.startswith("##"):
+            return False
+        heading_text = stripped.lstrip("#").strip()
+        return heading_text.lower() == section.lower()
+
+    @classmethod
+    def _memory_split_sections(cls, content: str) -> List[Tuple[str, str]]:
+        """Return [(heading_line_or_empty, body_text), ...] preserving order.
+
+        The first entry has heading_line="" and contains any prelude before the
+        first `##` heading. Subsequent entries start with their heading line.
+        """
+        lines = content.splitlines(keepends=True)
+        sections: List[Tuple[str, List[str]]] = [("", [])]
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("## ") or stripped == "##":
+                sections.append((line.rstrip("\n"), []))
+            else:
+                sections[-1][1].append(line)
+        return [(heading, "".join(body)) for heading, body in sections]
+
+    def _memory_read_raw(self) -> str:
+        if not self.memory_path.exists():
+            return ""
+        try:
+            return self.memory_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            raise ChatToolExecutionError("Failed to read parse-memory.md: {0}".format(exc))
+
+    def _tool_parse_memory_read(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        section_arg = self._memory_normalize_heading(args.get("section"))
+        max_bytes_raw = args.get("maxBytes")
+        try:
+            max_bytes = int(max_bytes_raw) if max_bytes_raw is not None else MEMORY_MAX_BYTES
+        except (TypeError, ValueError):
+            max_bytes = MEMORY_MAX_BYTES
+        max_bytes = max(512, min(MEMORY_MAX_BYTES, max_bytes))
+
+        path_display = self._display_readable_path(self.memory_path)
+
+        if not self.memory_path.exists():
+            return {
+                "ok": True,
+                "path": path_display,
+                "exists": False,
+                "content": "",
+                "sections": [],
+                "message": "parse-memory.md does not exist yet. Use parse_memory_upsert_section to create it.",
+            }
+
+        raw = self._memory_read_raw()
+        parsed = self._memory_split_sections(raw)
+        section_headings = [
+            heading_line.lstrip("#").strip()
+            for heading_line, _body in parsed
+            if heading_line
+        ]
+
+        if section_arg:
+            for heading_line, body in parsed:
+                if heading_line and self._memory_match_section(section_arg, heading_line):
+                    content = "{0}\n{1}".format(heading_line, body).strip("\n")
+                    truncated = False
+                    encoded = content.encode("utf-8")
+                    if len(encoded) > max_bytes:
+                        content = encoded[:max_bytes].decode("utf-8", errors="ignore")
+                        truncated = True
+                    return {
+                        "ok": True,
+                        "path": path_display,
+                        "exists": True,
+                        "section": section_arg,
+                        "content": content,
+                        "truncated": truncated,
+                        "sections": section_headings,
+                    }
+            return {
+                "ok": True,
+                "path": path_display,
+                "exists": True,
+                "section": section_arg,
+                "found": False,
+                "content": "",
+                "sections": section_headings,
+                "message": "Section not found. Existing sections: {0}".format(
+                    ", ".join(section_headings) or "(none)"
+                ),
+            }
+
+        encoded = raw.encode("utf-8")
+        truncated = len(encoded) > max_bytes
+        content = encoded[:max_bytes].decode("utf-8", errors="ignore") if truncated else raw
+
+        return {
+            "ok": True,
+            "path": path_display,
+            "exists": True,
+            "content": content,
+            "truncated": truncated,
+            "totalBytes": len(encoded),
+            "sections": section_headings,
+        }
+
+    def _tool_parse_memory_upsert_section(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        section = self._memory_normalize_heading(args.get("section"))
+        if not section:
+            raise ChatToolValidationError("section is required")
+
+        body = str(args.get("body") or "").rstrip()
+        if not body:
+            raise ChatToolValidationError("body is required")
+
+        dry_run = bool(args.get("dryRun"))
+
+        # Ensure parse-memory.md lives somewhere writable (project root or under it).
+        try:
+            self.memory_path.relative_to(self.project_root)
+        except ValueError:
+            # Absolute custom location is allowed; just make sure the parent exists.
+            pass
+
+        existing = self._memory_read_raw()
+        sections = self._memory_split_sections(existing) if existing else [("", "")]
+
+        rendered_heading = "## {0}".format(section)
+        rendered_section = "{0}\n{1}\n".format(rendered_heading, body)
+
+        updated_parts: List[str] = []
+        replaced = False
+        for heading_line, section_body in sections:
+            if heading_line and self._memory_match_section(section, heading_line):
+                updated_parts.append(rendered_section)
+                replaced = True
+            elif not heading_line:
+                # Prelude (before first ## heading)
+                updated_parts.append(section_body)
+            else:
+                updated_parts.append("{0}\n{1}".format(heading_line, section_body))
+
+        if not replaced:
+            # Append a new section at end, ensuring a blank line separator.
+            preface = "".join(updated_parts)
+            if preface and not preface.endswith("\n"):
+                preface = preface + "\n"
+            if preface and not preface.endswith("\n\n"):
+                preface = preface + "\n"
+            if not preface:
+                preface = "# PARSE chat memory\n\n"
+            updated_content = preface + rendered_section
+        else:
+            updated_content = "".join(updated_parts)
+            if not updated_content.endswith("\n"):
+                updated_content = updated_content + "\n"
+
+        if len(updated_content.encode("utf-8")) > MEMORY_MAX_BYTES:
+            return {
+                "ok": False,
+                "error": "parse-memory.md would exceed {0} bytes. Trim an old section first.".format(MEMORY_MAX_BYTES),
+            }
+
+        path_display = self._display_readable_path(self.memory_path)
+
+        if dry_run:
+            return {
+                "ok": True,
+                "dryRun": True,
+                "path": path_display,
+                "section": section,
+                "action": "replace" if replaced else "create",
+                "previewSection": rendered_section,
+                "totalBytesAfter": len(updated_content.encode("utf-8")),
+            }
+
+        try:
+            self.memory_path.parent.mkdir(parents=True, exist_ok=True)
+            self.memory_path.write_text(updated_content, encoding="utf-8")
+        except Exception as exc:
+            return {"ok": False, "error": "Failed to write parse-memory.md: {0}".format(exc)}
+
+        return {
+            "ok": True,
+            "dryRun": False,
+            "path": path_display,
+            "section": section,
+            "action": "replace" if replaced else "create",
+            "totalBytesAfter": len(updated_content.encode("utf-8")),
+            "message": "parse-memory.md {0}d section {1!r}.".format(
+                "update" if replaced else "create",
+                section,
+            ),
         }
 
 

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -48,7 +48,7 @@ _DEFAULT_AI_CONFIG: Dict[str, Any] = {
     },
     "chat": {
         "enabled": True,
-        "read_only": True,
+        "read_only": False,
         "attachments_supported": False,
         "provider": "openai",
         "model": "gpt-5.4",
@@ -283,7 +283,9 @@ def load_ai_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
 def _build_chat_config(merged_config: Dict[str, Any]) -> Dict[str, Any]:
     """Resolve chat config from merged defaults/user config.
 
-    Chat is OpenAI-only and read-only in the current PARSE MVP backend.
+    Chat is OpenAI-compatible (OpenAI or xAI). ``read_only`` is honored from
+    config (env ``PARSE_CHAT_READ_ONLY`` also overrides it at orchestrator
+    construction). Attachments remain unsupported.
     """
     llm_config = merged_config.get("llm", {})
     if not isinstance(llm_config, dict):
@@ -295,7 +297,7 @@ def _build_chat_config(merged_config: Dict[str, Any]) -> Dict[str, Any]:
 
     defaults = {
         "enabled": True,
-        "read_only": True,
+        "read_only": False,
         "attachments_supported": False,
         "provider": "openai",
         "model": str(chat_config.get("model") or llm_config.get("model") or "gpt-5.4").strip() or "gpt-5.4",
@@ -380,13 +382,7 @@ def _build_chat_config(merged_config: Dict[str, Any]) -> Dict[str, Any]:
         maximum=1000,
     )
 
-    read_only = _coerce_bool(resolved.get("read_only"), True)
-    if not read_only:
-        print(
-            "[WARN] chat.read_only=false is unsupported in MVP; forcing read-only",
-            file=sys.stderr,
-        )
-    resolved["read_only"] = True
+    resolved["read_only"] = _coerce_bool(resolved.get("read_only"), False)
 
     attachments_supported = _coerce_bool(resolved.get("attachments_supported"), False)
     if attachments_supported:

--- a/python/ai/test_chat_orchestrator_read_only.py
+++ b/python/ai/test_chat_orchestrator_read_only.py
@@ -1,0 +1,100 @@
+"""Regression coverage for chat orchestrator read-only resolution.
+
+Before this change the orchestrator unconditionally forced ``read_only=True``,
+ignoring ``chat.read_only`` in ``config/ai_config.json`` and ignoring the
+``PARSE_CHAT_READ_ONLY`` environment override. New behavior: config drives the
+default, env overrides config.
+"""
+import pathlib
+import sys
+
+_HERE = pathlib.Path(__file__).resolve().parent
+_PYTHON_DIR = _HERE.parent
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+import pytest
+
+from ai import chat_orchestrator
+from ai.chat_orchestrator import ChatOrchestrator
+from ai.chat_tools import ParseChatTools
+
+
+class _StubRuntime:
+    def __init__(self, chat_config):
+        self.chat_config = chat_config
+        self.model = "stub-model"
+
+
+@pytest.fixture
+def patched_runtime(monkeypatch):
+    """Patch OpenAIChatRuntime to a stub so ChatOrchestrator can be constructed
+    without touching credentials or network."""
+    def _factory(chat_config):
+        def _build(*args, **kwargs):
+            return _StubRuntime(chat_config)
+
+        monkeypatch.setattr(chat_orchestrator, "OpenAIChatRuntime", _build)
+
+    return _factory
+
+
+def test_read_only_defaults_to_config_value(tmp_path, monkeypatch, patched_runtime) -> None:
+    monkeypatch.delenv("PARSE_CHAT_READ_ONLY", raising=False)
+    patched_runtime({"read_only": False})
+    tools = ParseChatTools(project_root=tmp_path)
+
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    assert orch.read_only is False
+
+
+def test_read_only_config_true_is_respected(tmp_path, monkeypatch, patched_runtime) -> None:
+    monkeypatch.delenv("PARSE_CHAT_READ_ONLY", raising=False)
+    patched_runtime({"read_only": True})
+    tools = ParseChatTools(project_root=tmp_path)
+
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    assert orch.read_only is True
+
+
+def test_env_overrides_config_to_enable_writes(tmp_path, monkeypatch, patched_runtime) -> None:
+    monkeypatch.setenv("PARSE_CHAT_READ_ONLY", "0")
+    patched_runtime({"read_only": True})
+    tools = ParseChatTools(project_root=tmp_path)
+
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    assert orch.read_only is False
+
+
+def test_env_overrides_config_to_enforce_read_only(tmp_path, monkeypatch, patched_runtime) -> None:
+    monkeypatch.setenv("PARSE_CHAT_READ_ONLY", "1")
+    patched_runtime({"read_only": False})
+    tools = ParseChatTools(project_root=tmp_path)
+
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    assert orch.read_only is True
+
+
+def test_write_mode_system_prompt_omits_read_only_language(tmp_path, monkeypatch, patched_runtime) -> None:
+    monkeypatch.setenv("PARSE_CHAT_READ_ONLY", "0")
+    patched_runtime({"read_only": True})
+    tools = ParseChatTools(project_root=tmp_path)
+
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    assert "WRITE-ENABLED MODE" in orch._system_prompt
+    assert "READ-ONLY MODE" not in orch._system_prompt
+
+
+def test_read_mode_system_prompt_has_read_only_language(tmp_path, monkeypatch, patched_runtime) -> None:
+    monkeypatch.setenv("PARSE_CHAT_READ_ONLY", "1")
+    patched_runtime({"read_only": False})
+    tools = ParseChatTools(project_root=tmp_path)
+
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    assert "READ-ONLY MODE" in orch._system_prompt

--- a/python/ai/test_chat_turn_priming.py
+++ b/python/ai/test_chat_turn_priming.py
@@ -1,0 +1,166 @@
+"""Tests for chat turn priming — parse-memory.md and source_index.json are
+auto-injected into every turn's system context so the model doesn't have to
+call parse_memory_read / project_context_read to see them."""
+import json
+import pathlib
+import sys
+
+_HERE = pathlib.Path(__file__).resolve().parent
+_PYTHON_DIR = _HERE.parent
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+import pytest
+
+from ai import chat_orchestrator
+from ai.chat_orchestrator import ChatOrchestrator
+from ai.chat_tools import ParseChatTools
+
+
+class _StubRuntime:
+    def __init__(self, chat_config):
+        self.chat_config = chat_config
+        self.model = "stub-model"
+
+
+@pytest.fixture
+def stub_runtime(monkeypatch):
+    def _install(chat_config):
+        monkeypatch.setattr(
+            chat_orchestrator,
+            "OpenAIChatRuntime",
+            lambda *args, **kwargs: _StubRuntime(chat_config),
+        )
+
+    return _install
+
+
+def test_priming_block_empty_when_no_memory_or_source_index(tmp_path, monkeypatch, stub_runtime) -> None:
+    stub_runtime({})
+    tools = ParseChatTools(project_root=tmp_path)
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    assert orch._build_turn_priming_block() == ""
+
+
+def test_priming_block_includes_parse_memory_content(tmp_path, monkeypatch, stub_runtime) -> None:
+    stub_runtime({})
+    (tmp_path / "parse-memory.md").write_text(
+        "# PARSE chat memory\n\n## User preferences\n- terse tone\n",
+        encoding="utf-8",
+    )
+    tools = ParseChatTools(project_root=tmp_path)
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    block = orch._build_turn_priming_block()
+    assert "Persistent memory" in block
+    assert "terse tone" in block
+    assert "parse-memory.md" in block
+
+
+def test_priming_block_truncates_oversize_memory(tmp_path, monkeypatch, stub_runtime) -> None:
+    stub_runtime({})
+    big_payload = "# memory\n\n" + ("a" * (32 * 1024))
+    (tmp_path / "parse-memory.md").write_text(big_payload, encoding="utf-8")
+    tools = ParseChatTools(project_root=tmp_path)
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    block = orch._build_turn_priming_block()
+    assert "(truncated — call parse_memory_read for full content)" in block
+
+
+def test_priming_block_includes_source_index_summary(tmp_path, monkeypatch, stub_runtime) -> None:
+    stub_runtime({})
+    source_index = {
+        "speakers": {
+            "Faili01": {
+                "source_wavs": [
+                    {
+                        "path": "audio/original/Faili01/Faili_M_1984.wav",
+                        "filename": "Faili_M_1984.wav",
+                        "is_primary": True,
+                    }
+                ],
+            },
+            "Kalh01": {
+                "source_wavs": [
+                    {"path": "audio/original/Kalh01/Kalh_F_1990.wav", "is_primary": True},
+                    {"path": "audio/original/Kalh01/alt_take.wav", "is_primary": False},
+                ],
+            },
+        }
+    }
+    (tmp_path / "source_index.json").write_text(json.dumps(source_index), encoding="utf-8")
+    tools = ParseChatTools(project_root=tmp_path)
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    block = orch._build_turn_priming_block()
+    assert "Source index summary" in block
+    assert "Faili01" in block
+    assert "Faili_M_1984.wav" in block
+    assert "Kalh01" in block
+    assert "+1 more" in block  # secondary wav counted
+
+
+def test_run_injects_priming_block_as_second_system_message(tmp_path, monkeypatch, stub_runtime) -> None:
+    """The priming block must appear as its own system message so the model
+    sees it even when the static system prompt is cached upstream."""
+    stub_runtime({})
+    (tmp_path / "parse-memory.md").write_text(
+        "## User preferences\n- terse tone\n", encoding="utf-8"
+    )
+
+    tools = ParseChatTools(project_root=tmp_path)
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    captured: dict = {}
+
+    class _FakeChoice:
+        def __init__(self, text):
+            self.message = type("Msg", (), {"content": text, "tool_calls": None})()
+
+    class _FakeResponse:
+        def __init__(self, text):
+            self.choices = [_FakeChoice(text)]
+
+    def _fake_complete(messages, tools=None, tool_choice=None):
+        captured["messages"] = list(messages)
+        return _FakeResponse("ok"), {"model": "stub-model"}
+
+    orch.runtime.complete = _fake_complete  # type: ignore[assignment]
+
+    orch.run(
+        session_id="session-1",
+        session_messages=[{"role": "user", "content": "hi"}],
+    )
+
+    msgs = captured["messages"]
+    # [0] is the static system prompt; [1] is the auto-priming block; [2] is the user turn.
+    assert msgs[0]["role"] == "system"
+    assert msgs[1]["role"] == "system"
+    assert "terse tone" in msgs[1]["content"]
+    assert msgs[2]["role"] == "user"
+
+
+def test_priming_reflects_parse_memory_updates_between_turns(tmp_path, monkeypatch, stub_runtime) -> None:
+    """An update from turn N must be visible in turn N+1's priming block."""
+    stub_runtime({})
+    tools = ParseChatTools(project_root=tmp_path)
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    # Simulate a write that the agent made on turn N.
+    tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Speakers", "body": "- Faili01 from Fail01", "dryRun": False},
+    )
+
+    block = orch._build_turn_priming_block()
+    assert "Faili01 from Fail01" in block
+
+    tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Speakers", "body": "- Faili01 from Fail01\n- Kalh01 from Kalh01", "dryRun": False},
+    )
+
+    block2 = orch._build_turn_priming_block()
+    assert "Kalh01 from Kalh01" in block2

--- a/python/ai/test_chat_turn_priming.py
+++ b/python/ai/test_chat_turn_priming.py
@@ -102,19 +102,7 @@ def test_priming_block_includes_source_index_summary(tmp_path, monkeypatch, stub
     assert "+1 more" in block  # secondary wav counted
 
 
-def test_run_injects_priming_block_as_second_system_message(tmp_path, monkeypatch, stub_runtime) -> None:
-    """The priming block must appear as its own system message so the model
-    sees it even when the static system prompt is cached upstream."""
-    stub_runtime({})
-    (tmp_path / "parse-memory.md").write_text(
-        "## User preferences\n- terse tone\n", encoding="utf-8"
-    )
-
-    tools = ParseChatTools(project_root=tmp_path)
-    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
-
-    captured: dict = {}
-
+def _install_fake_completion(orchestrator, captured):
     class _FakeChoice:
         def __init__(self, text):
             self.message = type("Msg", (), {"content": text, "tool_calls": None})()
@@ -127,7 +115,22 @@ def test_run_injects_priming_block_as_second_system_message(tmp_path, monkeypatc
         captured["messages"] = list(messages)
         return _FakeResponse("ok"), {"model": "stub-model"}
 
-    orch.runtime.complete = _fake_complete  # type: ignore[assignment]
+    orchestrator.runtime.complete = _fake_complete  # type: ignore[assignment]
+
+
+def test_run_injects_priming_block_on_first_turn_of_session(tmp_path, monkeypatch, stub_runtime) -> None:
+    """First turn of a fresh session (no prior assistant reply) gets the
+    auto-injected priming block as a second system message."""
+    stub_runtime({})
+    (tmp_path / "parse-memory.md").write_text(
+        "## User preferences\n- terse tone\n", encoding="utf-8"
+    )
+
+    tools = ParseChatTools(project_root=tmp_path)
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    captured: dict = {}
+    _install_fake_completion(orch, captured)
 
     orch.run(
         session_id="session-1",
@@ -135,20 +138,52 @@ def test_run_injects_priming_block_as_second_system_message(tmp_path, monkeypatc
     )
 
     msgs = captured["messages"]
-    # [0] is the static system prompt; [1] is the auto-priming block; [2] is the user turn.
+    # [0] static system prompt, [1] priming block, [2] user turn.
     assert msgs[0]["role"] == "system"
     assert msgs[1]["role"] == "system"
     assert "terse tone" in msgs[1]["content"]
     assert msgs[2]["role"] == "user"
 
 
-def test_priming_reflects_parse_memory_updates_between_turns(tmp_path, monkeypatch, stub_runtime) -> None:
-    """An update from turn N must be visible in turn N+1's priming block."""
+def test_run_skips_priming_on_subsequent_turns_of_session(tmp_path, monkeypatch, stub_runtime) -> None:
+    """If the session already has an assistant reply the priming block is
+    NOT re-injected — the model inherits context through conversation history
+    instead of reloading it each turn."""
+    stub_runtime({})
+    (tmp_path / "parse-memory.md").write_text(
+        "## User preferences\n- terse tone\n", encoding="utf-8"
+    )
+
+    tools = ParseChatTools(project_root=tmp_path)
+    orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
+
+    captured: dict = {}
+    _install_fake_completion(orch, captured)
+
+    orch.run(
+        session_id="session-1",
+        session_messages=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "what did I say?"},
+        ],
+    )
+
+    msgs = captured["messages"]
+    # Exactly one system message — the static prompt. No priming block.
+    system_messages = [m for m in msgs if m.get("role") == "system"]
+    assert len(system_messages) == 1
+    assert "terse tone" not in system_messages[0]["content"]
+
+
+def test_priming_reflects_parse_memory_updates_between_sessions(tmp_path, monkeypatch, stub_runtime) -> None:
+    """An update from session N must be visible in session N+1's priming block.
+    The priming reads straight off disk so the new session sees the new file
+    whether or not the writing session is still alive."""
     stub_runtime({})
     tools = ParseChatTools(project_root=tmp_path)
     orch = ChatOrchestrator(project_root=tmp_path, tools=tools)
 
-    # Simulate a write that the agent made on turn N.
     tools.execute(
         "parse_memory_upsert_section",
         {"section": "Speakers", "body": "- Faili01 from Fail01", "dryRun": False},

--- a/python/ai/test_parse_memory_tool.py
+++ b/python/ai/test_parse_memory_tool.py
@@ -1,0 +1,160 @@
+"""Tests for parse_memory_read / parse_memory_upsert_section chat tools."""
+import pathlib
+import sys
+
+_HERE = pathlib.Path(__file__).resolve().parent
+_PYTHON_DIR = _HERE.parent
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+from ai.chat_tools import ParseChatTools, WRITE_ALLOWED_TOOL_NAMES
+
+
+def _tools(tmp_path) -> ParseChatTools:
+    return ParseChatTools(project_root=tmp_path)
+
+
+def test_memory_read_returns_not_exists_when_file_missing(tmp_path) -> None:
+    result = _tools(tmp_path).execute("parse_memory_read", {})["result"]
+    assert result["ok"] is True
+    assert result["exists"] is False
+    assert result["content"] == ""
+
+
+def test_memory_upsert_creates_file_with_header_and_section(tmp_path) -> None:
+    tools = _tools(tmp_path)
+
+    payload = tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Speakers", "body": "- Faili01: /mnt/c/...", "dryRun": False},
+    )["result"]
+    assert payload["ok"] is True
+    assert payload["action"] == "create"
+
+    memory = (tmp_path / "parse-memory.md").read_text(encoding="utf-8")
+    assert memory.startswith("# PARSE chat memory")
+    assert "## Speakers" in memory
+    assert "Faili01" in memory
+
+
+def test_memory_upsert_replaces_existing_section_without_touching_others(tmp_path) -> None:
+    tools = _tools(tmp_path)
+
+    tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Speakers", "body": "- Faili01", "dryRun": False},
+    )
+    tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Preferences", "body": "- terse tone", "dryRun": False},
+    )
+    tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Speakers", "body": "- Faili01\n- Kalh01", "dryRun": False},
+    )
+
+    memory = (tmp_path / "parse-memory.md").read_text(encoding="utf-8")
+    # Preferences section untouched
+    assert "- terse tone" in memory
+    # Speakers section now has both entries
+    assert "- Faili01" in memory
+    assert "- Kalh01" in memory
+    # Section heading appears exactly once
+    assert memory.count("## Speakers") == 1
+
+
+def test_memory_upsert_dry_run_does_not_write(tmp_path) -> None:
+    tools = _tools(tmp_path)
+
+    preview = tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Notes", "body": "hello", "dryRun": True},
+    )["result"]
+    assert preview["dryRun"] is True
+    assert not (tmp_path / "parse-memory.md").exists()
+
+
+def test_memory_read_section_filter_returns_just_that_block(tmp_path) -> None:
+    tools = _tools(tmp_path)
+
+    tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Speakers", "body": "- A", "dryRun": False},
+    )
+    tools.execute(
+        "parse_memory_upsert_section",
+        {"section": "Preferences", "body": "- terse", "dryRun": False},
+    )
+
+    result = tools.execute("parse_memory_read", {"section": "Speakers"})["result"]
+    assert result["ok"] is True
+    assert "## Speakers" in result["content"]
+    assert "Preferences" not in result["content"]
+
+
+def test_memory_tools_are_write_allowlisted() -> None:
+    # parse_memory_read is read-only; the upsert tool must be in the write allowlist.
+    assert "parse_memory_upsert_section" in WRITE_ALLOWED_TOOL_NAMES
+    assert "parse_memory_read" not in WRITE_ALLOWED_TOOL_NAMES
+
+
+def test_onboard_speaker_import_is_write_allowlisted() -> None:
+    assert "onboard_speaker_import" in WRITE_ALLOWED_TOOL_NAMES
+
+
+def test_onboard_speaker_dry_run_reports_plan_without_callback(tmp_path) -> None:
+    import wave
+
+    external_root = tmp_path / "external"
+    external_root.mkdir()
+    wav = external_root / "spk1.wav"
+    with wave.open(str(wav), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(b"\x00\x00" * 8000)
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+
+    tools = ParseChatTools(
+        project_root=project_root,
+        external_read_roots=[external_root],
+    )
+
+    result = tools.execute(
+        "onboard_speaker_import",
+        {"speaker": "Speaker01", "sourceWav": str(wav), "dryRun": True},
+    )["result"]
+    assert result["ok"] is True
+    assert result["plan"]["speaker"] == "Speaker01"
+    assert result["plan"]["isPrimary"] is True
+    assert result["plan"]["wavDest"].endswith("Speaker01/spk1.wav")
+
+
+def test_onboard_speaker_rejects_source_outside_allowed_roots(tmp_path) -> None:
+    import wave
+
+    import pytest
+
+    from ai.chat_tools import ChatToolValidationError
+
+    stray_root = tmp_path / "stray"
+    stray_root.mkdir()
+    wav = stray_root / "spk.wav"
+    with wave.open(str(wav), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(b"\x00\x00" * 8000)
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+
+    tools = ParseChatTools(project_root=project_root)  # no external_read_roots
+
+    with pytest.raises(ChatToolValidationError, match="outside allowed read roots"):
+        tools.execute(
+            "onboard_speaker_import",
+            {"speaker": "Speaker01", "sourceWav": str(wav), "dryRun": True},
+        )

--- a/python/server.py
+++ b/python/server.py
@@ -1369,6 +1369,116 @@ def _chat_docs_root() -> Optional[pathlib.Path]:
         return root
 
 
+def _chat_external_read_roots() -> List[pathlib.Path]:
+    """Parse PARSE_EXTERNAL_READ_ROOTS as an OS-path-separated list.
+
+    Use ``:`` on POSIX and ``;`` on Windows. Non-existent or unreadable entries
+    are dropped silently so an over-eager config doesn't break chat startup.
+    """
+    raw = str(os.environ.get("PARSE_EXTERNAL_READ_ROOTS") or "").strip()
+    if not raw:
+        return []
+
+    sep = ";" if os.name == "nt" or ";" in raw else os.pathsep
+    roots: List[pathlib.Path] = []
+    for piece in raw.split(sep):
+        piece = piece.strip()
+        if not piece:
+            continue
+        candidate = pathlib.Path(piece).expanduser()
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            continue
+        if resolved not in roots:
+            roots.append(resolved)
+    return roots
+
+
+def _chat_memory_path() -> pathlib.Path:
+    raw = str(os.environ.get("PARSE_CHAT_MEMORY_PATH") or "").strip()
+    if raw:
+        candidate = pathlib.Path(raw).expanduser()
+        if not candidate.is_absolute():
+            candidate = _project_root() / candidate
+        try:
+            return candidate.resolve()
+        except Exception:
+            return candidate
+    return (_project_root() / "parse-memory.md").resolve()
+
+
+def _chat_onboard_speaker(
+    speaker: str,
+    source_wav_path: pathlib.Path,
+    source_csv_path: Optional[pathlib.Path],
+    is_primary: bool,
+) -> Dict[str, Any]:
+    """Synchronous onboarding callback used by the chat tool.
+
+    Copies the source WAV (and optional CSV) into the project's audio/original/
+    tree, then runs the existing onboard-speaker worker in-thread so the
+    annotation scaffold and source_index registration follow the same path the
+    HTTP /api/onboard/speaker endpoint uses.
+    """
+    project_root_path = _project_root()
+    target_dir = project_root_path / "audio" / "original" / speaker
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    wav_dest = target_dir / source_wav_path.name
+    wav_dest.write_bytes(source_wav_path.read_bytes())
+
+    csv_dest: Optional[pathlib.Path] = None
+    if source_csv_path is not None:
+        csv_dest = target_dir / source_csv_path.name
+        csv_dest.write_bytes(source_csv_path.read_bytes())
+
+    job_id = _create_job(
+        "onboard:speaker",
+        {
+            "speaker": speaker,
+            "wavPath": str(wav_dest.relative_to(project_root_path)),
+            "csvPath": str(csv_dest.relative_to(project_root_path)) if csv_dest else None,
+            "initiatedBy": "chat",
+        },
+    )
+
+    # Run synchronously — we're already inside the chat job's worker thread.
+    _run_onboard_speaker_job(job_id, speaker, wav_dest, csv_dest)
+
+    snapshot = _get_job_snapshot(job_id) or {}
+    result = snapshot.get("result") if isinstance(snapshot, dict) else None
+
+    if snapshot.get("status") != "complete":
+        raise RuntimeError(
+            "Onboarding job {0} failed: {1}".format(
+                job_id, snapshot.get("error") or "unknown error"
+            )
+        )
+
+    # If the caller marked this as non-primary, patch source_index.json accordingly.
+    # _run_onboard_speaker_job already sets is_primary based on list length; respect
+    # an explicit False override from the caller.
+    if is_primary is False and isinstance(result, dict):
+        source_index_path = _source_index_path()
+        source_index = _read_json_file(source_index_path, {})
+        speakers_block = source_index.get("speakers") if isinstance(source_index, dict) else None
+        if isinstance(speakers_block, dict):
+            entry = speakers_block.get(speaker)
+            if isinstance(entry, dict):
+                for source_entry in entry.get("source_wavs", []) or []:
+                    if isinstance(source_entry, dict) and source_entry.get("filename") == wav_dest.name:
+                        source_entry["is_primary"] = False
+                _write_json_file(source_index_path, source_index)
+
+    return {
+        "jobId": job_id,
+        "annotationPath": (result or {}).get("annotationPath") if isinstance(result, dict) else None,
+        "wavPath": (result or {}).get("wavPath") if isinstance(result, dict) else None,
+        "csvPath": (result or {}).get("csvPath") if isinstance(result, dict) else None,
+    }
+
+
 def _get_chat_runtime() -> Tuple[ParseChatTools, ChatOrchestrator]:
     global _chat_tools_runtime
     global _chat_orchestrator_runtime
@@ -1381,6 +1491,9 @@ def _get_chat_runtime() -> Tuple[ParseChatTools, ChatOrchestrator]:
                 docs_root=_chat_docs_root(),
                 start_stt_job=_chat_start_stt_job,
                 get_job_snapshot=_chat_get_job_snapshot,
+                external_read_roots=_chat_external_read_roots(),
+                memory_path=_chat_memory_path(),
+                onboard_speaker=_chat_onboard_speaker,
             )
 
         if _chat_orchestrator_runtime is None:

--- a/scripts/parse-init-workspace.sh
+++ b/scripts/parse-init-workspace.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# scripts/parse-init-workspace.sh — scaffold a fresh PARSE workspace directory.
+#
+# Creates a self-contained data directory outside the repo where PARSE keeps
+# all generated state (copied audio, normalized audio, annotations, peaks,
+# source_index.json, parse-memory.md, etc.). Original source files on disk
+# are never mutated — chat onboarding copies them into <workspace>/audio/
+# original/<speaker>/. The pipeline reads from audio/original/ and writes to
+# audio/working/.
+#
+# Usage
+# -----
+#   scripts/parse-init-workspace.sh /path/to/workspace
+#   scripts/parse-init-workspace.sh --concepts-csv /path/to/concepts.csv /path/to/workspace
+#   scripts/parse-init-workspace.sh --project-id southern-kurdish /path/to/workspace
+#
+# Idempotent: running twice against the same workspace only creates what's
+# missing. Never overwrites an existing project.json, parse-memory.md, or
+# concepts.csv.
+
+set -eu
+
+PROJECT_ID=""
+CONCEPTS_CSV=""
+WORKSPACE=""
+
+usage() {
+  cat <<'EOF' 1>&2
+Usage: parse-init-workspace.sh [--project-id ID] [--concepts-csv FILE] <workspace>
+
+Options:
+  --project-id ID        Value to write into project.json "project_id".
+                         Default: basename of <workspace>.
+  --concepts-csv FILE    Copy an initial concepts.csv into <workspace>.
+                         Only copied if <workspace>/concepts.csv does not
+                         already exist.
+
+Positional:
+  <workspace>            Absolute or relative path to the workspace directory.
+                         Created if missing.
+EOF
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-id)
+      [ $# -ge 2 ] || usage
+      PROJECT_ID="$2"
+      shift 2
+      ;;
+    --concepts-csv)
+      [ $# -ge 2 ] || usage
+      CONCEPTS_CSV="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      printf 'unknown flag: %s\n' "$1" 1>&2
+      usage
+      ;;
+    *)
+      if [ -n "${WORKSPACE}" ]; then
+        printf 'unexpected argument: %s\n' "$1" 1>&2
+        usage
+      fi
+      WORKSPACE="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${WORKSPACE}" ]; then
+  usage
+fi
+
+# Resolve to an absolute path without depending on GNU realpath.
+mkdir -p "${WORKSPACE}"
+WORKSPACE="$(cd "${WORKSPACE}" && pwd)"
+
+if [ -z "${PROJECT_ID}" ]; then
+  PROJECT_ID="$(basename "${WORKSPACE}")"
+fi
+
+log() { printf '[parse-init] %s\n' "$*"; }
+
+log "Workspace: ${WORKSPACE}"
+log "Project ID: ${PROJECT_ID}"
+
+# --- Directory skeleton -------------------------------------------------------
+for dir in \
+  audio/original \
+  audio/working \
+  annotations \
+  peaks \
+  coarse_transcripts \
+  config
+do
+  target="${WORKSPACE}/${dir}"
+  if [ ! -d "${target}" ]; then
+    mkdir -p "${target}"
+    log "created ${dir}/"
+  fi
+done
+
+# --- project.json -------------------------------------------------------------
+project_json="${WORKSPACE}/project.json"
+if [ ! -f "${project_json}" ]; then
+  cat >"${project_json}" <<EOF
+{
+  "project_id": "${PROJECT_ID}",
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+  log "wrote project.json"
+else
+  log "project.json already exists — left alone"
+fi
+
+# --- concepts.csv (optional copy) --------------------------------------------
+if [ -n "${CONCEPTS_CSV}" ]; then
+  if [ ! -f "${CONCEPTS_CSV}" ]; then
+    log "WARNING: --concepts-csv path does not exist: ${CONCEPTS_CSV}"
+  elif [ -f "${WORKSPACE}/concepts.csv" ]; then
+    log "concepts.csv already exists in workspace — left alone"
+  else
+    cp "${CONCEPTS_CSV}" "${WORKSPACE}/concepts.csv"
+    log "copied concepts.csv from ${CONCEPTS_CSV}"
+  fi
+fi
+
+# --- parse-memory.md ----------------------------------------------------------
+memory_path="${WORKSPACE}/parse-memory.md"
+if [ ! -f "${memory_path}" ]; then
+  cat >"${memory_path}" <<EOF
+# PARSE chat memory
+
+Persistent notes for PARSE AI. Maintained by \`parse_memory_upsert_section\`.
+Each \`## Section\` is replaceable; other sections are left untouched.
+
+## User preferences
+
+(empty — PARSE AI fills this in as the user states preferences)
+
+## Speakers
+
+(empty — one entry per speaker as they are onboarded, noting provenance
+and any notes the user shares)
+
+## File provenance
+
+(empty — absolute paths of originals that were copied into audio/original/
+during onboarding, plus any transcription CSV origins)
+EOF
+  log "seeded parse-memory.md"
+else
+  log "parse-memory.md already exists — left alone"
+fi
+
+# --- Final guidance -----------------------------------------------------------
+cat <<EOF
+
+Workspace ready. To start PARSE against this workspace:
+
+  PARSE_WORKSPACE_ROOT="${WORKSPACE}" \\
+    PARSE_CHAT_MEMORY_PATH="${WORKSPACE}/parse-memory.md" \\
+    PARSE_EXTERNAL_READ_ROOTS="/path/to/your/source/tree" \\
+    bash "\$(dirname "\$0")/parse-run.sh"
+
+Set PARSE_EXTERNAL_READ_ROOTS to the directory your original WAV/CSV files
+live under (e.g. /mnt/c/Users/Lucas/Thesis on WSL). PARSE AI will copy files
+from there into ${WORKSPACE}/audio/original/<speaker>/ via onboard_speaker_import.
+Originals are never mutated.
+EOF

--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -14,6 +14,13 @@
 #   PARSE_ROOT       Repo root (default: auto-detected from script location)
 #   PARSE_WORKSPACE_ROOT  Data workspace root for backend chat/tools (default: PARSE_ROOT)
 #   PARSE_CHAT_DOCS_ROOT  Optional docs root for chat markdown/text preview (default: PARSE_WORKSPACE_ROOT)
+#   PARSE_EXTERNAL_READ_ROOTS  OS-path-separated list of absolute roots chat may read
+#                               outside the workspace (e.g. "/mnt/c/Users/Lucas/Thesis").
+#                               Used by read_audio_info / read_csv_preview / read_text_preview
+#                               and by onboard_speaker_import source paths.
+#   PARSE_CHAT_MEMORY_PATH  Path to parse-memory.md (default: PARSE_WORKSPACE_ROOT/parse-memory.md)
+#   PARSE_CHAT_READ_ONLY    Set to "1" to force chat read-only; "0" to force write-enabled.
+#                           Empty (default) defers to config/ai_config.json.
 #   PARSE_API_PORT   API server port (default: 8766)
 #   PARSE_VITE_PORT  Vite dev server port (default: 5173)
 #   PARSE_SKIP_PULL  Set to 1 to skip `git pull` (default: 0)
@@ -43,6 +50,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${PARSE_ROOT:=$(cd "${SCRIPT_DIR}/.." && pwd)}"
 : "${PARSE_WORKSPACE_ROOT:=${PARSE_ROOT}}"
 : "${PARSE_CHAT_DOCS_ROOT:=${PARSE_WORKSPACE_ROOT}}"
+: "${PARSE_CHAT_MEMORY_PATH:=${PARSE_WORKSPACE_ROOT}/parse-memory.md}"
+: "${PARSE_EXTERNAL_READ_ROOTS:=}"
+: "${PARSE_CHAT_READ_ONLY:=}"
 : "${PARSE_PY:=python3}"
 : "${PARSE_API_PORT:=8766}"
 : "${PARSE_VITE_PORT:=5173}"
@@ -193,10 +203,20 @@ start_api() {
   log "Starting Python API server on :${PARSE_API_PORT}..."
   log "Backend workspace root: ${PARSE_WORKSPACE_ROOT}"
   log "Chat docs root: ${PARSE_CHAT_DOCS_ROOT}"
+  log "Chat memory path: ${PARSE_CHAT_MEMORY_PATH}"
+  if [ -n "${PARSE_EXTERNAL_READ_ROOTS}" ]; then
+    log "External read roots: ${PARSE_EXTERNAL_READ_ROOTS}"
+  fi
+  if [ -n "${PARSE_CHAT_READ_ONLY}" ]; then
+    log "Chat read-only override: ${PARSE_CHAT_READ_ONLY}"
+  fi
   # -u = unbuffered stdout (so logs appear immediately; critical for remote debugging).
   (
     cd "${PARSE_WORKSPACE_ROOT}" || exit 1
     PARSE_CHAT_DOCS_ROOT="${PARSE_CHAT_DOCS_ROOT}" \
+      PARSE_CHAT_MEMORY_PATH="${PARSE_CHAT_MEMORY_PATH}" \
+      PARSE_EXTERNAL_READ_ROOTS="${PARSE_EXTERNAL_READ_ROOTS}" \
+      PARSE_CHAT_READ_ONLY="${PARSE_CHAT_READ_ONLY}" \
       "${PARSE_PY}" -u "${PARSE_ROOT}/python/server.py" \
       >"${API_STDOUT_LOG}" 2>"${API_STDERR_LOG}"
   ) &
@@ -252,6 +272,10 @@ print_banner() {
   log "  API:       http://localhost:${PARSE_API_PORT}/api/config"
   log "  Workspace: ${PARSE_WORKSPACE_ROOT}"
   log "  Chat docs: ${PARSE_CHAT_DOCS_ROOT}"
+  log "  Chat memory: ${PARSE_CHAT_MEMORY_PATH}"
+  if [ -n "${PARSE_EXTERNAL_READ_ROOTS}" ]; then
+    log "  External reads: ${PARSE_EXTERNAL_READ_ROOTS}"
+  fi
   log "════════════════════════════════════════"
 }
 


### PR DESCRIPTION
## Summary

Re-applies the reverted [PR #85](https://github.com/ArdeleanLucas/PARSE/pull/85) on top of current `main` (post-revert), rebased cleanly alongside the readable-markdown work from [PR #87](https://github.com/ArdeleanLucas/PARSE/pull/87). Adds `scripts/parse-init-workspace.sh` so a new PC can scaffold a workspace outside the repo in one command.

## What comes back from #85

- Config-driven `chat.read_only` + `PARSE_CHAT_READ_ONLY` env override
- `onboard_speaker_import` chat tool — copies external WAV (+ optional CSV) into `audio/original/<speaker>/`, scaffolds annotation, registers in `source_index.json`. Dry-run gated.
- `parse_memory_read` / `parse_memory_upsert_section` — persistent markdown at `parse-memory.md`, section-based upsert, 256 KB cap.
- `PARSE_EXTERNAL_READ_ROOTS` — `os.pathsep`-separated absolute roots unlocking `read_audio_info` / `read_csv_preview` / `read_text_preview` / `onboard_speaker_import` for paths like `/mnt/c/Users/Lucas/Thesis/...`.
- MCP adapter exposes all three new tools; onboarding proxies through HTTP multipart.
- `scripts/parse-run.sh` threads the new env vars through.

## New in this PR

- **`scripts/parse-init-workspace.sh`** — scaffolds `<workspace>/{project.json, audio/original, audio/working, annotations, peaks, coarse_transcripts, config, parse-memory.md}`. Idempotent. Prints ready-to-run env.

## Conflict resolution notes

Cherry-picking commit `e679220` onto current main produced one conflict in `python/ai/chat_orchestrator.py` because PR #87 added two markdown-style lines to the `Response style` block after the revert. Resolution layers PR #87's two lines on top of #85's `{mode_note}` structure:

```python
"- {mode_note}\n"
"- Use readable Markdown with short headings, bullets, and blank lines between sections\n"
"- Never wrap the entire reply in a code fence unless the user explicitly asked for raw copy-paste output\n"
```

## Typical PC setup

```bash
# On a fresh Windows/WSL box
git clone https://github.com/ArdeleanLucas/PARSE /mnt/c/Users/Lucas/gh/PARSE
bash /mnt/c/Users/Lucas/gh/PARSE/scripts/parse-init-workspace.sh /mnt/c/Users/Lucas/parse-workspace

PARSE_ROOT=/mnt/c/Users/Lucas/gh/PARSE \
  PARSE_WORKSPACE_ROOT=/mnt/c/Users/Lucas/parse-workspace \
  PARSE_EXTERNAL_READ_ROOTS=/mnt/c/Users/Lucas/Thesis \
  bash /mnt/c/Users/Lucas/gh/PARSE/scripts/parse-run.sh
```

Chat can then onboard speakers by pointing at absolute paths inside `PARSE_EXTERNAL_READ_ROOTS`. Originals are never mutated — PARSE copies them into `audio/original/<speaker>/`.

## Test plan

- [x] `pytest python/ --ignore=python/compare/providers` — 81 passed
- [x] `vitest run` — 160 passed across 30 test files (includes PR #87's `ChatMarkdown` + `ParseUI` coverage)
- [x] `tsc --noEmit` — clean
- [x] `scripts/parse-init-workspace.sh` manual smoke: idempotent, leaves existing files alone, prints correct run command
- [ ] Manual on PC: `parse-init-workspace.sh C:\parse-workspace` → start server → ask PARSE AI to onboard a speaker from `/mnt/c/Users/Lucas/Thesis/Audio_Original/Fail01/Faili_M_1984.wav`; verify copy + `source_index.json` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)