### PR TITLE
feat(chat): show live tool-call status, fix activity-based timeout

### DIFF
--- a/python/ai/chat_orchestrator.py
+++ b/python/ai/chat_orchestrator.py
@@ -16,7 +16,7 @@ import os
 import re
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from .chat_tools import ChatToolError, ParseChatTools, WRITE_ALLOWED_TOOL_NAMES
 from .provider import OpenAIChatRuntime
@@ -468,6 +468,7 @@ class ChatOrchestrator:
         self,
         session_id: str,
         session_messages: Sequence[Mapping[str, Any]],
+        on_tool_call: Optional[Callable[[str], None]] = None,
     ) -> Dict[str, Any]:
         """Run one assistant turn for an existing session history."""
         if not session_messages:
@@ -519,6 +520,12 @@ class ChatOrchestrator:
                 for call in tool_calls:
                     tool_name = str(call.get("name") or "").strip()
                     raw_args = call.get("arguments") or "{}"
+
+                    if on_tool_call is not None:
+                        try:
+                            on_tool_call(tool_name)
+                        except Exception:
+                            pass
 
                     try:
                         tool_result = self.tools.execute(tool_name, raw_args)

--- a/python/server.py
+++ b/python/server.py
@@ -1530,9 +1530,14 @@ def _run_chat_job(job_id: str, session_id: str) -> None:
 
         _set_job_progress(job_id, 20.0, message="Running chat orchestration")
         _, orchestrator = _get_chat_runtime()
+
+        def _tool_progress(tool_name: str) -> None:
+            _set_job_progress(job_id, 20.0, message="Running: {0}".format(tool_name))
+
         result = orchestrator.run(
             session_id=session_id,
             session_messages=session_snapshot.get("messages", []),
+            on_tool_call=_tool_progress,
         )
 
         assistant_payload = result.get("assistant") if isinstance(result, dict) else {}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -79,6 +79,8 @@ export interface ChatStatus {
   status: string;
   result?: string | Record<string, unknown>;
   error?: string;
+  progress?: number;
+  message?: string;
 }
 
 export interface ComputeJob {

--- a/src/components/annotate/ChatPanel.tsx
+++ b/src/components/annotate/ChatPanel.tsx
@@ -24,7 +24,7 @@ const authSecondaryBtnClass =
   "w-full rounded-md border border-indigo-600 bg-white px-5 py-2.5 text-sm font-semibold text-indigo-600 hover:bg-slate-50"
 
 export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
-  const { messages, sending, tokensUsed, tokensLimit, send, clear } = useChatSession()
+  const { messages, sending, statusMessage, tokensUsed, tokensLimit, send, clear } = useChatSession()
   const [inputText, setInputText] = useState("")
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
@@ -331,7 +331,9 @@ export function ChatPanel({ speaker, conceptId }: ChatPanelProps) {
             <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.3s]" />
             <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.15s]" />
             <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400" />
-            <span className="ml-1.5 text-[12px] font-medium text-slate-500">Thinking…</span>
+            <span className="ml-1.5 text-[12px] font-medium text-slate-500">
+              {statusMessage ?? "Thinking…"}
+            </span>
           </div>
         )}
         <div ref={messagesEndRef} />

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -11,6 +11,7 @@ export interface UseChatSessionResult {
   messages: ChatMessage[]
   sessionId: string | null
   sending: boolean
+  statusMessage: string | null
   error: string | null
   tokensUsed: number | null
   tokensLimit: number | null
@@ -19,8 +20,10 @@ export interface UseChatSessionResult {
 }
 
 const SESSION_KEY = "parse-chat-session-id"
-const MAX_POLLS = 60
 const POLL_INTERVAL_MS = 2000
+// How many consecutive polls with no message change before giving up.
+// Each poll is POLL_INTERVAL_MS, so 30 idle polls = 60 s of silence.
+const MAX_IDLE_POLLS = 30
 
 export function extractAssistantContent(raw: unknown): string {
   if (typeof raw === "string") return raw
@@ -43,6 +46,7 @@ export function useChatSession(): UseChatSessionResult {
     () => sessionStorage.getItem(SESSION_KEY),
   )
   const [sending, setSending] = useState(false)
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [tokensUsed, setTokensUsed] = useState<number | null>(null)
   const [tokensLimit, setTokensLimit] = useState<number | null>(null)
@@ -107,8 +111,12 @@ export function useChatSession(): UseChatSessionResult {
 
       const job = await runChat(sid, text)
 
-      // Poll for completion
-      let polls = 0
+      // Poll for completion.  Timeout is activity-based: idlePolls resets
+      // to zero whenever the server's status message changes, so long-running
+      // tool calls (STT, imports) never time out as long as they keep
+      // reporting progress.
+      let idlePolls = 0
+      let lastMessage: string | undefined
       const pollOnce = (): Promise<string> =>
         new Promise((resolve, reject) => {
           const tick = () => {
@@ -116,9 +124,17 @@ export function useChatSession(): UseChatSessionResult {
               reject(new Error("Aborted"))
               return
             }
-            polls++
             pollChat(job.job_id)
               .then((status) => {
+                // Reset idle counter whenever the server reports new activity.
+                if (status.message !== lastMessage) {
+                  idlePolls = 0
+                  lastMessage = status.message
+                  setStatusMessage(status.message ?? null)
+                } else {
+                  idlePolls++
+                }
+
                 if (
                   status.status === "done"
                   || status.status === "completed"
@@ -127,8 +143,8 @@ export function useChatSession(): UseChatSessionResult {
                   resolve(extractAssistantContent(status.result))
                 } else if (status.status === "error") {
                   reject(new Error(status.error ?? extractAssistantContent(status.result) ?? "Chat error"))
-                } else if (polls >= MAX_POLLS) {
-                  reject(new Error("Chat timed out"))
+                } else if (idlePolls >= MAX_IDLE_POLLS) {
+                  reject(new Error("Chat timed out — no response after 60 s of inactivity"))
                 } else {
                   setTimeout(tick, POLL_INTERVAL_MS)
                 }
@@ -163,6 +179,7 @@ export function useChatSession(): UseChatSessionResult {
       }
     } finally {
       setSending(false)
+      setStatusMessage(null)
     }
   }, [sessionId])
 
@@ -175,5 +192,5 @@ export function useChatSession(): UseChatSessionResult {
     sessionStorage.removeItem(SESSION_KEY)
   }, [])
 
-  return { messages, sessionId, sending, error, tokensUsed, tokensLimit, send, clear }
+  return { messages, sessionId, sending, statusMessage, error, tokensUsed, tokensLimit, send, clear }
 }


### PR DESCRIPTION
## Summary

- The thinking bubble now updates in real-time as the agent executes tools, replacing the static "Thinking…" label with the active tool name (e.g. "Running: onboard_speaker_import")
- The chat timeout now resets on every new status message from the server, so long-running operations (file imports, STT jobs) are never cut short as long as the backend keeps reporting activity
- The poll-count ceiling is now an idle ceiling: if there is no new message for 60 s the request times out with a clear error, but active jobs run as long as they need

## Test plan

- [ ] Start a chat, ask the agent to import a speaker or run STT
- [ ] Verify the thinking bubble cycles through tool names as each tool fires
- [ ] Verify the bubble reads the final tool name until the response arrives
- [ ] Let a long import run — confirm it does not time out mid-job
- [ ] Verify a genuinely stalled job (backend crashes mid-poll) still times out after ~60 s of silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)