### PR TITLE
fix(chat-tools): translate WSL /mnt/X/ paths on Windows Python

### DIFF
--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -238,6 +238,26 @@ def _deepcopy_jsonable(payload: Any) -> Any:
     return copy.deepcopy(payload)
 
 
+_WSL_MOUNT_RE = re.compile(r'^[/\\]mnt[/\\]([a-zA-Z])[/\\]?(.*)', re.DOTALL)
+
+
+def _wsl_to_windows_path(raw: str) -> Optional[str]:
+    """Convert a WSL /mnt/X/... path to a Windows drive-letter path.
+
+    On Windows Python, /mnt/c/Users/... is not absolute (no drive letter),
+    so pathlib anchors it under cwd and produces a broken UNC path.
+    Returns the translated string, or None if the input isn't a WSL mount path.
+    """
+    if os.name != 'nt':
+        return None
+    m = _WSL_MOUNT_RE.match(raw)
+    if not m:
+        return None
+    drive = m.group(1).upper()
+    rest = m.group(2).replace('\\', '/')
+    return f"{drive}:/{rest}" if rest else f"{drive}:/"
+
+
 class ParseChatTools:
     """Strict read-only tool allowlist for PARSE chat."""
 
@@ -898,7 +918,15 @@ class ParseChatTools:
 
         candidate = Path(value).expanduser()
         if not candidate.is_absolute():
-            candidate = self.project_root / candidate
+            # On Windows Python, /mnt/X/... paths are WSL drive-letter mounts and
+            # are not recognised as absolute.  Translate before anchoring so we
+            # resolve to the real Windows path (C:\...) rather than appending the
+            # raw string under project_root and ending up with a broken UNC path.
+            translated = _wsl_to_windows_path(value)
+            if translated is not None:
+                candidate = Path(translated)
+            else:
+                candidate = self.project_root / candidate
 
         resolved = candidate.resolve()
 


### PR DESCRIPTION
## Root cause

The PARSE server can run under a Windows Python interpreter (e.g. a Conda environment on the Windows side). On Windows Python, \`pathlib.Path('/mnt/c/...').is_absolute()\` returns **False** — there is no drive letter, so Windows does not consider it absolute. \`_resolve_readable_path\` was therefore anchoring those paths under \`project_root\`, producing a broken UNC path that either fails to resolve or raises \`WinError 5 (Access denied)\`. This caused \`onboard_speaker_import\` to reject all WSL mount paths even with the sandbox fully disabled.

## Fix

Add \`_wsl_to_windows_path()\` which converts \`/mnt/X/rest\` → \`X:/rest\` when \`os.name == 'nt'\`. Apply it in \`_resolve_readable_path\` before the \`project_root\` anchor so the path becomes a proper Windows absolute path. On Linux/WSL Python the helper returns \`None\` and behaviour is unchanged.

## Test plan

- [ ] \`onboard_speaker_import\` with a \`/mnt/c/...\` source path resolves correctly on Windows Python
- [ ] Non-\`/mnt/\` relative paths still anchor to \`project_root\` unchanged
- [ ] On Linux Python \`_wsl_to_windows_path\` returns \`None\` for all inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)