### PR TITLE
fix(chat): preserve wildcard token in _chat_external_read_roots

### DIFF
--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -192,6 +192,9 @@ def _resolve_external_read_roots() -> list:
         piece = piece.strip()
         if not piece:
             continue
+        if piece in {"*", "**", "/"}:
+            roots.append(Path(piece))
+            continue
         candidate = Path(piece).expanduser()
         try:
             resolved = candidate.resolve()

--- a/python/server.py
+++ b/python/server.py
@@ -1395,6 +1395,10 @@ def _chat_external_read_roots() -> List[pathlib.Path]:
         piece = piece.strip()
         if not piece:
             continue
+        # Preserve wildcard tokens as-is so ParseChatTools.__init__ can detect them.
+        if piece in {"*", "**", "/"}:
+            roots.append(pathlib.Path(piece))
+            continue
         candidate = pathlib.Path(piece).expanduser()
         try:
             resolved = candidate.resolve()


### PR DESCRIPTION
## Summary

`pathlib.Path("*").resolve()` silently turns the wildcard string into an absolute path like `/home/lucas/parse-workspace/*`, so `ParseChatTools.__init__` never sees the bare `"*"` string, never sets `external_read_wildcard = True`, and the sandbox stays active regardless of `PARSE_EXTERNAL_READ_ROOTS=*`.

Fix: short-circuit the `.resolve()` call for the three wildcard tokens (`*`, `**`, `/`) and append them as-is so the downstream wildcard check fires correctly. Same fix applied to the mirror copy in `mcp_adapter._resolve_external_read_roots`.

## Impact

- `PARSE_EXTERNAL_READ_ROOTS=*` now correctly disables the sandbox
- `PARSE_EXTERNAL_READ_ROOTS=/mnt/c/Users/Lucas/Thesis` (concrete path) is unaffected
- `onboard_speaker_import` and `read_audio_info` / `read_csv_preview` / `read_text_preview` now respect the wildcard

## Test plan

- [ ] `PARSE_EXTERNAL_READ_ROOTS=*` → `external_read_wildcard` is `True` in `ParseChatTools`
- [ ] `onboard_speaker_import` reaches files outside workspace when `*` is set
- [ ] Concrete root path (e.g. `/mnt/c/Users/Lucas/Thesis`) still works correctly
- [ ] Missing / empty `PARSE_EXTERNAL_READ_ROOTS` still blocks out-of-workspace paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)