### PR TITLE
fix: refresh chat runtime after API key save

### DIFF
--- a/python/ai/openai_auth.py
+++ b/python/ai/openai_auth.py
@@ -11,6 +11,7 @@ Tokens are stored in config/auth_tokens.json (gitignored).
 """
 
 import json
+import os
 import pathlib
 import threading
 import time
@@ -366,17 +367,23 @@ def get_auth_status() -> Dict[str, Any]:
 
 
 def save_api_key(key: str, provider: str = "xai") -> None:
-    """Save a direct API key to auth_tokens.json."""
+    """Save a direct API key to auth_tokens.json and mirror it into the live env."""
     path = _token_path()
     try:
         with open(path, "r", encoding="utf-8") as f:
             tokens = json.load(f)
     except (json.JSONDecodeError, OSError):
         tokens = {}
-    tokens["direct_api_key"] = key.strip()
-    tokens["direct_api_key_provider"] = provider.strip()
+
+    normalized_key = key.strip()
+    normalized_provider = provider.strip().lower() or "xai"
+    tokens["direct_api_key"] = normalized_key
+    tokens["direct_api_key_provider"] = normalized_provider
     with open(path, "w", encoding="utf-8") as f:
         json.dump(tokens, f, indent=2)
+
+    env_var = "XAI_API_KEY" if normalized_provider in {"xai", "grok", "x.ai"} else "OPENAI_API_KEY"
+    os.environ[env_var] = normalized_key
 
 
 def get_api_key() -> Optional[str]:

--- a/python/server.py
+++ b/python/server.py
@@ -77,6 +77,16 @@ _chat_tools_runtime: Optional[ParseChatTools] = None
 _chat_orchestrator_runtime: Optional[ChatOrchestrator] = None
 
 
+def _reset_chat_runtime_after_auth_key_save() -> None:
+    """Clear cached chat runtimes so a newly saved API key applies immediately."""
+    global _chat_tools_runtime
+    global _chat_orchestrator_runtime
+
+    with _chat_runtime_lock:
+        _chat_tools_runtime = None
+        _chat_orchestrator_runtime = None
+
+
 class ApiError(Exception):
     """API error with explicit HTTP status."""
 
@@ -2974,6 +2984,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
                 return
             from ai.openai_auth import save_api_key, get_auth_status
             save_api_key(key, provider)
+            _reset_chat_runtime_after_auth_key_save()
             status = get_auth_status()
             self._send_json(HTTPStatus.OK, status)
         except Exception as exc:

--- a/python/test_openai_auth_status.py
+++ b/python/test_openai_auth_status.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pathlib
 import sys
 import time
@@ -87,6 +88,16 @@ def test_save_api_key_round_trips_openai_provider(tmp_path, monkeypatch) -> None
     assert status["provider"] == "openai"
     assert openai_auth.get_api_key() == "sk-openai-key-456"
     assert openai_auth.get_api_key_provider() == "openai"
+
+
+def test_save_api_key_updates_runtime_env_for_xai(tmp_path, monkeypatch) -> None:
+    token_path = tmp_path / "auth_tokens.json"
+    monkeypatch.setattr(openai_auth, "_token_path", lambda: token_path)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    openai_auth.save_api_key("xai-key-123", "xai")
+
+    assert os.environ.get("XAI_API_KEY") == "xai-key-123"
 
 
 def test_save_tokens_preserves_existing_direct_api_key(tmp_path, monkeypatch) -> None:

--- a/python/test_server_auth_key_refresh.py
+++ b/python/test_server_auth_key_refresh.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+def test_reset_chat_runtime_after_auth_key_save_clears_cached_runtime() -> None:
+    original_tools = server._chat_tools_runtime
+    original_orchestrator = server._chat_orchestrator_runtime
+    try:
+        server._chat_tools_runtime = object()
+        server._chat_orchestrator_runtime = object()
+
+        server._reset_chat_runtime_after_auth_key_save()
+
+        assert server._chat_tools_runtime is None
+        assert server._chat_orchestrator_runtime is None
+    finally:
+        server._chat_tools_runtime = original_tools
+        server._chat_orchestrator_runtime = original_orchestrator


### PR DESCRIPTION
## Summary
- mirror saved API keys into the live backend env
- clear cached chat runtimes after `POST /api/auth/key` so newly saved keys apply without a backend restart
- add regressions for env mirroring and runtime reset

## Why
Recent auth/persistence PRs fixed provider labeling and token coexistence, but the live save-key path still left the cached chat runtime untouched. That meant a newly saved xAI key could still leave chat stuck on the old in-memory client until the backend restarted.

## Validation
- `pytest -q python/test_openai_auth_status.py python/test_server_auth_key_refresh.py`
- `pytest -q python/test_server_chat_policy.py python/test_openai_auth_status.py python/test_server_auth_key_refresh.py`
- `python3 -m py_compile python/server.py python/ai/openai_auth.py python/test_openai_auth_status.py python/test_server_auth_key_refresh.py`
- `npm run test -- --run`
- `./node_modules/.bin/tsc --noEmit`
