### PR TITLE
fix(parse-run): API port pre-flight probe with actionable error

### DIFF
--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -42,6 +42,15 @@
 # cannot signal it, which historically left zombie python.exe processes
 # holding port 8766 and breaking subsequent launches. This script detects
 # that case and uses taskkill.exe to clean both sides.
+#
+# Phantom port reservation
+# ------------------------
+# A crashed python.exe occasionally leaves a kernel-level reservation on
+# the API port that netstat cannot see but bind() still trips over
+# (WinError 10013 / 10048). preflight_api_port below probes the port with
+# PARSE_PY before start_api and, on failure, points at the fix:
+# `wsl --shutdown` from Windows cmd clears the reservation. Override
+# PARSE_API_PORT to skip the block entirely.
 
 set -u
 
@@ -135,6 +144,67 @@ stop_servers() {
   fuser -k "${PARSE_VITE_PORT}/tcp" 2>/dev/null || true
 
   sleep 1
+}
+
+# ---------- API port pre-flight ------------------------------------------
+#
+# On Windows + WSL a crashed python.exe can leave a kernel-level reservation
+# on the server port that never appears in netstat or `netsh int ipv4 show
+# excludedportrange`. The subsequent server.py start crashes inside
+# socketserver.bind with WinError 10013 (ACCESS) or 10048 (ADDRINUSE), and
+# parse-run then wastes the full 12-second curl healthcheck window before
+# giving up with a vague "API did not respond" message.
+#
+# Do a tiny bind probe using PARSE_PY (so the same interpreter/network stack
+# as the real server) and, when it fails, print the underlying OS error plus
+# the actionable fix (wsl --shutdown) before start_api wastes time.
+
+preflight_api_port() {
+  local probe_out
+  probe_out=$(
+    "${PARSE_PY}" - <<PY 2>&1
+import socket, sys
+s = socket.socket()
+try:
+    s.bind(("127.0.0.1", ${PARSE_API_PORT}))
+except OSError as exc:
+    print("BIND_FAIL: {0}".format(exc))
+    sys.exit(1)
+finally:
+    try:
+        s.close()
+    except Exception:
+        pass
+print("BIND_OK")
+PY
+  ) || true
+
+  case "${probe_out}" in
+    BIND_OK*)
+      return 0
+      ;;
+    *WinError\ 10013*|*WinError\ 10048*)
+      log "ERROR: cannot bind 127.0.0.1:${PARSE_API_PORT} — ${probe_out#BIND_FAIL: }"
+      log "  → Likely Windows/WSL phantom port reservation (visible to bind, invisible to netstat)."
+      log "  → Fix: run 'wsl --shutdown' from Windows cmd/PowerShell, then retry parse-run."
+      log "  → Alternative: set PARSE_API_PORT=<other> in your environment before relaunching."
+      return 1
+      ;;
+    *BIND_FAIL*)
+      log "ERROR: cannot bind 127.0.0.1:${PARSE_API_PORT} — ${probe_out#BIND_FAIL: }"
+      log "  → Check what's holding the port:"
+      log "      lsof -i :${PARSE_API_PORT}   (WSL/Linux)"
+      log "      netstat.exe -ano | grep ${PARSE_API_PORT}   (from WSL, hits Windows side)"
+      log "  → Or override the port with PARSE_API_PORT=<other> and restart."
+      return 1
+      ;;
+    *)
+      # Non-bind failure (Python invocation error, etc.) — surface it but don't block.
+      log "WARNING: API port pre-flight probe did not produce BIND_OK/BIND_FAIL; continuing anyway."
+      log "  probe output: ${probe_out}"
+      return 0
+      ;;
+  esac
 }
 
 # ---------- Git pull (defensive) -----------------------------------------
@@ -290,6 +360,7 @@ main() {
 
   pull_main
   stop_servers
+  preflight_api_port || return 1
   start_api || return 1
   start_vite || return 1
   print_banner


### PR DESCRIPTION
## Summary

Add a pre-flight port check to \`scripts/parse-run.sh\` that runs a tiny Python bind probe on \`127.0.0.1:\${PARSE_API_PORT}\` between \`stop_servers\` and \`start_api\`. When the bind fails, parse-run now prints the OS error plus the fix command, and aborts with exit 1 instead of wasting the 12-second curl healthcheck window on a server that can't possibly come up.

## Why

Diagnosed on Lucas's PC earlier today: python.exe server was crashing inside \`socketserver.bind()\` with \`WinError 10013 (ACCESS)\`/\`10048 (ADDRINUSE)\` on port 8766, even though \`netstat\` and \`netsh int ipv4 show excludedportrange\` both showed 8766 was free. The reservation was at the Windows/WSL kernel level — left behind by an earlier crashed python.exe — and survived pkill, fuser, and taskkill. The old flow printed \`Starting Python API server on :8766...\` → waited 12s → \`WARNING: API did not respond\` with no hint about what was actually wrong. stderr redirect doesn't help either: the server dies before the shell-opened log file is usable.

Fix sequence that unblocked the PC: \`wsl --shutdown\` from Windows cmd → port 8766 bindable again. The pre-flight encodes that diagnosis.

## Error message users now see

\`\`\`
[parse-run] ERROR: cannot bind 127.0.0.1:8766 — [WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted
[parse-run]   → Likely Windows/WSL phantom port reservation (visible to bind, invisible to netstat).
[parse-run]   → Fix: run 'wsl --shutdown' from Windows cmd/PowerShell, then retry parse-run.
[parse-run]   → Alternative: set PARSE_API_PORT=<other> in your environment before relaunching.
\`\`\`

On Linux/WSL without the Windows quirk, the generic branch suggests \`lsof -i :PORT\` / \`netstat.exe -ano\` and the same \`PARSE_API_PORT\` override.

## Test plan

- [x] Smoke: port held by another process → preflight prints ERROR block and returns 1 (repro'd locally on macOS with a dummy socket).
- [x] Smoke: port free → preflight is silent and returns 0.
- [x] \`bash -n scripts/parse-run.sh\` — syntax clean.
- [ ] On PC: verify the diagnostic fires when the phantom reservation is reproduced (easy repro: \`parse-run\`, Ctrl-C during API startup, re-run \`parse-run\`).

## Notes

- Uses \`PARSE_PY\` so it shares the same interpreter and (Windows) network stack as the real server — a macOS/Linux probe would falsely succeed on Windows.
- Extra safety: unknown probe output (e.g. Python interpreter can't launch) falls through with a WARNING instead of blocking startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)