### PR TITLE
feat(chat): PARSE_EXTERNAL_READ_ROOTS wildcard + virtual-timeline awareness

### DIFF
--- a/python/ai/chat_orchestrator.py
+++ b/python/ai/chat_orchestrator.py
@@ -128,6 +128,10 @@ class ChatOrchestrator:
             "- Subsequent turns in the same session inherit that context via conversation history — not re-read on every turn. If you wrote to `parse-memory.md` mid-session and want to reference the new content by file rather than by memory, call `parse_memory_read`.\n"
             "- parse_memory_upsert_section creates or replaces a `## Section` block there. Updates persist across sessions; the next session you start will see them in its auto-injected context.\n"
             "\n"
+            "Multi-source speakers and virtual timelines:\n"
+            "- A speaker may have multiple source WAVs. Call onboard_speaker_import once per WAV — the first is primary, subsequent imports default to non-primary.\n"
+            "- When onboard_speaker_import returns `virtualTimelineRequired=true` (or the source index already shows >1 WAV for a speaker), PARSE has no automatic cross-WAV alignment. Do not assert that annotations on one WAV transfer to the other. Record the gap in `parse-memory.md` (e.g. under a `## Alignment status` section) and surface it to the user so manual reconciliation can be scheduled.\n"
+            "\n"
             "Response style:\n"
             "- concise, technical, and accurate\n"
             "- when using tools, summarize what was checked\n"
@@ -249,7 +253,7 @@ class ChatOrchestrator:
                 if isinstance(first, dict):
                     primary = str(first.get("path") or first.get("filename") or "").strip()
 
-            suffix = " (+{0} more)".format(extras) if extras else ""
+            suffix = " (+{0} more, virtual-timeline required)".format(extras) if extras else ""
             lines.append("- {0}: {1}{2}".format(speaker_name, primary or "(no primary wav)", suffix))
 
         if len(speakers) > _TURN_PRIMING_SOURCE_INDEX_MAX_SPEAKERS:

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -258,8 +258,20 @@ class ParseChatTools:
         self.config_path = (Path(config_path).expanduser().resolve() if config_path else self.project_root / "config" / "ai_config.json")
         self.docs_root = Path(docs_root).expanduser().resolve() if docs_root else None
 
+        # ``external_read_roots`` supports two modes:
+        #   - a list of concrete absolute roots → paths must fall under one
+        #   - a single-element list containing "*" or "/" (or a Path("*")) →
+        #     wildcard mode, any absolute path that exists is readable
+        # Wildcard is the "broad access" knob for local single-user setups
+        # where enumerating every source tree is tedious; default stays
+        # conservative so unintended deployments don't leak the filesystem.
         self.external_read_roots: List[Path] = []
+        self.external_read_wildcard: bool = False
         for raw_root in external_read_roots or []:
+            raw_str = str(raw_root).strip()
+            if raw_str in {"*", "/", "**"}:
+                self.external_read_wildcard = True
+                continue
             try:
                 resolved_root = Path(raw_root).expanduser().resolve()
             except Exception:
@@ -619,12 +631,19 @@ class ParseChatTools:
             "onboard_speaker_import": ChatToolSpec(
                 name="onboard_speaker_import",
                 description=(
-                    "Import a new speaker from on-disk audio (and optional transcription CSV). "
-                    "Copies files into audio/original/<speaker>/, scaffolds an annotation record, "
-                    "and registers the speaker in source_index.json. sourceWav/sourceCsv may be "
-                    "absolute paths under PARSE_EXTERNAL_READ_ROOTS or paths under the project "
-                    "audio/ directory. Gated by dryRun: call dryRun=true first to preview planned "
-                    "copies/registrations, then dryRun=false after the user confirms."
+                    "Import a speaker's audio source from on-disk paths (and optional transcription CSV). "
+                    "Copies files into audio/original/<speaker>/, scaffolds an annotation record on the "
+                    "first import, and appends the source to source_index.json. sourceWav/sourceCsv may "
+                    "be absolute paths under PARSE_EXTERNAL_READ_ROOTS (set to '*' for no sandbox) or "
+                    "paths under the project audio/ directory. "
+                    "Multi-source speakers: call this tool once per audio source. The first import "
+                    "defaults to is_primary=true; subsequent imports default to is_primary=false. "
+                    "When a speaker already has registered sources, the response flags "
+                    "`virtualTimelineRequired=true` — PARSE does not yet auto-align multiple WAVs "
+                    "across a shared virtual timeline, so annotation spanning them must be coordinated "
+                    "manually or deferred. "
+                    "Gated by dryRun: call dryRun=true first to preview planned copies/registrations, "
+                    "then dryRun=false after the user confirms."
                 ),
                 parameters={
                     "type": "object",
@@ -860,7 +879,9 @@ class ParseChatTools:
 
         Expanded allowed roots = [project_root, *external_read_roots, *extra_roots]. Paths may
         be absolute (then must fall under one of the roots) or relative (resolved against
-        project_root). Raises ChatToolValidationError on escape.
+        project_root). When ``external_read_wildcard`` is set (PARSE_EXTERNAL_READ_ROOTS=*)
+        any absolute path is accepted. Raises ChatToolValidationError on escape with a
+        message listing the actual allowed roots so the caller knows what to fix.
         """
         value = str(raw_path or "").strip()
         if not value:
@@ -881,6 +902,9 @@ class ParseChatTools:
 
         resolved = candidate.resolve()
 
+        if self.external_read_wildcard:
+            return resolved
+
         for root in allowed_roots:
             try:
                 resolved.relative_to(root)
@@ -889,8 +913,10 @@ class ParseChatTools:
                 continue
 
         raise ChatToolValidationError(
-            "Path is outside allowed read roots: {0}".format(
-                ", ".join([str(root) for root in allowed_roots])
+            "Path {0!r} is outside allowed read roots. Allowed: {1}. "
+            "Extend access by setting PARSE_EXTERNAL_READ_ROOTS "
+            "(e.g. '/mnt/c/Users/Lucas/Thesis') or use '*' for no sandbox.".format(
+                str(resolved), ", ".join([str(root) for root in allowed_roots])
             )
         )
 
@@ -1854,10 +1880,11 @@ class ParseChatTools:
         if not source_wav:
             raise ChatToolValidationError("sourceWav is required")
 
-        # Paths under audio/ may be relative; absolute paths must fall under
-        # the project root or a configured PARSE_EXTERNAL_READ_ROOTS entry.
+        # Relative paths are anchored at audio/ for continuity with earlier
+        # behavior. Absolute paths go through the broader readable-path
+        # resolver so PARSE_EXTERNAL_READ_ROOTS (including "*") applies.
         candidate = Path(source_wav).expanduser()
-        if candidate.is_absolute() and self.external_read_roots:
+        if candidate.is_absolute():
             safe_audio = self._resolve_readable_path(source_wav)
         else:
             safe_audio = self._resolve_project_path(source_wav, allowed_roots=[self.audio_dir])
@@ -2288,6 +2315,22 @@ class ParseChatTools:
         wav_dest = target_dir / wav_path.name
         csv_dest = (target_dir / csv_path.name) if csv_path else None
 
+        # Multi-source speakers require a virtual-timeline to align
+        # annotations across WAVs. PARSE doesn't auto-build one yet, so flag
+        # it explicitly so the agent raises the gap with the user instead of
+        # silently writing two disjoint source entries.
+        projected_source_count = len(existing_sources) + (0 if already_registered else 1)
+        virtual_timeline_required = projected_source_count > 1
+        virtual_timeline_note = ""
+        if virtual_timeline_required:
+            virtual_timeline_note = (
+                "Speaker {0!r} will have {1} source WAVs after this import. PARSE does not "
+                "yet auto-align multiple WAVs on a shared virtual timeline. Flag downstream "
+                "annotation/alignment as pending until a virtual-timeline workflow is in "
+                "place; annotations authored against one WAV will not transfer to the other "
+                "without manual reconciliation."
+            ).format(speaker, projected_source_count)
+
         plan: Dict[str, Any] = {
             "speaker": speaker,
             "sourceWav": str(wav_path),
@@ -2299,7 +2342,11 @@ class ParseChatTools:
             "alreadyRegistered": already_registered,
             "wavSizeBytes": wav_path.stat().st_size,
             "csvSizeBytes": csv_path.stat().st_size if csv_path else None,
+            "projectedSourceCount": projected_source_count,
+            "virtualTimelineRequired": virtual_timeline_required,
         }
+        if virtual_timeline_note:
+            plan["virtualTimelineNote"] = virtual_timeline_note
 
         if dry_run:
             return {
@@ -2338,7 +2385,11 @@ class ParseChatTools:
             "ok": True,
             "dryRun": False,
             "plan": plan,
-            "message": "Speaker {0!r} imported.".format(speaker),
+            "message": (
+                "Speaker {0!r} imported. {1}".format(speaker, virtual_timeline_note).strip()
+                if virtual_timeline_note
+                else "Speaker {0!r} imported.".format(speaker)
+            ),
         }
         if isinstance(callback_result, dict):
             out.update(callback_result)

--- a/python/ai/test_parse_memory_tool.py
+++ b/python/ai/test_parse_memory_tool.py
@@ -153,8 +153,101 @@ def test_onboard_speaker_rejects_source_outside_allowed_roots(tmp_path) -> None:
 
     tools = ParseChatTools(project_root=project_root)  # no external_read_roots
 
-    with pytest.raises(ChatToolValidationError, match="outside allowed read roots"):
+    with pytest.raises(
+        ChatToolValidationError,
+        match=r"outside allowed read roots.*PARSE_EXTERNAL_READ_ROOTS",
+    ):
         tools.execute(
             "onboard_speaker_import",
             {"speaker": "Speaker01", "sourceWav": str(wav), "dryRun": True},
         )
+
+
+def test_external_read_wildcard_allows_any_absolute_path(tmp_path) -> None:
+    import wave
+
+    stray_root = tmp_path / "stray"
+    stray_root.mkdir()
+    wav = stray_root / "Faili_M_1984.wav"
+    with wave.open(str(wav), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(b"\x00\x00" * 8000)
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+
+    # PARSE_EXTERNAL_READ_ROOTS="*" → wildcard mode
+    tools = ParseChatTools(project_root=project_root, external_read_roots=["*"])
+
+    result = tools.execute(
+        "read_audio_info", {"sourceWav": str(wav)}
+    )["result"]
+    assert result["ok"] is True
+    assert result["sampleRateHz"] == 16000
+
+
+def test_onboard_speaker_flags_virtual_timeline_on_second_source(tmp_path) -> None:
+    """When a speaker already has a registered WAV, a second onboarding call
+    must surface virtualTimelineRequired=true + an explanatory note so the
+    agent raises the gap rather than silently writing two disjoint sources."""
+    import json
+    import wave
+
+    external_root = tmp_path / "Thesis"
+    external_root.mkdir()
+
+    def make_wav(name: str) -> pathlib.Path:
+        wav = external_root / name
+        with wave.open(str(wav), "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(16000)
+            w.writeframes(b"\x00\x00" * 8000)
+        return wav
+
+    wav_a = make_wav("Mand_M_1962_01.wav")
+    wav_b = make_wav("Mand_M_1962_02.wav")
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+
+    # Seed source_index.json as if Mand_M_1962_01.wav was already onboarded.
+    (project_root / "source_index.json").write_text(
+        json.dumps(
+            {
+                "speakers": {
+                    "Mand01": {
+                        "source_wavs": [
+                            {
+                                "filename": "Mand_M_1962_01.wav",
+                                "path": "audio/original/Mand01/Mand_M_1962_01.wav",
+                                "is_primary": True,
+                            }
+                        ]
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tools = ParseChatTools(project_root=project_root, external_read_roots=[external_root])
+
+    first_result = tools.execute(
+        "onboard_speaker_import",
+        {"speaker": "Mand01", "sourceWav": str(wav_a), "dryRun": True},
+    )["result"]
+    # wav_a is already registered → no count increase, no virtual-timeline flag.
+    assert first_result["plan"]["alreadyRegistered"] is True
+    assert first_result["plan"]["projectedSourceCount"] == 1
+    assert first_result["plan"]["virtualTimelineRequired"] is False
+
+    second_result = tools.execute(
+        "onboard_speaker_import",
+        {"speaker": "Mand01", "sourceWav": str(wav_b), "dryRun": True},
+    )["result"]
+    assert second_result["plan"]["projectedSourceCount"] == 2
+    assert second_result["plan"]["virtualTimelineRequired"] is True
+    assert "virtual timeline" in second_result["plan"]["virtualTimelineNote"].lower()

--- a/scripts/parse-init-workspace.sh
+++ b/scripts/parse-init-workspace.sh
@@ -170,11 +170,17 @@ Workspace ready. To start PARSE against this workspace:
 
   PARSE_WORKSPACE_ROOT="${WORKSPACE}" \\
     PARSE_CHAT_MEMORY_PATH="${WORKSPACE}/parse-memory.md" \\
-    PARSE_EXTERNAL_READ_ROOTS="/path/to/your/source/tree" \\
+    PARSE_EXTERNAL_READ_ROOTS="/mnt/c/Users/Lucas/Thesis" \\
     bash "\$(dirname "\$0")/parse-run.sh"
 
 Set PARSE_EXTERNAL_READ_ROOTS to the directory your original WAV/CSV files
-live under (e.g. /mnt/c/Users/Lucas/Thesis on WSL). PARSE AI will copy files
-from there into ${WORKSPACE}/audio/original/<speaker>/ via onboard_speaker_import.
-Originals are never mutated.
+live under (e.g. /mnt/c/Users/Lucas/Thesis on WSL). Use multiple entries
+separated by ':' (':' on POSIX, ';' on Windows), or pass '*' to disable the
+sandbox entirely:
+
+  PARSE_EXTERNAL_READ_ROOTS="*"   # any absolute path is readable
+
+PARSE AI copies the sources you point at into
+${WORKSPACE}/audio/original/<speaker>/ via onboard_speaker_import — originals
+are never mutated.
 EOF

--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -17,7 +17,8 @@
 #   PARSE_EXTERNAL_READ_ROOTS  OS-path-separated list of absolute roots chat may read
 #                               outside the workspace (e.g. "/mnt/c/Users/Lucas/Thesis").
 #                               Used by read_audio_info / read_csv_preview / read_text_preview
-#                               and by onboard_speaker_import source paths.
+#                               and by onboard_speaker_import source paths. Set to "*" to
+#                               disable the sandbox entirely (any absolute path readable).
 #   PARSE_CHAT_MEMORY_PATH  Path to parse-memory.md (default: PARSE_WORKSPACE_ROOT/parse-memory.md)
 #   PARSE_CHAT_READ_ONLY    Set to "1" to force chat read-only; "0" to force write-enabled.
 #                           Empty (default) defers to config/ai_config.json.


### PR DESCRIPTION
Two blockers from PC-side testing of PR #88:

## 1. Read sandbox too narrow

Agent still hit \`Path '/mnt/c/Users/Lucas/Thesis/…' is outside allowed read roots\` even with \`PARSE_EXTERNAL_READ_ROOTS\` set — enumerating every source folder is tedious for a local single-user setup.

**Fix:** accept \`*\` / \`/\` / \`**\` as a wildcard that disables the read sandbox entirely. Explicit root lists still work (and stay the default for safety); wildcard is opt-in for "trust the whole filesystem" setups.

```bash
# All of these now work
PARSE_EXTERNAL_READ_ROOTS="/mnt/c/Users/Lucas/Thesis"          # one root
PARSE_EXTERNAL_READ_ROOTS="/mnt/c/Users/Lucas/Thesis:/opt/data" # many roots
PARSE_EXTERNAL_READ_ROOTS="*"                                   # any absolute path
```

Path-rejected errors now list the actual allowed roots and tell the caller how to extend them, so the agent can diagnose without a human turn:

```
Path '/mnt/c/.../Faili_M_1984.wav' is outside allowed read roots.
Allowed: /home/lucas/parse-workspace. Extend access by setting
PARSE_EXTERNAL_READ_ROOTS (e.g. '/mnt/c/Users/Lucas/Thesis') or use '*' for no sandbox.
```

\`read_audio_info\` now also routes absolute paths through the readable-path resolver (not just \`read_csv_preview\` / \`read_text_preview\` / \`onboard_speaker_import\`), so the wildcard applies uniformly.

## 2. Multi-source speakers (Mand01 with two WAVs)

\`onboard_speaker_import\` accepts one \`sourceWav\` per call. PARSE does not yet implement automatic cross-WAV alignment, so a speaker ending up with two source WAVs creates a silent annotation gap.

**Fix:** on each onboard call, compute \`projectedSourceCount\` and \`virtualTimelineRequired\`; when >1 WAV will be registered for the speaker, include a \`virtualTimelineNote\` in both dry-run plan and real-run message explaining that:
- PARSE has no auto-alignment across the WAVs yet
- Annotations on WAV A do not transfer to WAV B
- Downstream work must be coordinated manually or flagged pending

Session-priming source-index summary tags existing multi-source speakers with \`(+N more, virtual-timeline required)\` so the agent sees the gap on turn one.

System prompt gains a *"Multi-source speakers and virtual timelines"* section instructing the agent to record the alignment gap in \`parse-memory.md\` under \`## Alignment status\` and raise it explicitly.

## Files

- \`python/ai/chat_tools.py\` — wildcard in \`ParseChatTools\`; diagnostic errors; multi-source plan fields; onboard description refresh.
- \`python/ai/chat_orchestrator.py\` — system-prompt additions; multi-source tag in source-index summary.
- \`scripts/parse-init-workspace.sh\` / \`scripts/parse-run.sh\` — docs mention \`*\`.
- \`python/ai/test_parse_memory_tool.py\` — two new tests (wildcard, virtual-timeline flag).

## Test plan

- [x] \`pytest python/ --ignore=python/compare/providers\` — 90 passed (+2)
- [ ] Manual on PC with \`PARSE_EXTERNAL_READ_ROOTS=*\`: confirm agent can onboard from \`/mnt/c/Users/Lucas/Thesis/Audio_Original/Fail01/Faili_M_1984.wav\` and \`read_audio_info\` on the same path.
- [ ] Manual on PC: onboard Mand01's second WAV; verify the response carries \`virtualTimelineRequired=true\` and the agent records a \`## Alignment status\` section in \`parse-memory.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)