### PR TITLE
fix(compare): load annotations for every selected speaker

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1382,6 +1382,14 @@ export function ParseUI() {
   const loadSpeaker = useAnnotationStore((s) => s.loadSpeaker);
   const loadEnrichments = useEnrichmentStore((s) => s.load);
 
+  useEffect(() => {
+    for (const speaker of selectedSpeakers) {
+      loadSpeaker(speaker).catch((err) => {
+        console.error('[ParseUI] loadSpeaker failed:', speaker, err);
+      });
+    }
+  }, [selectedSpeakers, loadSpeaker]);
+
   const reloadSpeakerAnnotation = async (speakerId: string | null) => {
     if (!speakerId) {
       return;


### PR DESCRIPTION
## Summary
- Compare view built speaker-form rows from `useAnnotationStore.records[speaker]`, but nothing ever called `loadSpeaker` in Compare mode — `useAnnotationSync` only loads the single `activeSpeaker` from `uiStore`, and `activeSpeaker` is never set in Compare.
- Result: every row rendered `//` and `0 utterances` even when `/api/annotations/<speaker>` had full tier data.
- Fix: add an effect in `ParseUI` that calls `loadSpeaker` for each `selectedSpeakers` entry. The store short-circuits when a record is already loaded and not dirty, so this is idempotent.

## Context
Hit while verifying a Fail02 import on the PC. Import wrote 131 intervals (ipa/ortho/concept/speaker) into `annotations/Fail02.parse.json`, `/api/annotations/Fail02` returned them correctly, but Compare showed empty IPA. Tracing the render path: `buildSpeakerForm(annotationRecords[speaker], …)` received `undefined` because the store was never populated. Verified the fix via live HMR against the PC backend — the Fail02 row now renders `/sauʃɔjakama/` / `1 utterance` for concept #1 and the A/B variants (e.g. `brother of husband (A)`) also populate correctly.

## Test plan
- [x] Live verify via Vite preview against the PC backend — Compare rows populate for all selected speakers
- [ ] Add a test that asserts Compare renders IPA when `/api/annotations/<speaker>` returns intervals and only `selectedSpeakers` (not `activeSpeaker`) is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)