### PR TITLE
feat(parse-run): source .parse-env for machine-local overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Machine-specific local overrides (not committed)
+.parse-env
+
 # Python
 python/__pycache__/
 *.pyc

--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -54,6 +54,25 @@
 
 set -u
 
+# ---------- Local env override --------------------------------------------
+#
+# Create <repo-root>/.parse-env to set machine-specific overrides without
+# touching tracked files. This file is gitignored. Example contents:
+#
+#   PARSE_EXTERNAL_READ_ROOTS=/mnt/c/Users/Lucas/Thesis
+#   PARSE_PY=/mnt/c/Users/Lucas/miniconda3/python.exe
+#
+# The file is sourced before the defaults block so any variable it exports
+# takes precedence over the :=  defaults below.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARSE_ENV_FILE="$(cd "${SCRIPT_DIR}/.." && pwd)/.parse-env"
+if [ -f "${PARSE_ENV_FILE}" ]; then
+  # shellcheck source=/dev/null
+  . "${PARSE_ENV_FILE}"
+  printf '[parse-run] Loaded local overrides from .parse-env\n'
+fi
+
 # ---------- Defaults ------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary

- Adds `.parse-env` sourcing to `parse-run.sh` (before the defaults block) so machine-specific settings like `PARSE_EXTERNAL_READ_ROOTS` survive `git pull` without modifying tracked files
- `.parse-env` is gitignored — each machine creates its own copy
- Fixes: PARSE AI rejected audio/CSV paths under `/mnt/c/Users/Lucas/Thesis/` with "path escapes allowed root" because `PARSE_EXTERNAL_READ_ROOTS` was never set

## Usage

Create `<repo-root>/.parse-env` on the machine:
```bash
PARSE_EXTERNAL_READ_ROOTS=/mnt/c/Users/Lucas/Thesis
```

Set `*` to disable the sandbox entirely. Use `:` (POSIX) or `;` (Windows) to separate multiple roots.

## Test plan

- [ ] `parse-run.sh` logs `Loaded local overrides from .parse-env` at startup when the file exists
- [ ] `PARSE_EXTERNAL_READ_ROOTS` set in `.parse-env` is reflects by `read_audio_info` / `read_csv_preview` / `read_text_preview` / `onboard_speaker_import`
- [ ] Missing `.parse-env` is silently skipped — no error
- [ ] `git pull` on restart does not remove `.parse-env` (it's gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)