### PR TITLE
fix: load repo parse env in mcp adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Environment overrides:
 | `PARSE_SKIP_PULL` | `0` | Set to `1` to skip the `git pull` step. |
 | `PARSE_PULL_MODE` | `auto` | Git integration strategy: `auto`, `ff`, `rebase`, or `reset`. |
 
-For machine-local overrides without editing tracked files, create a gitignored `.parse-env` file in the repo root. `parse-run.sh` sources it before applying defaults, so settings like `PARSE_PY` or `PARSE_EXTERNAL_READ_ROOTS` can live there permanently.
+For machine-local overrides without editing tracked files, create a gitignored `.parse-env` file in the repo root. `parse-run.sh` sources it before applying defaults, and the standalone MCP adapter now mirrors that convention when launched directly, so settings like `PARSE_PY`, `PARSE_EXTERNAL_READ_ROOTS`, or `PARSE_CHAT_MEMORY_PATH` can live there permanently. Explicit process environment variables still win over `.parse-env`.
 
 Two companion commands are also available:
 
@@ -412,6 +412,8 @@ Add PARSE as an MCP server in your client config. Example for Claude Desktop (`c
     }
 }
 ```
+
+If you launch the adapter without an explicit `env` block, it also reads repo-local overrides from `<project-root>/.parse-env` (same convention as `scripts/parse-run.sh`). Use that for machine-specific `PARSE_EXTERNAL_READ_ROOTS`, `PARSE_CHAT_MEMORY_PATH`, or `PARSE_PROJECT_ROOT`; explicit client-provided env vars still take precedence.
 
 ### Exposed Tools
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -82,6 +82,47 @@ def _resolve_project_root(cli_root: Optional[str] = None) -> Path:
     return Path.cwd()
 
 
+def _load_repo_parse_env(project_root_path: Path) -> Dict[str, str]:
+    """Load machine-local overrides from <project>/.parse-env into os.environ.
+
+    The dev launcher (scripts/parse-run.sh) already sources this file before
+    booting the browser/server stack, but the standalone MCP adapter is often
+    launched directly by an editor or agent process. In that mode, the process
+    inherits no PARSE_* environment and silently falls back to the strict
+    project-root sandbox, which breaks legitimate thesis imports from /mnt/c.
+
+    This helper mirrors the launcher convention: read simple KEY=VALUE pairs
+    from .parse-env and populate only variables that are currently unset.
+    Existing environment variables always win.
+    """
+    parse_env_path = project_root_path / ".parse-env"
+    if not parse_env_path.exists() or not parse_env_path.is_file():
+        return {}
+
+    applied: Dict[str, str] = {}
+    for raw_line in parse_env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].strip()
+        if "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key or key in os.environ:
+            continue
+
+        cleaned = value.strip()
+        if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in {'"', "'"}:
+            cleaned = cleaned[1:-1]
+        os.environ[key] = cleaned
+        applied[key] = cleaned
+
+    return applied
+
+
 def _resolve_api_base() -> str:
     """Resolve the HTTP base URL of the running PARSE API server.
 
@@ -342,9 +383,15 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
     from ai.chat_tools import ParseChatTools
 
     root = _resolve_project_root(project_root)
+    applied_env = _load_repo_parse_env(root)
     external_roots = _resolve_external_read_roots()
     memory_path = _resolve_memory_path(root)
     logger.info("PARSE MCP server starting with project root: %s", root)
+    if applied_env:
+        logger.info(
+            "Loaded .parse-env overrides: %s",
+            ", ".join("{0}={1}".format(k, v) for k, v in sorted(applied_env.items())),
+        )
     if external_roots:
         logger.info("External read roots: %s", ", ".join(str(r) for r in external_roots))
     logger.info("Chat memory path: %s", memory_path)

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -5,6 +5,7 @@ through ParseChatTools.execute(), so registering an MCP tool that isn't
 in the allowlist produces a runtime ChatToolValidationError on the
 client side. A test at import time catches that before shipping.
 """
+import os
 import pathlib
 import sys
 
@@ -16,6 +17,57 @@ if str(_PYTHON_DIR) not in sys.path:
     sys.path.insert(0, str(_PYTHON_DIR))
 
 from ai.chat_tools import ParseChatTools
+
+
+def test_load_repo_parse_env_sets_missing_vars(tmp_path, monkeypatch) -> None:
+    from adapters import mcp_adapter
+
+    (tmp_path / ".parse-env").write_text(
+        "# local overrides\nPARSE_EXTERNAL_READ_ROOTS=*\nexport PARSE_CHAT_MEMORY_PATH=memory/custom.md\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("PARSE_EXTERNAL_READ_ROOTS", raising=False)
+    monkeypatch.delenv("PARSE_CHAT_MEMORY_PATH", raising=False)
+
+    applied = mcp_adapter._load_repo_parse_env(tmp_path)
+
+    assert applied == {
+        "PARSE_EXTERNAL_READ_ROOTS": "*",
+        "PARSE_CHAT_MEMORY_PATH": "memory/custom.md",
+    }
+    assert os.environ["PARSE_EXTERNAL_READ_ROOTS"] == "*"
+    assert os.environ["PARSE_CHAT_MEMORY_PATH"] == "memory/custom.md"
+
+
+def test_repo_parse_env_can_disable_mcp_path_sandbox(tmp_path, monkeypatch) -> None:
+    import wave
+
+    from adapters import mcp_adapter
+
+    (tmp_path / ".parse-env").write_text("PARSE_EXTERNAL_READ_ROOTS=*\n", encoding="utf-8")
+    monkeypatch.delenv("PARSE_EXTERNAL_READ_ROOTS", raising=False)
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    stray_root = tmp_path / "external"
+    stray_root.mkdir()
+    wav = stray_root / "speaker.wav"
+    with wave.open(str(wav), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(16000)
+        handle.writeframes(b"\x00\x00" * 16000)
+
+    mcp_adapter._load_repo_parse_env(tmp_path)
+    tools = ParseChatTools(
+        project_root=project_root,
+        external_read_roots=mcp_adapter._resolve_external_read_roots(),
+    )
+
+    result = tools.execute("read_audio_info", {"sourceWav": str(wav)})["result"]
+    assert result["ok"] is True
+    assert result["sampleRateHz"] == 16000
 
 
 def _has_mcp() -> bool:


### PR DESCRIPTION
## Summary
- load repo-local `.parse-env` inside the standalone MCP adapter before resolving external read roots
- add regression coverage for `.parse-env` loading and wildcard external path access
- document that direct MCP launches mirror `scripts/parse-run.sh` for local PARSE env overrides

## Root cause
The browser-backed PARSE server was already running with `PARSE_EXTERNAL_READ_ROOTS=*`, but direct MCP launches of `python/adapters/mcp_adapter.py` did not load repo-local `.parse-env`. That meant MCP clients silently fell back to the strict project-root sandbox and rejected thesis `/mnt/c/...` source paths.

## Test plan
- [x] `python3 -m pytest python/adapters/test_mcp_adapter.py python/ai/test_parse_memory_tool.py -q`
- [x] `npm run test -- --run`
- [x] `./node_modules/.bin/tsc --noEmit`
