### PR TITLE
fix(parse-run): don't pop stash after reset --hard

### DIFF
--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -251,7 +251,13 @@ pull_main() {
       reset)
         if git reset --hard origin/main; then
           log "Local main reset to origin/main (destructive)"
-          [ "${pop}" = "1" ] && git stash pop -q 2>/dev/null || true
+          # Do NOT pop: reset mode intentionally discards local state.
+          # Popping after a hard reset causes conflicts between the rescued
+          # changes and the new origin/main tree.  The stash entry remains
+          # as a safety net; recover manually with: git stash pop
+          if [ "${stashed}" = "1" ]; then
+            log "  Local changes were stashed (not restored). Recover with: git stash pop"
+          fi
           return 0
         fi
         ;;


### PR DESCRIPTION
## Summary

In `reset` mode, `pull_main()` was stashing local changes, running `git reset --hard origin/main`, then immediately popping the stash back. This is contradictory: the entire point of `reset` mode is to discard local state and match `origin/main`. Popping the stash after a hard reset reintroduces old files that conflict with the freshly-reset tree.

**Root cause of the recurring CONFLICT errors on `parse-run`**: any time a file was hot-patched between launches (e.g. `server.py`, `parse-run.sh`), it landed in the autostash, survived the reset, then conflicted on pop.

**Fix**: for the `reset` case, skip the stash pop. The stash entry is still created as a safety net so nothing is silently lost — the user can recover with `git stash pop` if needed. `ff`, `rebase`, and `auto` modes are unaffected.

## Test plan

- [ ] `PARSE_PULL_MODE=reset` with dirty working tree → reset succeeds, stash is kept, log prints recovery hint, no conflict
- [ ] `PARSE_PULL_MODE=ff` with dirty working tree → stash pop still happens (unchanged)
- [ ] `PARSE_PULL_MODE=rebase` with dirty working tree → stash pop still happens (unchanged)
- [ ] Clean working tree → no stash created, no change in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)