### PR TITLE
fix(auth): API keys (xAI + OpenAI) survive reload

### DIFF
--- a/python/ai/openai_auth.py
+++ b/python/ai/openai_auth.py
@@ -146,10 +146,30 @@ def load_tokens() -> Optional[Dict[str, Any]]:
 
 
 def save_tokens(tokens: Dict[str, Any]) -> None:
-    """Save tokens to disk."""
+    """Save OAuth tokens to disk, preserving any direct API key fields.
+
+    auth_tokens.json holds both OAuth tokens (access_token / refresh_token /
+    expires / token_type) and direct API key fields (direct_api_key /
+    direct_api_key_provider). Earlier this function wrote the OAuth tokens
+    with open(..., "w"), which truncated the whole file — so completing an
+    OAuth login after saving an xAI or OpenAI API key silently wiped that
+    key. Merge on top of whatever's already on disk so both auth methods
+    coexist.
+    """
     path = _token_path()
+    existing: Dict[str, Any] = {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+            if isinstance(loaded, dict):
+                existing = loaded
+    except (json.JSONDecodeError, OSError):
+        existing = {}
+
+    merged = {**existing, **tokens}
+
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(tokens, f, indent=2)
+        json.dump(merged, f, indent=2)
 
 
 def clear_tokens() -> None:

--- a/python/test_openai_auth_status.py
+++ b/python/test_openai_auth_status.py
@@ -55,3 +55,89 @@ def test_get_auth_status_returns_saved_api_key_when_no_flow_is_active(tmp_path, 
         "method": "api_key",
         "provider": "xai",
     }
+
+
+def test_save_api_key_round_trips_xai_provider(tmp_path, monkeypatch) -> None:
+    token_path = tmp_path / "auth_tokens.json"
+    monkeypatch.setattr(openai_auth, "_token_path", lambda: token_path)
+    with openai_auth._auth_lock:
+        openai_auth._auth_state.clear()
+
+    openai_auth.save_api_key("xai-key-123", "xai")
+    status = openai_auth.get_auth_status()
+
+    assert status["authenticated"] is True
+    assert status["method"] == "api_key"
+    assert status["provider"] == "xai"
+    assert openai_auth.get_api_key() == "xai-key-123"
+    assert openai_auth.get_api_key_provider() == "xai"
+
+
+def test_save_api_key_round_trips_openai_provider(tmp_path, monkeypatch) -> None:
+    token_path = tmp_path / "auth_tokens.json"
+    monkeypatch.setattr(openai_auth, "_token_path", lambda: token_path)
+    with openai_auth._auth_lock:
+        openai_auth._auth_state.clear()
+
+    openai_auth.save_api_key("sk-openai-key-456", "openai")
+    status = openai_auth.get_auth_status()
+
+    assert status["authenticated"] is True
+    assert status["method"] == "api_key"
+    assert status["provider"] == "openai"
+    assert openai_auth.get_api_key() == "sk-openai-key-456"
+    assert openai_auth.get_api_key_provider() == "openai"
+
+
+def test_save_tokens_preserves_existing_direct_api_key(tmp_path, monkeypatch) -> None:
+    """Regression: completing OAuth used to overwrite auth_tokens.json with
+    just the OAuth fields, silently dropping any API key the user had saved
+    previously. save_tokens must merge on top of existing content so both
+    auth methods can coexist in the same file."""
+    token_path = tmp_path / "auth_tokens.json"
+    token_path.write_text(
+        json.dumps({"direct_api_key": "xai-key", "direct_api_key_provider": "xai"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(openai_auth, "_token_path", lambda: token_path)
+
+    openai_auth.save_tokens(
+        {
+            "access_token": "oauth-access",
+            "refresh_token": "oauth-refresh",
+            "expires_in": 3600,
+            "expires": time.time() + 3600,
+            "token_type": "Bearer",
+        }
+    )
+
+    merged = json.loads(token_path.read_text(encoding="utf-8"))
+    assert merged["direct_api_key"] == "xai-key"
+    assert merged["direct_api_key_provider"] == "xai"
+    assert merged["access_token"] == "oauth-access"
+    assert merged["refresh_token"] == "oauth-refresh"
+
+
+def test_save_api_key_preserves_existing_oauth_tokens(tmp_path, monkeypatch) -> None:
+    """Symmetric case: saving an API key must not drop OAuth tokens already
+    on disk."""
+    token_path = tmp_path / "auth_tokens.json"
+    token_path.write_text(
+        json.dumps(
+            {
+                "access_token": "oauth-access",
+                "refresh_token": "oauth-refresh",
+                "expires": time.time() + 3600,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(openai_auth, "_token_path", lambda: token_path)
+
+    openai_auth.save_api_key("xai-key", "xai")
+
+    merged = json.loads(token_path.read_text(encoding="utf-8"))
+    assert merged["direct_api_key"] == "xai-key"
+    assert merged["direct_api_key_provider"] == "xai"
+    assert merged["access_token"] == "oauth-access"
+    assert merged["refresh_token"] == "oauth-refresh"

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -431,6 +431,44 @@ describe("ParseUI", () => {
     render(<ParseUI />);
     expect(screen.getAllByText("No reference data").length).toBeGreaterThanOrEqual(1);
   });
+
+  it("restores the xAI provider badge after reload when backend reports provider=xai", async () => {
+    // Regression: the mount effect used to call setProvider('openai')
+    // unconditionally whenever the backend said authenticated=true, so users
+    // who saved an xAI key would see the OpenAI badge on reload.
+    mockGetAuthStatus.mockResolvedValue({
+      authenticated: true,
+      provider: "xai",
+      method: "api_key",
+      flow_active: false,
+    });
+
+    render(<ParseUI />);
+
+    // Expand the minimized AI chat so the provider badge renders.
+    fireEvent.focus(screen.getByPlaceholderText(/Ask PARSE AI about water/i));
+
+    expect(await screen.findByText("Connected to xAI")).toBeTruthy();
+    expect(screen.getByText(/grok-4\.2 reasoning/i)).toBeTruthy();
+    expect(screen.queryByText("Connected to OpenAI")).toBeNull();
+  });
+
+  it("restores the OpenAI provider badge after reload when backend reports provider=openai", async () => {
+    mockGetAuthStatus.mockResolvedValue({
+      authenticated: true,
+      provider: "openai",
+      method: "api_key",
+      flow_active: false,
+    });
+
+    render(<ParseUI />);
+
+    fireEvent.focus(screen.getByPlaceholderText(/Ask PARSE AI about water/i));
+
+    expect(await screen.findByText("Connected to OpenAI")).toBeTruthy();
+    expect(screen.getByText("gpt-5.4")).toBeTruthy();
+    expect(screen.queryByText("Connected to xAI")).toBeNull();
+  });
 });
 
 

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -251,6 +251,14 @@ const PROVIDER_META: Record<AIProvider, { label: string; model: string; badgeCla
   openai: { label: 'OpenAI', model: 'gpt-5.4',            badgeClass: 'bg-emerald-50 text-emerald-700 ring-emerald-200' },
 };
 
+// Narrow the backend's free-form `provider` string (from /api/auth/status) to
+// the UI's AIProvider union. Defaults to 'openai' when unset or unrecognized
+// — OAuth-only flows don't populate it and historical tokens predate the
+// provider field.
+function resolveAuthProvider(raw: string | undefined | null): AIProvider {
+  return raw === 'xai' ? 'xai' : 'openai';
+}
+
 const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMinimize, conceptName, conceptId, speakerCount, chatSession }) => {
   // Connection state machine
   const [view, setView] = useState<AIConnectionView>('welcome');
@@ -341,7 +349,7 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
   useEffect(() => {
     getAuthStatus().then(s => {
       if (s.authenticated) {
-        setProvider('openai');
+        setProvider(resolveAuthProvider(s.provider));
         setView('connected');
       } else if (s.flow_active) {
         // OAuth was started before this mount (page reload mid-flow) — resume.
@@ -355,7 +363,11 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
               if (oauthPollRef.current) clearInterval(oauthPollRef.current);
               oauthPollRef.current = null;
               setOauthPending(false);
-              setProvider('openai');
+              // OAuth device flow is OpenAI-specific today; re-check status so
+              // we never hard-code a provider that doesn't match what the
+              // backend actually persisted.
+              const after = await getAuthStatus().catch(() => null);
+              setProvider(resolveAuthProvider(after?.provider));
               setView('connected');
             } else if (result.status === 'expired' || result.status === 'error') {
               if (oauthPollRef.current) clearInterval(oauthPollRef.current);
@@ -389,7 +401,8 @@ const AIChat: React.FC<AIChatProps> = ({ height, minimized, onResizeStart, onMin
             if (oauthPollRef.current) clearInterval(oauthPollRef.current);
             oauthPollRef.current = null;
             setOauthPending(false);
-            setProvider('openai');
+            const after = await getAuthStatus().catch(() => null);
+            setProvider(resolveAuthProvider(after?.provider));
             setView('connected');
           } else if (result.status === 'expired' || result.status === 'error') {
             if (oauthPollRef.current) clearInterval(oauthPollRef.current);


### PR DESCRIPTION
Two independent bugs blocked API-key persistence across reload. Codex OAuth login appeared fine because the OAuth path dodged both bugs.

## 1. Frontend hardcoded provider='openai' on mount

\`ParseUI.tsx\` mount effect:
\`\`\`ts
getAuthStatus().then(s => {
  if (s.authenticated) {
    setProvider('openai');   // BUG — ignores s.provider
    setView('connected');
  }
  ...
});
\`\`\`
Backend persisted the xAI key correctly in \`auth_tokens.json\` and \`/api/auth/status\` returned \`provider: "xai"\`, but the frontend clobbered it with 'openai' on every reload. OpenAI happened to "work" only because the hardcoded value matched; xAI visibly failed.

**Fix:** add \`resolveAuthProvider()\` helper that narrows the free-form backend string to the \`AIProvider\` union and use it at all three \`setProvider()\` call sites (mount-time status check, on-mount OAuth resume, post-OAuth completion). OAuth completion re-queries \`/api/auth/status\` so the persisted provider wins even if OAuth is extended beyond OpenAI later.

## 2. Backend OAuth completion truncated auth_tokens.json

\`save_tokens()\` opened \`auth_tokens.json\` in \`"w"\` mode and wrote only the OAuth fields, **silently dropping any \`direct_api_key\` / \`direct_api_key_provider\` a prior \`save_api_key()\` had stored.** Anyone who saved an API key and later completed Codex OAuth lost their API key on the next read.

**Fix:** merge the OAuth payload on top of whatever's already on disk so both auth methods coexist.
\`\`\`python
existing = {}
try:
    with open(path, "r", encoding="utf-8") as f:
        loaded = json.load(f)
        if isinstance(loaded, dict):
            existing = loaded
except (json.JSONDecodeError, OSError):
    existing = {}
merged = {**existing, **tokens}
\`\`\`

## Tests

- \`src/ParseUI.test.tsx\` — two new cases: \`provider='xai'\` and \`provider='openai'\` each restore the correct "Connected to …" badge + model label after reload.
- \`python/test_openai_auth_status.py\` — four new cases:
  - save_api_key round-trips 'xai' (save → status.provider → get_api_key_provider)
  - save_api_key round-trips 'openai' (same)
  - save_tokens preserves existing direct_api_key after OAuth completion (regression)
  - save_api_key preserves existing OAuth tokens (symmetric check)

## Verification

- \`pytest python/ --ignore=python/compare/providers\` — **94 passed** (+4)
- \`vitest run\` — **162 passed** (+2)
- \`tsc --noEmit\` — clean

## Notes

- No migration needed. Users whose \`direct_api_key\` was already wiped will need to re-save the API key once; afterwards it persists correctly.
- Browser preview verification skipped — the active preview servers on this machine point at the stale UI mockup clone (\`/Users/lucasardelean/PARSE\`), not the real tree (\`/tmp/PARSE-audit\`), so rendering against them would be misleading. Coverage is via the new vitest assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)