### PR TITLE
fix(onboard): populate project.json + concepts.csv on speaker onboard

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -1897,6 +1897,78 @@ def _run_stt_job(job_id: str, speaker: str, source_wav: str, language: Optional[
         _set_job_error(job_id, str(exc))
 
 
+def _parse_concepts_csv(csv_path: pathlib.Path) -> List[Dict[str, str]]:
+    """Parse a concepts-style CSV (id, concept_en). Returns [] if columns don't match."""
+    import csv as _csv
+
+    try:
+        with open(csv_path, newline="", encoding="utf-8-sig") as handle:
+            reader = _csv.DictReader(handle)
+            fieldnames = [str(name or "").strip().lower() for name in (reader.fieldnames or [])]
+            if "id" not in fieldnames or "concept_en" not in fieldnames:
+                return []
+            concepts: List[Dict[str, str]] = []
+            for row in reader:
+                cid = _normalize_concept_id(row.get("id"))
+                label = str(row.get("concept_en") or "").strip()
+                if cid and label:
+                    concepts.append({"id": cid, "label": label})
+            return concepts
+    except (OSError, UnicodeDecodeError, _csv.Error):
+        return []
+
+
+def _merge_concepts_into_root_csv(new_concepts: List[Dict[str, str]]) -> int:
+    """Merge new concepts into root concepts.csv. Existing rows win on id collision. Returns total."""
+    import csv as _csv
+
+    concepts_path = _project_root() / "concepts.csv"
+    merged: Dict[str, str] = {}
+    if concepts_path.exists():
+        try:
+            with open(concepts_path, newline="", encoding="utf-8") as handle:
+                reader = _csv.DictReader(handle)
+                for row in reader:
+                    cid = _normalize_concept_id(row.get("id"))
+                    label = str(row.get("concept_en") or "").strip()
+                    if cid and label:
+                        merged[cid] = label
+        except (OSError, _csv.Error):
+            pass
+
+    for item in new_concepts:
+        cid = _normalize_concept_id(item.get("id"))
+        label = str(item.get("label") or "").strip()
+        if cid and label and cid not in merged:
+            merged[cid] = label
+
+    ordered = sorted(merged.items(), key=lambda kv: _concept_sort_key(kv[0]))
+    concepts_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(concepts_path, "w", newline="", encoding="utf-8") as handle:
+        writer = _csv.DictWriter(handle, fieldnames=["id", "concept_en"])
+        writer.writeheader()
+        for cid, label in ordered:
+            writer.writerow({"id": cid, "concept_en": label})
+    return len(ordered)
+
+
+def _register_speaker_in_project_json(speaker: str) -> None:
+    """Add speaker to project.json speakers block. Preserves existing keys."""
+    project = _read_json_file(_project_json_path(), {})
+    if not isinstance(project, dict):
+        project = {}
+
+    speakers_block = project.get("speakers")
+    if isinstance(speakers_block, list):
+        speakers_block = {str(item).strip(): {} for item in speakers_block if str(item).strip()}
+    elif not isinstance(speakers_block, dict):
+        speakers_block = {}
+    speakers_block.setdefault(speaker, {})
+    project["speakers"] = speakers_block
+
+    _write_json_file(_project_json_path(), project)
+
+
 def _run_onboard_speaker_job(
     job_id: str,
     speaker: str,
@@ -1916,7 +1988,7 @@ def _run_onboard_speaker_job(
         annotation_path = _annotation_record_path_for_speaker(speaker)
         _write_json_file(annotation_path, annotation)
 
-        _set_job_progress(job_id, 60.0, message="Updating source index")
+        _set_job_progress(job_id, 55.0, message="Updating source index")
 
         # Register in source_index.json
         source_index_path = _source_index_path()
@@ -1951,6 +2023,18 @@ def _run_onboard_speaker_job(
 
         _write_json_file(source_index_path, source_index)
 
+        _set_job_progress(job_id, 70.0, message="Registering speaker in project.json")
+        _register_speaker_in_project_json(speaker)
+
+        concept_total: Optional[int] = None
+        concepts_added = 0
+        if csv_dest is not None and csv_dest.exists():
+            _set_job_progress(job_id, 80.0, message="Merging concepts from CSV")
+            parsed = _parse_concepts_csv(csv_dest)
+            if parsed:
+                concepts_added = len(parsed)
+                concept_total = _merge_concepts_into_root_csv(parsed)
+
         _set_job_progress(job_id, 90.0, message="Finalizing")
 
         result: Dict[str, Any] = {
@@ -1958,6 +2042,8 @@ def _run_onboard_speaker_job(
             "wavPath": wav_relative,
             "csvPath": str(csv_dest.relative_to(_project_root())) if csv_dest else None,
             "annotationPath": str(annotation_path.relative_to(_project_root())),
+            "conceptsAdded": concepts_added,
+            "conceptTotal": concept_total,
         }
         _set_job_complete(job_id, result, message="Speaker onboarded")
     except Exception as exc:

--- a/python/test_server_onboard_speaker.py
+++ b/python/test_server_onboard_speaker.py
@@ -1,0 +1,127 @@
+"""Tests for _run_onboard_speaker_job concepts.csv / project.json updates."""
+import csv
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+def _make_wav(project_root: pathlib.Path, speaker: str, name: str = "source.wav") -> pathlib.Path:
+    wav_dir = project_root / "audio" / "original" / speaker
+    wav_dir.mkdir(parents=True, exist_ok=True)
+    wav_dest = wav_dir / name
+    wav_dest.write_bytes(b"RIFF0000WAVEfmt ")
+    return wav_dest
+
+
+def _write_concepts_csv(path: pathlib.Path, rows: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["id", "concept_en"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _stub_job(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_set_job_progress", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_set_job_complete", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_set_job_error", lambda *args, **kwargs: None)
+
+
+def test_onboard_populates_project_json_speakers(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _stub_job(monkeypatch)
+
+    wav_dest = _make_wav(tmp_path, "Fail02")
+    server._run_onboard_speaker_job("job-1", "Fail02", wav_dest, None)
+
+    project = json.loads((tmp_path / "project.json").read_text())
+    assert "speakers" in project
+    assert "Fail02" in project["speakers"]
+
+
+def test_onboard_merges_concepts_csv_when_format_matches(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _stub_job(monkeypatch)
+
+    wav_dest = _make_wav(tmp_path, "Fail02")
+    csv_dest = wav_dest.parent / "elicitation.csv"
+    _write_concepts_csv(
+        csv_dest,
+        [{"id": "1", "concept_en": "ash"}, {"id": "2", "concept_en": "bark"}],
+    )
+
+    server._run_onboard_speaker_job("job-2", "Fail02", wav_dest, csv_dest)
+
+    concepts_path = tmp_path / "concepts.csv"
+    assert concepts_path.exists()
+    with open(concepts_path, newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows == [
+        {"id": "1", "concept_en": "ash"},
+        {"id": "2", "concept_en": "bark"},
+    ]
+
+
+def test_onboard_preserves_existing_concepts_on_id_collision(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _stub_job(monkeypatch)
+
+    existing = tmp_path / "concepts.csv"
+    _write_concepts_csv(existing, [{"id": "1", "concept_en": "ash"}])
+
+    wav_dest = _make_wav(tmp_path, "Fail02")
+    csv_dest = wav_dest.parent / "elicitation.csv"
+    _write_concepts_csv(
+        csv_dest,
+        [
+            {"id": "1", "concept_en": "ASH-OVERWRITE"},
+            {"id": "3", "concept_en": "fire"},
+        ],
+    )
+
+    server._run_onboard_speaker_job("job-3", "Fail02", wav_dest, csv_dest)
+
+    with open(existing, newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    rows_by_id = {row["id"]: row["concept_en"] for row in rows}
+    assert rows_by_id == {"1": "ash", "3": "fire"}
+
+
+def test_onboard_ignores_csv_with_unexpected_columns(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _stub_job(monkeypatch)
+
+    wav_dest = _make_wav(tmp_path, "Fail02")
+    csv_dest = wav_dest.parent / "cues.csv"
+    csv_dest.write_text("Start,End,Label\n0.0,1.0,cue1\n", encoding="utf-8")
+
+    server._run_onboard_speaker_job("job-4", "Fail02", wav_dest, csv_dest)
+
+    assert not (tmp_path / "concepts.csv").exists()
+
+
+def test_onboard_is_idempotent_on_replay(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _stub_job(monkeypatch)
+
+    wav_dest = _make_wav(tmp_path, "Fail02")
+    csv_dest = wav_dest.parent / "elicitation.csv"
+    _write_concepts_csv(csv_dest, [{"id": "1", "concept_en": "ash"}])
+
+    server._run_onboard_speaker_job("job-5a", "Fail02", wav_dest, csv_dest)
+    server._run_onboard_speaker_job("job-5b", "Fail02", wav_dest, csv_dest)
+
+    with open(tmp_path / "concepts.csv", newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows == [{"id": "1", "concept_en": "ash"}]
+
+    project = json.loads((tmp_path / "project.json").read_text())
+    assert list(project["speakers"].keys()) == ["Fail02"]
+
+    source_index = json.loads((tmp_path / "source_index.json").read_text())
+    wav_entries = source_index["speakers"]["Fail02"]["source_wavs"]
+    assert len(wav_entries) == 1


### PR DESCRIPTION
## Summary
- HTTP `/api/onboard/speaker` job now registers the speaker in `project.json` and merges uploaded concept rows into project-root `concepts.csv`, so the compare UI sees non-empty concepts after onboarding.
- Existing concept rows win on id collision — re-uploads can't clobber curated labels.
- CSVs without `id,concept_en` columns (e.g. Audition cue lists) are left alone on the concepts path; the raw file is still staged under `audio/original/<speaker>/`.

## Context
Diagnosing a Windows-side report that loading **Fail02** produced `/api/config → speakers=["Fail02"], concepts=[]`. Root cause: `_run_onboard_speaker_job` scaffolded an empty annotation and updated `source_index.json`, but never touched `concepts.csv` or `project.json`. `_workspace_frontend_config` reads concepts exclusively from project-root `concepts.csv`, so the UI stayed empty.

(GPT's report cited failing tests in `python/test_server_onboard_speaker.py` and `src/tests/storePersistence.test.ts` — neither file existed on main before this PR. The underlying browser-repro bug is real; the test evidence was hallucinated. Added real coverage under the first path.)

## Test plan
- [x] `python3.12 -m pytest python/test_server_onboard_speaker.py python/test_server_workspace_config.py` — 6 passed
- [x] `python3.12 -m pytest python/ --ignore=python/compare` — no new failures vs. main (same 6 pre-existing failures in chat-job shape / text-preview / audio-info tests)
- [ ] On the PC: re-onboard Fail02 with the concepts CSV and verify `/api/config` returns non-empty concepts + compare UI renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)