### PR TITLE
feat: add processed-speaker MCP import workflow

### DIFF
--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -4,12 +4,13 @@
 Starts a stdio MCP server that lets any MCP client (Claude Code, Cursor, Codex,
 Windsurf, etc.) call PARSE's linguistic analysis tools programmatically.
 
-Tools exposed (14):
+Tools exposed (15):
   project_context_read, annotation_read, read_csv_preview,
   cognate_compute_preview, cross_speaker_match_preview, spectrogram_preview,
   contact_lexeme_lookup, stt_start, stt_status,
   import_tag_csv, prepare_tag_import,
-  onboard_speaker_import, parse_memory_read, parse_memory_upsert_section
+  onboard_speaker_import, import_processed_speaker,
+  parse_memory_read, parse_memory_upsert_section
 
 Usage:
     python python/adapters/mcp_adapter.py
@@ -132,6 +133,36 @@ def _resolve_api_base() -> str:
     """
     port = os.environ.get("PARSE_API_PORT") or os.environ.get("PARSE_PORT") or "8766"
     return "http://127.0.0.1:{0}".format(str(port).strip() or "8766")
+
+
+def _resolve_onboard_http_timeout(total_bytes: int) -> float:
+    """Return a socket timeout for MCP onboarding HTTP calls.
+
+    Thesis WAV uploads are often multi-gigabyte files. The original fixed
+    120-second timeout is too short even on localhost once the adapter spends
+    time reading the file, constructing multipart payloads, and waiting for the
+    server to persist the upload. Scale the timeout with payload size while
+    keeping a sane floor/cap, and allow an explicit environment override for
+    machine-specific tuning.
+    """
+    override_raw = str(os.environ.get("PARSE_MCP_ONBOARD_TIMEOUT_SEC") or "").strip()
+    if override_raw:
+        try:
+            override = float(override_raw)
+        except ValueError:
+            override = 0.0
+        if override > 0:
+            return override
+
+    base_timeout = 120.0
+    max_timeout = 1800.0
+    payload_bytes = max(0, int(total_bytes))
+    if payload_bytes <= 128 * 1024 * 1024:
+        return base_timeout
+
+    processing_buffer = 180.0
+    transfer_budget = payload_bytes / float(8 * 1024 * 1024)
+    return min(max_timeout, max(base_timeout, processing_buffer + transfer_budget))
 
 
 def _build_stt_callbacks() -> tuple:
@@ -280,6 +311,8 @@ def _build_onboard_callback() -> Optional[object]:
         boundary = "----parse-mcp-{0}".format(uuid.uuid4().hex)
         crlf = b"\r\n"
         parts: list = []
+        total_bytes = source_wav.stat().st_size + (source_csv.stat().st_size if source_csv is not None else 0)
+        http_timeout = _resolve_onboard_http_timeout(total_bytes)
 
         def add_field(name: str, value: str) -> None:
             parts.append(
@@ -314,7 +347,7 @@ def _build_onboard_callback() -> Optional[object]:
         )
 
         try:
-            with urllib.request.urlopen(req, timeout=120.0) as resp:
+            with urllib.request.urlopen(req, timeout=http_timeout) as resp:
                 response = json.loads(resp.read().decode("utf-8") or "{}")
         except urllib.error.URLError as exc:
             raise RuntimeError(
@@ -329,7 +362,7 @@ def _build_onboard_callback() -> Optional[object]:
 
         # Poll for completion (bounded).
         status_req_body = json.dumps({"job_id": job_id}).encode("utf-8")
-        deadline = time.time() + 120.0
+        deadline = time.time() + http_timeout
         final: Dict[str, Any] = {}
         while time.time() < deadline:
             status_req = urllib.request.Request(
@@ -755,6 +788,42 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         if isPrimary is not None:
             args["isPrimary"] = isPrimary
         result = tools.execute("onboard_speaker_import", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def import_processed_speaker(
+        speaker: str,
+        workingWav: str,
+        annotationJson: str,
+        dryRun: bool,
+        peaksJson: Optional[str] = None,
+        transcriptCsv: Optional[str] = None,
+    ) -> str:
+        """Import a speaker from existing processed artifacts.
+
+        Use when lexemes are already timestamped to a working WAV and the goal is
+        to bootstrap the PARSE workspace from those processed files rather than
+        re-running raw-audio onboarding or STT.
+
+        Args:
+            speaker: Speaker ID
+            workingWav: Path to the processed/working WAV
+            annotationJson: Path to the timestamp-bearing annotation JSON
+            dryRun: If true, preview only
+            peaksJson: Optional peaks JSON for the same working WAV
+            transcriptCsv: Optional legacy transcript CSV to preserve in workspace
+        """
+        args: Dict[str, Any] = {
+            "speaker": speaker,
+            "workingWav": workingWav,
+            "annotationJson": annotationJson,
+            "dryRun": dryRun,
+        }
+        if peaksJson is not None:
+            args["peaksJson"] = peaksJson
+        if transcriptCsv is not None:
+            args["transcriptCsv"] = transcriptCsv
+        result = tools.execute("import_processed_speaker", args)
         return json.dumps(result, indent=2, ensure_ascii=False)
 
     @mcp.tool()

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -99,6 +99,22 @@ def test_every_mcp_tool_is_allowlisted_in_parse_chat_tools(tmp_path) -> None:
     )
 
 
+def test_resolve_onboard_http_timeout_scales_for_large_files(monkeypatch) -> None:
+    from adapters import mcp_adapter
+
+    monkeypatch.delenv("PARSE_MCP_ONBOARD_TIMEOUT_SEC", raising=False)
+
+    small = mcp_adapter._resolve_onboard_http_timeout(10 * 1024 * 1024)
+    fail02_like = mcp_adapter._resolve_onboard_http_timeout(1519246722)
+
+    assert small == 120.0
+    assert fail02_like > 120.0
+    assert fail02_like < 1800.0
+
+    monkeypatch.setenv("PARSE_MCP_ONBOARD_TIMEOUT_SEC", "300")
+    assert mcp_adapter._resolve_onboard_http_timeout(1519246722) == 300.0
+
+
 def test_contact_lexeme_lookup_is_allowlisted(tmp_path) -> None:
     """contact_lexeme_lookup specifically — the bug that motivated this test."""
     tools = ParseChatTools(project_root=tmp_path)
@@ -128,7 +144,7 @@ def test_no_duplicate_tool_specs_or_handlers() -> None:
     text = source.read_text(encoding="utf-8")
     for tool in [
         "annotation_read", "cognate_compute_preview", "contact_lexeme_lookup",
-        "cross_speaker_match_preview", "import_tag_csv", "prepare_tag_import",
+        "cross_speaker_match_preview", "import_processed_speaker", "import_tag_csv", "prepare_tag_import",
         "project_context_read", "read_csv_preview", "spectrogram_preview",
         "stt_start", "stt_status",
     ]:

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -44,6 +44,7 @@ WRITE_ALLOWED_TOOL_NAMES = frozenset({
     "import_tag_csv",
     "prepare_tag_import",
     "onboard_speaker_import",
+    "import_processed_speaker",
     "parse_memory_upsert_section",
 })
 TEXT_PREVIEW_EXTENSIONS = frozenset({".md", ".markdown", ".txt", ".rst"})
@@ -681,6 +682,29 @@ class ParseChatTools:
                             "type": "boolean",
                             "description": "If true, preview only — no file copies or source_index.json writes.",
                         },
+                    },
+                },
+            ),
+            "import_processed_speaker": ChatToolSpec(
+                name="import_processed_speaker",
+                description=(
+                    "Import a speaker from existing processed artifacts when lexemes are already timestamped to a WAV. "
+                    "Copies a working WAV plus annotation JSON (and optional peaks JSON / legacy transcript CSV) into the "
+                    "PARSE workspace, writes concepts.csv, updates project.json and source_index.json, and preserves the "
+                    "annotation's timestamp alignment to the working WAV. Call dryRun=true first, then dryRun=false "
+                    "after confirmation."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["speaker", "workingWav", "annotationJson", "dryRun"],
+                    "properties": {
+                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "workingWav": {"type": "string", "minLength": 1, "maxLength": 1024},
+                        "annotationJson": {"type": "string", "minLength": 1, "maxLength": 1024},
+                        "peaksJson": {"type": "string", "maxLength": 1024},
+                        "transcriptCsv": {"type": "string", "maxLength": 1024},
+                        "dryRun": {"type": "boolean"},
                     },
                 },
             ),
@@ -2300,6 +2324,338 @@ class ParseChatTools:
                 raise ChatToolValidationError("sourceCsv must have a .csv extension")
 
         return resolved
+
+    def _resolve_processed_json_source(self, raw_path: str, field_name: str) -> Path:
+        resolved = self._resolve_readable_path(raw_path)
+        if not resolved.exists() or not resolved.is_file():
+            raise ChatToolValidationError("{0} not found: {1}".format(field_name, resolved))
+        if resolved.suffix.lower() != ".json":
+            raise ChatToolValidationError("{0} must have a .json extension".format(field_name))
+        return resolved
+
+    def _resolve_processed_csv_source(self, raw_path: str, field_name: str) -> Path:
+        resolved = self._resolve_readable_path(raw_path)
+        if not resolved.exists() or not resolved.is_file():
+            raise ChatToolValidationError("{0} not found: {1}".format(field_name, resolved))
+        if resolved.suffix.lower() != ".csv":
+            raise ChatToolValidationError("{0} must have a .csv extension".format(field_name))
+        return resolved
+
+    def _extract_concepts_from_annotation(self, annotation_payload: Dict[str, Any]) -> List[Dict[str, str]]:
+        tiers = annotation_payload.get("tiers") if isinstance(annotation_payload, dict) else {}
+        if not isinstance(tiers, dict):
+            raise ChatToolValidationError("annotationJson must contain a tiers object")
+
+        concept_tier = tiers.get("concept")
+        if not isinstance(concept_tier, dict):
+            raise ChatToolValidationError("annotationJson is missing tiers.concept")
+
+        intervals = concept_tier.get("intervals")
+        if not isinstance(intervals, list):
+            raise ChatToolValidationError("annotationJson tiers.concept.intervals must be a list")
+
+        concept_re = re.compile(r"^\s*#?(\d+)\s*[:.-]\s*(.+?)\s*$")
+        existing_concepts = self._load_project_concepts()
+        existing_id_by_label = {
+            _normalize_space(item.get("label")).casefold(): _normalize_space(item.get("id"))
+            for item in existing_concepts
+            if _normalize_space(item.get("id")) and _normalize_space(item.get("label"))
+        }
+        reserved_numeric_ids = {
+            _normalize_space(item.get("id"))
+            for item in existing_concepts
+            if _normalize_space(item.get("id"))
+        }
+        for raw_interval in intervals:
+            if not isinstance(raw_interval, dict):
+                continue
+            text = _normalize_space(raw_interval.get("text"))
+            if not text:
+                continue
+            match = concept_re.match(text)
+            if match:
+                reserved_numeric_ids.add(_normalize_space(match.group(1)))
+
+        concepts: List[Dict[str, str]] = []
+        seen_ids = set()
+        fallback_index = 1
+        for raw_interval in intervals:
+            if not isinstance(raw_interval, dict):
+                continue
+            text = _normalize_space(raw_interval.get("text"))
+            if not text:
+                continue
+            match = concept_re.match(text)
+            if match:
+                concept_id = _normalize_space(match.group(1))
+                label = _normalize_space(match.group(2))
+            else:
+                existing_concept_id = existing_id_by_label.get(text.casefold())
+                if existing_concept_id and existing_concept_id not in seen_ids:
+                    concept_id = existing_concept_id
+                    label = text
+                else:
+                    while str(fallback_index) in reserved_numeric_ids or str(fallback_index) in seen_ids:
+                        fallback_index += 1
+                    concept_id = str(fallback_index)
+                    label = text
+                    fallback_index += 1
+            if not concept_id or not label or concept_id in seen_ids:
+                continue
+            seen_ids.add(concept_id)
+            concepts.append({"id": concept_id, "label": label})
+
+        if not concepts:
+            raise ChatToolValidationError("annotationJson does not contain importable concept intervals")
+
+        concepts.sort(key=lambda item: _concept_sort_key(item["id"]))
+        return concepts
+
+    def _write_concepts_csv(self, concepts: Sequence[Dict[str, str]]) -> int:
+        import csv as _csv
+
+        merged: Dict[str, str] = {item["id"]: item["label"] for item in self._load_project_concepts() if item.get("id") and item.get("label")}
+        for item in concepts:
+            concept_id = _normalize_space(item.get("id"))
+            label = _normalize_space(item.get("label"))
+            if concept_id and label:
+                merged[concept_id] = label
+
+        ordered = sorted(merged.items(), key=lambda kv: _concept_sort_key(kv[0]))
+        concepts_path = self.project_root / "concepts.csv"
+        concepts_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(concepts_path, "w", newline="", encoding="utf-8") as handle:
+            writer = _csv.DictWriter(handle, fieldnames=["id", "concept_en"])
+            writer.writeheader()
+            for concept_id, label in ordered:
+                writer.writerow({"id": concept_id, "concept_en": label})
+        return len(ordered)
+
+    def _write_project_json_for_processed_import(
+        self,
+        speaker: str,
+        project_id: str,
+        language_code: str,
+        concept_total: int,
+    ) -> None:
+        project = _read_json_file(self.project_json_path, {})
+        if not isinstance(project, dict):
+            project = {}
+
+        speakers_block = project.get("speakers")
+        if isinstance(speakers_block, list):
+            speakers_block = {str(item).strip(): {} for item in speakers_block if str(item).strip()}
+        elif not isinstance(speakers_block, dict):
+            speakers_block = {}
+        speakers_block.setdefault(speaker, {})
+        project["speakers"] = speakers_block
+
+        resolved_project_id = _normalize_space(project.get("project_id")) or _normalize_space(project_id) or "parse-project"
+        project["project_id"] = resolved_project_id
+        project_name = _normalize_space(project.get("name") or project.get("project_name"))
+        if not project_name:
+            project_name = resolved_project_id.replace("-", " ").title()
+        project["name"] = project_name
+        project["sourceIndex"] = "source_index.json"
+        project["audio_dir"] = "audio"
+        project["annotations_dir"] = "annotations"
+
+        language_block = project.get("language") if isinstance(project.get("language"), dict) else {}
+        language_block["code"] = _normalize_space(language_block.get("code") or language_code) or "und"
+        project["language"] = language_block
+
+        project["concepts"] = {
+            "source": "concepts.csv",
+            "id_column": "id",
+            "label_column": "concept_en",
+            "total": int(concept_total),
+        }
+
+        self.project_json_path.parent.mkdir(parents=True, exist_ok=True)
+        self.project_json_path.write_text(json.dumps(project, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    def _write_source_index_for_processed_import(
+        self,
+        speaker: str,
+        audio_rel: str,
+        duration_sec: float,
+        file_size_bytes: int,
+        peaks_rel: Optional[str],
+        transcript_csv_rel: Optional[str],
+    ) -> None:
+        source_index = _read_json_file(self.source_index_path, {})
+        if not isinstance(source_index, dict):
+            source_index = {}
+        speakers_block = source_index.get("speakers")
+        if not isinstance(speakers_block, dict):
+            speakers_block = {}
+            source_index["speakers"] = speakers_block
+
+        speaker_entry = speakers_block.get(speaker)
+        if not isinstance(speaker_entry, dict):
+            speaker_entry = {}
+
+        current_source = {
+            "filename": Path(audio_rel).name,
+            "path": audio_rel,
+            "duration_sec": float(duration_sec),
+            "file_size_bytes": int(file_size_bytes),
+            "is_primary": True,
+            "added_at": _utc_now_iso(),
+        }
+        existing_sources = speaker_entry.get("source_wavs") if isinstance(speaker_entry.get("source_wavs"), list) else []
+        merged_sources = [item for item in existing_sources if isinstance(item, dict)]
+        match_index = -1
+        for idx, entry in enumerate(merged_sources):
+            entry_path = _normalize_space(entry.get("path"))
+            if entry_path == audio_rel:
+                match_index = idx
+                break
+        if match_index >= 0:
+            merged_sources[match_index] = current_source
+        else:
+            merged_sources.append(current_source)
+        for entry in merged_sources:
+            if not isinstance(entry, dict):
+                continue
+            entry["is_primary"] = _normalize_space(entry.get("path")) == audio_rel
+        speaker_entry["source_wavs"] = merged_sources
+
+        if peaks_rel:
+            speaker_entry["peaks_file"] = peaks_rel
+        else:
+            speaker_entry.pop("peaks_file", None)
+        speaker_entry["has_csv"] = False
+        notes = ["imported from processed artifacts"]
+        if transcript_csv_rel:
+            speaker_entry["legacy_transcript_csv"] = transcript_csv_rel
+            notes.append("legacy transcript csv copied")
+        else:
+            speaker_entry.pop("legacy_transcript_csv", None)
+        speaker_entry["notes"] = "; ".join(notes)
+        speakers_block[speaker] = speaker_entry
+
+        self.source_index_path.parent.mkdir(parents=True, exist_ok=True)
+        self.source_index_path.write_text(json.dumps(source_index, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    def _tool_import_processed_speaker(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        import shutil
+
+        speaker = self._normalize_speaker(args.get("speaker"))
+        working_wav_raw = str(args.get("workingWav") or "").strip()
+        annotation_json_raw = str(args.get("annotationJson") or "").strip()
+        if not working_wav_raw:
+            raise ChatToolValidationError("workingWav is required")
+        if not annotation_json_raw:
+            raise ChatToolValidationError("annotationJson is required")
+
+        working_wav = self._resolve_onboard_source(working_wav_raw, must_be_audio=True)
+        annotation_json = self._resolve_processed_json_source(annotation_json_raw, "annotationJson")
+
+        peaks_json: Optional[Path] = None
+        peaks_json_raw = str(args.get("peaksJson") or "").strip()
+        if peaks_json_raw:
+            peaks_json = self._resolve_processed_json_source(peaks_json_raw, "peaksJson")
+
+        transcript_csv: Optional[Path] = None
+        transcript_csv_raw = str(args.get("transcriptCsv") or "").strip()
+        if transcript_csv_raw:
+            transcript_csv = self._resolve_processed_csv_source(transcript_csv_raw, "transcriptCsv")
+
+        dry_run = bool(args.get("dryRun"))
+
+        annotation_payload = _read_json_file(annotation_json, None)
+        if not isinstance(annotation_payload, dict):
+            raise ChatToolValidationError("annotationJson must contain a JSON object")
+
+        annotation_speaker = _normalize_space(annotation_payload.get("speaker"))
+        if annotation_speaker and annotation_speaker != speaker:
+            raise ChatToolValidationError(
+                "annotationJson speaker {0!r} does not match requested speaker {1!r}".format(annotation_speaker, speaker)
+            )
+
+        annotation_source_audio = _normalize_space(annotation_payload.get("source_audio"))
+        if annotation_source_audio and Path(annotation_source_audio).name != working_wav.name:
+            raise ChatToolValidationError(
+                "annotationJson source_audio points at a different WAV: {0}".format(annotation_source_audio)
+            )
+
+        concepts = self._extract_concepts_from_annotation(annotation_payload)
+        metadata = annotation_payload.get("metadata") if isinstance(annotation_payload.get("metadata"), dict) else {}
+        language_code = _normalize_space(metadata.get("language_code")) or "und"
+        project_id = _normalize_space(annotation_payload.get("project_id")) or "parse-project"
+        duration_sec = _coerce_float(annotation_payload.get("source_audio_duration_sec"), 0.0)
+
+        audio_dest = self.audio_dir / "working" / speaker / working_wav.name
+        annotation_dest = self.annotations_dir / (speaker + ".json")
+        peaks_dest = self.peaks_dir / (speaker + ".json") if peaks_json else None
+        transcript_dest = (
+            self.project_root / "imports" / "legacy" / speaker / transcript_csv.name
+            if transcript_csv else None
+        )
+
+        plan: Dict[str, Any] = {
+            "speaker": speaker,
+            "workingWav": str(working_wav),
+            "annotationJson": str(annotation_json),
+            "peaksJson": str(peaks_json) if peaks_json else None,
+            "transcriptCsv": str(transcript_csv) if transcript_csv else None,
+            "audioDest": self._display_readable_path(audio_dest),
+            "annotationDest": self._display_readable_path(annotation_dest),
+            "peaksDest": self._display_readable_path(peaks_dest) if peaks_dest else None,
+            "transcriptDest": self._display_readable_path(transcript_dest) if transcript_dest else None,
+            "conceptCount": len(concepts),
+            "languageCode": language_code,
+            "projectId": project_id,
+            "wavSizeBytes": working_wav.stat().st_size,
+            "annotationSizeBytes": annotation_json.stat().st_size,
+            "peaksSizeBytes": peaks_json.stat().st_size if peaks_json else None,
+        }
+
+        if dry_run:
+            return {
+                "ok": True,
+                "dryRun": True,
+                "plan": plan,
+                "message": "Preview only. Run again with dryRun=false to copy processed artifacts and register the speaker.",
+            }
+
+        audio_dest.parent.mkdir(parents=True, exist_ok=True)
+        annotation_dest.parent.mkdir(parents=True, exist_ok=True)
+        if peaks_dest is not None:
+            peaks_dest.parent.mkdir(parents=True, exist_ok=True)
+        if transcript_dest is not None:
+            transcript_dest.parent.mkdir(parents=True, exist_ok=True)
+
+        shutil.copy2(working_wav, audio_dest)
+        if peaks_json is not None and peaks_dest is not None:
+            shutil.copy2(peaks_json, peaks_dest)
+        if transcript_csv is not None and transcript_dest is not None:
+            shutil.copy2(transcript_csv, transcript_dest)
+
+        annotation_out = copy.deepcopy(annotation_payload)
+        annotation_out["speaker"] = speaker
+        annotation_out["source_audio"] = self._display_readable_path(audio_dest)
+        annotation_dest.write_text(json.dumps(annotation_out, indent=2, ensure_ascii=False), encoding="utf-8")
+
+        concept_total = self._write_concepts_csv(concepts)
+        self._write_project_json_for_processed_import(speaker, project_id, language_code, concept_total)
+        self._write_source_index_for_processed_import(
+            speaker=speaker,
+            audio_rel=self._display_readable_path(audio_dest),
+            duration_sec=duration_sec,
+            file_size_bytes=audio_dest.stat().st_size,
+            peaks_rel=self._display_readable_path(peaks_dest) if peaks_dest else None,
+            transcript_csv_rel=self._display_readable_path(transcript_dest) if transcript_dest else None,
+        )
+
+        return {
+            "ok": True,
+            "dryRun": False,
+            "plan": plan,
+            "conceptCount": concept_total,
+            "message": "Speaker {0!r} imported from processed artifacts.".format(speaker),
+        }
 
     def _tool_onboard_speaker_import(self, args: Dict[str, Any]) -> Dict[str, Any]:
         speaker = self._normalize_speaker(args.get("speaker"))

--- a/python/ai/test_parse_memory_tool.py
+++ b/python/ai/test_parse_memory_tool.py
@@ -251,3 +251,259 @@ def test_onboard_speaker_flags_virtual_timeline_on_second_source(tmp_path) -> No
     assert second_result["plan"]["projectedSourceCount"] == 2
     assert second_result["plan"]["virtualTimelineRequired"] is True
     assert "virtual timeline" in second_result["plan"]["virtualTimelineNote"].lower()
+
+
+def test_import_processed_speaker_is_write_allowlisted() -> None:
+    assert "import_processed_speaker" in WRITE_ALLOWED_TOOL_NAMES
+
+
+def _write_test_wav(path: pathlib.Path) -> None:
+    import wave
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(b"\x00\x00" * 8000)
+
+
+def _write_processed_fixture(root: pathlib.Path, speaker: str = "Fail02") -> tuple[pathlib.Path, pathlib.Path, pathlib.Path]:
+    import json
+
+    wav = root / "Audio_Working" / speaker / "speaker.wav"
+    _write_test_wav(wav)
+
+    annotation = root / "annotations" / f"{speaker}.json"
+    annotation.parent.mkdir(parents=True, exist_ok=True)
+    annotation.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "project_id": "southern-kurdish-dialect-comparison",
+                "speaker": speaker,
+                "source_audio": f"audio/working/{speaker}/speaker.wav",
+                "source_audio_duration_sec": 2.0,
+                "metadata": {"language_code": "sdh", "timestamps_source": "processed"},
+                "tiers": {
+                    "ipa": {"display_order": 1, "intervals": [{"start": 0.0, "end": 1.0, "text": "a"}, {"start": 1.0, "end": 2.0, "text": "b"}]},
+                    "ortho": {"display_order": 2, "intervals": [{"start": 0.0, "end": 1.0, "text": "ash"}, {"start": 1.0, "end": 2.0, "text": "bark"}]},
+                    "concept": {"display_order": 3, "intervals": [{"start": 0.0, "end": 1.0, "text": "1: ash"}, {"start": 1.0, "end": 2.0, "text": "2: bark"}]},
+                    "speaker": {"display_order": 4, "intervals": [{"start": 0.0, "end": 1.0, "text": speaker}, {"start": 1.0, "end": 2.0, "text": speaker}]},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    peaks = root / "peaks" / f"{speaker}.json"
+    peaks.parent.mkdir(parents=True, exist_ok=True)
+    peaks.write_text(json.dumps({"duration": 2.0, "peaks": [0, 1, 0, -1]}), encoding="utf-8")
+    return wav, annotation, peaks
+
+
+def test_import_processed_speaker_dry_run_reports_plan(tmp_path) -> None:
+    external_root = tmp_path / "Thesis"
+    wav, annotation, peaks = _write_processed_fixture(external_root)
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+
+    tools = ParseChatTools(project_root=project_root, external_read_roots=[external_root])
+    result = tools.execute(
+        "import_processed_speaker",
+        {
+            "speaker": "Fail02",
+            "workingWav": str(wav),
+            "annotationJson": str(annotation),
+            "peaksJson": str(peaks),
+            "dryRun": True,
+        },
+    )["result"]
+
+    assert result["ok"] is True
+    assert result["plan"]["speaker"] == "Fail02"
+    assert result["plan"]["conceptCount"] == 2
+    assert result["plan"]["audioDest"].endswith("audio/working/Fail02/speaker.wav")
+    assert result["plan"]["annotationDest"].endswith("annotations/Fail02.json")
+    assert result["plan"]["peaksDest"].endswith("peaks/Fail02.json")
+    assert result["plan"]["languageCode"] == "sdh"
+
+
+def test_import_processed_speaker_write_copies_assets_and_builds_workspace_files(tmp_path) -> None:
+    import csv
+    import json
+
+    external_root = tmp_path / "Thesis"
+    wav, annotation, peaks = _write_processed_fixture(external_root)
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+
+    tools = ParseChatTools(project_root=project_root, external_read_roots=[external_root])
+    result = tools.execute(
+        "import_processed_speaker",
+        {
+            "speaker": "Fail02",
+            "workingWav": str(wav),
+            "annotationJson": str(annotation),
+            "peaksJson": str(peaks),
+            "dryRun": False,
+        },
+    )["result"]
+
+    assert result["ok"] is True
+    assert (project_root / "audio" / "working" / "Fail02" / "speaker.wav").is_file()
+    assert (project_root / "annotations" / "Fail02.json").is_file()
+    assert (project_root / "peaks" / "Fail02.json").is_file()
+
+    source_index = json.loads((project_root / "source_index.json").read_text(encoding="utf-8"))
+    assert source_index["speakers"]["Fail02"]["source_wavs"][0]["path"] == "audio/working/Fail02/speaker.wav"
+    assert source_index["speakers"]["Fail02"]["peaks_file"] == "peaks/Fail02.json"
+
+    project_json = json.loads((project_root / "project.json").read_text(encoding="utf-8"))
+    assert "Fail02" in project_json["speakers"]
+    assert project_json["language"]["code"] == "sdh"
+
+    with open(project_root / "concepts.csv", newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows == [
+        {"id": "1", "concept_en": "ash"},
+        {"id": "2", "concept_en": "bark"},
+    ]
+
+    imported_annotation = json.loads((project_root / "annotations" / "Fail02.json").read_text(encoding="utf-8"))
+    assert imported_annotation["source_audio"] == "audio/working/Fail02/speaker.wav"
+
+
+def test_import_processed_speaker_assigns_fallback_ids_without_collisions(tmp_path) -> None:
+    import csv
+    import json
+
+    external_root = tmp_path / "Thesis"
+    wav, annotation, peaks = _write_processed_fixture(external_root)
+    payload = json.loads(annotation.read_text(encoding="utf-8"))
+    payload["tiers"]["concept"]["intervals"] = [
+        {"start": 0.0, "end": 1.0, "text": "free concept"},
+        {"start": 1.0, "end": 2.0, "text": "1: ash"},
+        {"start": 2.0, "end": 3.0, "text": "another free concept"},
+    ]
+    annotation.write_text(json.dumps(payload), encoding="utf-8")
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    tools = ParseChatTools(project_root=project_root, external_read_roots=[external_root])
+
+    result = tools.execute(
+        "import_processed_speaker",
+        {
+            "speaker": "Fail02",
+            "workingWav": str(wav),
+            "annotationJson": str(annotation),
+            "peaksJson": str(peaks),
+            "dryRun": False,
+        },
+    )["result"]
+
+    assert result["ok"] is True
+    with open(project_root / "concepts.csv", newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows == [
+        {"id": "1", "concept_en": "ash"},
+        {"id": "2", "concept_en": "free concept"},
+        {"id": "3", "concept_en": "another free concept"},
+    ]
+
+
+def test_import_processed_speaker_preserves_existing_concepts_when_free_text_lacks_ids(tmp_path) -> None:
+    import csv
+    import json
+
+    external_root = tmp_path / "Thesis"
+    wav, annotation, peaks = _write_processed_fixture(external_root)
+    payload = json.loads(annotation.read_text(encoding="utf-8"))
+    payload["tiers"]["concept"]["intervals"] = [
+        {"start": 0.0, "end": 1.0, "text": "ash"},
+        {"start": 1.0, "end": 2.0, "text": "bark"},
+    ]
+    annotation.write_text(json.dumps(payload), encoding="utf-8")
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    with open(project_root / "concepts.csv", "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["id", "concept_en"])
+        writer.writeheader()
+        writer.writerow({"id": "1", "concept_en": "water"})
+
+    tools = ParseChatTools(project_root=project_root, external_read_roots=[external_root])
+    result = tools.execute(
+        "import_processed_speaker",
+        {
+            "speaker": "Fail02",
+            "workingWav": str(wav),
+            "annotationJson": str(annotation),
+            "peaksJson": str(peaks),
+            "dryRun": False,
+        },
+    )["result"]
+
+    assert result["ok"] is True
+    with open(project_root / "concepts.csv", newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows == [
+        {"id": "1", "concept_en": "water"},
+        {"id": "2", "concept_en": "ash"},
+        {"id": "3", "concept_en": "bark"},
+    ]
+
+
+def test_import_processed_speaker_preserves_existing_sources_and_clears_stale_optional_metadata(tmp_path) -> None:
+    import json
+
+    external_root = tmp_path / "Thesis"
+    wav, annotation, _ = _write_processed_fixture(external_root)
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / "source_index.json").write_text(
+        json.dumps(
+            {
+                "speakers": {
+                    "Fail02": {
+                        "source_wavs": [
+                            {
+                                "filename": "speaker.wav",
+                                "path": "audio/original/Fail02/speaker.wav",
+                                "is_primary": True,
+                            }
+                        ],
+                        "peaks_file": "peaks/stale.json",
+                        "legacy_transcript_csv": "imports/legacy/Fail02/stale.csv",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tools = ParseChatTools(project_root=project_root, external_read_roots=[external_root])
+    result = tools.execute(
+        "import_processed_speaker",
+        {
+            "speaker": "Fail02",
+            "workingWav": str(wav),
+            "annotationJson": str(annotation),
+            "dryRun": False,
+        },
+    )["result"]
+
+    assert result["ok"] is True
+    source_index = json.loads((project_root / "source_index.json").read_text(encoding="utf-8"))
+    source_paths = [entry["path"] for entry in source_index["speakers"]["Fail02"]["source_wavs"]]
+    primary_paths = [
+        entry["path"]
+        for entry in source_index["speakers"]["Fail02"]["source_wavs"]
+        if entry.get("is_primary") is True
+    ]
+    assert "audio/original/Fail02/speaker.wav" in source_paths
+    assert "audio/working/Fail02/speaker.wav" in source_paths
+    assert primary_paths == ["audio/working/Fail02/speaker.wav"]
+    assert "peaks_file" not in source_index["speakers"]["Fail02"]
+    assert "legacy_transcript_csv" not in source_index["speakers"]["Fail02"]

--- a/python/server.py
+++ b/python/server.py
@@ -633,6 +633,63 @@ def _annotation_source_duration(speaker: str, source_wav: str) -> Optional[float
     return duration
 
 
+def _workspace_frontend_config(base_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    config = copy.deepcopy(base_config) if isinstance(base_config, dict) else {}
+
+    project_payload = _read_json_file(_project_json_path(), {})
+    if not isinstance(project_payload, dict):
+        project_payload = {}
+    source_index_payload = _read_json_file(_source_index_path(), {})
+    if not isinstance(source_index_payload, dict):
+        source_index_payload = {}
+
+    speakers: List[str] = []
+    speakers_value = project_payload.get("speakers")
+    if isinstance(speakers_value, dict):
+        speakers.extend(str(key).strip() for key in speakers_value.keys() if str(key).strip())
+    elif isinstance(speakers_value, list):
+        speakers.extend(str(item).strip() for item in speakers_value if str(item).strip())
+
+    source_speakers = source_index_payload.get("speakers")
+    if isinstance(source_speakers, dict):
+        speakers.extend(str(key).strip() for key in source_speakers.keys() if str(key).strip())
+    speakers = sorted(dict.fromkeys(speakers))
+
+    concepts_path = _project_root() / "concepts.csv"
+    concepts: list = []
+    if concepts_path.exists():
+        import csv as _csv
+        with open(concepts_path, newline="", encoding="utf-8") as f:
+            reader = _csv.DictReader(f)
+            for row in reader:
+                cid = str(row.get("id") or "").strip()
+                label = str(row.get("concept_en") or "").strip()
+                if cid and label:
+                    concepts.append({"id": cid, "label": label})
+
+    language_block = project_payload.get("language") if isinstance(project_payload.get("language"), dict) else {}
+    language_code = str(
+        project_payload.get("language_code")
+        or language_block.get("code")
+        or config.get("language_code")
+        or "und"
+    ).strip() or "und"
+    project_name = str(
+        project_payload.get("project_name")
+        or project_payload.get("name")
+        or config.get("project_name")
+        or "PARSE"
+    ).strip() or "PARSE"
+
+    config["project_name"] = project_name
+    config["language_code"] = language_code
+    config["speakers"] = speakers
+    config["concepts"] = concepts
+    config["audio_dir"] = str(project_payload.get("audio_dir") or config.get("audio_dir") or "audio")
+    config["annotations_dir"] = str(project_payload.get("annotations_dir") or config.get("annotations_dir") or "annotations")
+    return config
+
+
 def _annotation_empty_tier(display_order: int) -> Dict[str, Any]:
     return {
         "type": "interval",
@@ -3092,22 +3149,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
     # ── Config endpoints ─────────────────────────────────────────
 
     def _api_get_config(self) -> None:
-        config = load_ai_config(_config_path())
-
-        # Inject concepts from concepts.csv
-        concepts_path = _project_root() / "concepts.csv"
-        concepts: list = []
-        if concepts_path.exists():
-            import csv as _csv
-            with open(concepts_path, newline="", encoding="utf-8") as f:
-                reader = _csv.DictReader(f)
-                for row in reader:
-                    cid = str(row.get("id") or "").strip()
-                    label = str(row.get("concept_en") or "").strip()
-                    if cid and label:
-                        concepts.append({"id": cid, "label": label})
-        config["concepts"] = concepts
-
+        config = _workspace_frontend_config(load_ai_config(_config_path()))
         self._send_json(HTTPStatus.OK, {"config": config})
 
     def _api_get_export_lingpy(self) -> None:

--- a/python/test_server_workspace_config.py
+++ b/python/test_server_workspace_config.py
@@ -1,0 +1,45 @@
+import csv
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+def test_workspace_frontend_config_merges_project_speakers_and_concepts(tmp_path, monkeypatch) -> None:
+    project = tmp_path
+    (project / "project.json").write_text(
+        json.dumps(
+            {
+                "project_id": "southern-kurdish-dialect-comparison",
+                "name": "Southern Kurdish Dialect Comparison",
+                "language": {"code": "sdh"},
+                "speakers": {"Fail02": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / "source_index.json").write_text(
+        json.dumps({"speakers": {"Fail02": {}, "Kalh01": {}}}),
+        encoding="utf-8",
+    )
+    with open(project / "concepts.csv", "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["id", "concept_en"])
+        writer.writeheader()
+        writer.writerow({"id": "1", "concept_en": "ash"})
+        writer.writerow({"id": "2", "concept_en": "bark"})
+
+    monkeypatch.setattr(server, "_project_root", lambda: project)
+
+    result = server._workspace_frontend_config({"chat": {"enabled": True}})
+
+    assert result["project_name"] == "Southern Kurdish Dialect Comparison"
+    assert result["language_code"] == "sdh"
+    assert result["speakers"] == ["Fail02", "Kalh01"]
+    assert result["audio_dir"] == "audio"
+    assert result["annotations_dir"] == "annotations"
+    assert result["concepts"] == [
+        {"id": "1", "label": "ash"},
+        {"id": "2", "label": "bark"},
+    ]


### PR DESCRIPTION
## Summary
- add a new `import_processed_speaker` ParseChatTools write tool for timestamp-aligned processed artifacts
- expose the tool through the PARSE MCP adapter and keep adapter/chat-tool registrations in sync
- teach `/api/config` to merge workspace speakers/concepts from `project.json`, `source_index.json`, and `concepts.csv`
- add regression coverage for processed import dry-run/write behavior, concept ID safety, source preservation, and config exposure
- keep large WAV MCP onboarding timeout scaling in place for the raw-upload path

## Why
PARSE speaker import should not require rerunning the raw onboarding pipeline when a speaker already has:
- a working WAV
- timestamp-aligned annotation JSON
- optional peaks / legacy transcript artifacts

This PR adds a safe, explicit processed-artifact import path for that case and makes the resulting workspace visible to the current React frontend via `GET /api/config`.

## Test Plan
- `python3 -m pytest python/adapters/test_mcp_adapter.py python/ai/test_parse_memory_tool.py python/test_server_workspace_config.py -q`
- `npm run test -- --run`
- `./node_modules/.bin/tsc --noEmit`

## Notes
- The implementation preserves timestamp alignment by rewriting imported annotations to the copied workspace WAV path.
- Existing workspace concepts are preserved when imported concept intervals lack explicit numeric IDs.
- Existing source metadata is preserved, with the imported processed WAV becoming the sole primary source for that speaker.
