### PR TITLE
feat(concepts): survey-item / custom-order sort modes + CSV import

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -664,8 +664,22 @@ def _workspace_frontend_config(base_config: Optional[Dict[str, Any]] = None) -> 
             for row in reader:
                 cid = str(row.get("id") or "").strip()
                 label = str(row.get("concept_en") or "").strip()
-                if cid and label:
-                    concepts.append({"id": cid, "label": label})
+                if not (cid and label):
+                    continue
+                entry: Dict[str, Any] = {"id": cid, "label": label}
+                survey_item = str(row.get("survey_item") or "").strip()
+                if survey_item:
+                    entry["survey_item"] = survey_item
+                custom_order_raw = str(row.get("custom_order") or "").strip()
+                if custom_order_raw:
+                    try:
+                        entry["custom_order"] = int(custom_order_raw)
+                    except ValueError:
+                        try:
+                            entry["custom_order"] = float(custom_order_raw)
+                        except ValueError:
+                            pass
+                concepts.append(entry)
 
     language_block = project_payload.get("language") if isinstance(project_payload.get("language"), dict) else {}
     language_code = str(
@@ -2591,6 +2605,10 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             self._api_post_tags_merge()
             return
 
+        if request_path == "/api/concepts/import":
+            self._api_post_concepts_import()
+            return
+
         parts = self._path_parts(request_path)
 
         if len(parts) == 3 and parts[0] == "api" and parts[1] == "annotations":
@@ -3310,6 +3328,149 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         merged = _deep_merge_dicts(current, body)
         _write_json_file(_config_path(), merged)
         self._send_json(HTTPStatus.OK, {"success": True, "config": merged})
+
+    def _api_post_concepts_import(self) -> None:
+        """Merge survey_item / custom_order from an uploaded CSV into concepts.csv.
+
+        Upload format (CSV with header):
+            - `id` or `concept_en` (at least one for matching)
+            - `survey_item` (optional string)
+            - `custom_order` (optional integer; blank/non-numeric clears the field)
+
+        Matching: `id` first, then case-insensitive `concept_en`.
+        Rows in the existing concepts.csv that aren't in the upload keep their
+        existing `survey_item` / `custom_order`. Pass `?mode=replace` to clear
+        those fields on non-matching rows instead.
+        """
+        import csv as _csv
+        content_type = self.headers.get("Content-Type", "")
+        if "multipart/form-data" not in content_type:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "Content-Type must be multipart/form-data")
+
+        raw_length = self.headers.get("Content-Length", "")
+        try:
+            content_length = int(raw_length)
+        except (ValueError, TypeError):
+            raise ApiError(HTTPStatus.BAD_REQUEST, "Content-Length header is required")
+        if content_length > ONBOARD_MAX_UPLOAD_BYTES:
+            raise ApiError(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Upload exceeds limit")
+
+        environ = {
+            "REQUEST_METHOD": "POST",
+            "CONTENT_TYPE": content_type,
+            "CONTENT_LENGTH": str(content_length),
+        }
+        form = cgi.FieldStorage(
+            fp=self.rfile, headers=self.headers, environ=environ, keep_blank_values=True,
+        )
+
+        csv_item = form["csv"] if "csv" in form else None
+        if csv_item is None or not getattr(csv_item, "filename", None):
+            raise ApiError(HTTPStatus.BAD_REQUEST, "csv file is required (field name: csv)")
+
+        try:
+            csv_text = csv_item.file.read().decode("utf-8-sig")
+        except UnicodeDecodeError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "csv must be UTF-8: {0}".format(exc))
+
+        mode_field = form.getfirst("mode", "") if "mode" in form else ""
+        replace_mode = str(mode_field or "").strip().lower() == "replace"
+
+        try:
+            reader = _csv.DictReader(io.StringIO(csv_text))
+            upload_rows = list(reader)
+        except _csv.Error as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "csv parse error: {0}".format(exc))
+
+        if not upload_rows:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "csv is empty")
+
+        fieldnames = [str(n or "").strip().lower() for n in (reader.fieldnames or [])]
+        if "id" not in fieldnames and "concept_en" not in fieldnames:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "csv must have an id or concept_en column")
+
+        # Load existing
+        concepts_path = _project_root() / "concepts.csv"
+        existing: List[Dict[str, str]] = []
+        if concepts_path.exists():
+            with open(concepts_path, newline="", encoding="utf-8") as f:
+                existing = list(_csv.DictReader(f))
+
+        by_id: Dict[str, int] = {}
+        by_label: Dict[str, int] = {}
+        for idx, row in enumerate(existing):
+            rid = _normalize_concept_id(row.get("id"))
+            lbl = str(row.get("concept_en") or "").strip().lower()
+            if rid:
+                by_id[rid] = idx
+            if lbl:
+                by_label[lbl] = idx
+
+        if replace_mode:
+            for row in existing:
+                row["survey_item"] = ""
+                row["custom_order"] = ""
+
+        matched = 0
+        added = 0
+        for up in upload_rows:
+            up_id = _normalize_concept_id(up.get("id"))
+            up_label = str(up.get("concept_en") or "").strip()
+            target_idx: Optional[int] = None
+            if up_id and up_id in by_id:
+                target_idx = by_id[up_id]
+            elif up_label and up_label.lower() in by_label:
+                target_idx = by_label[up_label.lower()]
+
+            survey_raw = str(up.get("survey_item") or "").strip() if "survey_item" in up else ""
+            custom_raw = str(up.get("custom_order") or "").strip() if "custom_order" in up else ""
+
+            if target_idx is None:
+                if not up_label:
+                    continue
+                if not up_id:
+                    # Auto-assign next numeric id so imports that only specify labels work.
+                    existing_ids = {_normalize_concept_id(r.get("id")) for r in existing}
+                    next_id = 1
+                    while str(next_id) in existing_ids:
+                        next_id += 1
+                    up_id = str(next_id)
+                row = {
+                    "id": up_id,
+                    "concept_en": up_label,
+                    "survey_item": survey_raw,
+                    "custom_order": custom_raw,
+                }
+                existing.append(row)
+                by_id[up_id] = len(existing) - 1
+                by_label[up_label.lower()] = len(existing) - 1
+                added += 1
+            else:
+                row = existing[target_idx]
+                if survey_raw:
+                    row["survey_item"] = survey_raw
+                if custom_raw:
+                    row["custom_order"] = custom_raw
+                matched += 1
+
+        fieldnames_out = ["id", "concept_en", "survey_item", "custom_order"]
+        concepts_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(concepts_path, "w", newline="", encoding="utf-8") as f:
+            writer = _csv.DictWriter(f, fieldnames=fieldnames_out)
+            writer.writeheader()
+            for row in existing:
+                writer.writerow({k: row.get(k, "") or "" for k in fieldnames_out})
+
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "ok": True,
+                "matched": matched,
+                "added": added,
+                "total": len(existing),
+                "mode": "replace" if replace_mode else "merge",
+            },
+        )
 
     def _parse_single_range(self, range_header: str, file_size: int) -> Tuple[int, int]:
         unit, _, ranges_spec = range_header.partition("=")

--- a/python/test_server_concepts_import.py
+++ b/python/test_server_concepts_import.py
@@ -1,0 +1,186 @@
+"""Tests for POST /api/concepts/import endpoint (merge vs replace)."""
+import csv
+import email
+import email.parser
+import email.policy
+import io
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+class _FakeWfile:
+    def __init__(self) -> None:
+        self.chunks: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.chunks.append(data)
+
+    def flush(self) -> None:
+        pass
+
+    def payload(self) -> dict:
+        raw = b"".join(self.chunks).decode("utf-8")
+        body = raw.split("\r\n\r\n", 1)[-1]
+        return json.loads(body)
+
+
+class _FakeRequest:
+    def __init__(self, body: bytes, headers: dict) -> None:
+        self.rfile = io.BytesIO(body)
+        self.wfile = _FakeWfile()
+        self._headers = headers
+        self.status: int | None = None
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, k, v):
+        pass
+
+    def end_headers(self):
+        pass
+
+
+def _make_multipart(csv_body: str, mode: str = "") -> tuple[bytes, str]:
+    boundary = "----parseboundary"
+    parts = [
+        f"--{boundary}\r\n".encode(),
+        b'Content-Disposition: form-data; name="csv"; filename="concepts.csv"\r\n',
+        b"Content-Type: text/csv\r\n\r\n",
+        csv_body.encode("utf-8"),
+        b"\r\n",
+    ]
+    if mode:
+        parts += [
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="mode"\r\n\r\n',
+            mode.encode(),
+            b"\r\n",
+        ]
+    parts.append(f"--{boundary}--\r\n".encode())
+    body = b"".join(parts)
+    return body, boundary
+
+
+def _invoke(tmp_path, monkeypatch, existing_rows, upload_csv, mode=""):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    concepts_path = tmp_path / "concepts.csv"
+    if existing_rows is not None:
+        with open(concepts_path, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=["id", "concept_en", "survey_item", "custom_order"])
+            w.writeheader()
+            for row in existing_rows:
+                w.writerow({k: row.get(k, "") for k in w.fieldnames})
+
+    body, boundary = _make_multipart(upload_csv, mode=mode)
+    # cgi.FieldStorage expects an email.message.Message-like headers object
+    hdr_text = (
+        f"Content-Type: multipart/form-data; boundary={boundary}\r\n"
+        f"Content-Length: {len(body)}\r\n\r\n"
+    )
+    headers = email.parser.Parser(policy=email.policy.compat32).parsestr(hdr_text)
+    req = _FakeRequest(body, headers)
+
+    class H(server.RangeRequestHandler):
+        def __init__(self):
+            self.rfile = req.rfile
+            self.wfile = req.wfile
+            self.headers = headers
+
+        def send_response(self, code):
+            req.status = code
+
+        def send_header(self, *a, **kw):
+            pass
+
+        def end_headers(self):
+            pass
+
+    handler = H()
+    handler._api_post_concepts_import()
+
+    result = req.wfile.payload()
+
+    with open(concepts_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    return result, rows
+
+
+def test_import_merges_survey_and_custom_order(tmp_path, monkeypatch):
+    existing = [
+        {"id": "1", "concept_en": "hair", "survey_item": "", "custom_order": ""},
+        {"id": "2", "concept_en": "forehead", "survey_item": "", "custom_order": ""},
+        {"id": "3", "concept_en": "eyelid", "survey_item": "", "custom_order": ""},
+    ]
+    upload = "id,concept_en,survey_item,custom_order\n1,hair,1.1,10\n2,forehead,1.2,20\n"
+    result, rows = _invoke(tmp_path, monkeypatch, existing, upload)
+
+    assert result["ok"] is True
+    assert result["matched"] == 2
+    assert result["added"] == 0
+    rows_by_id = {r["id"]: r for r in rows}
+    assert rows_by_id["1"]["survey_item"] == "1.1"
+    assert rows_by_id["1"]["custom_order"] == "10"
+    assert rows_by_id["2"]["survey_item"] == "1.2"
+    assert rows_by_id["3"]["survey_item"] == ""  # unchanged
+
+
+def test_import_matches_by_label_when_id_missing(tmp_path, monkeypatch):
+    existing = [{"id": "1", "concept_en": "hair", "survey_item": "", "custom_order": ""}]
+    upload = "concept_en,custom_order\nhair,5\n"
+    result, rows = _invoke(tmp_path, monkeypatch, existing, upload)
+
+    assert result["matched"] == 1
+    assert rows[0]["custom_order"] == "5"
+
+
+def test_import_adds_new_concepts(tmp_path, monkeypatch):
+    existing = [{"id": "1", "concept_en": "hair", "survey_item": "", "custom_order": ""}]
+    upload = "id,concept_en,survey_item\n99,sky,3.1\n"
+    result, rows = _invoke(tmp_path, monkeypatch, existing, upload)
+
+    assert result["matched"] == 0
+    assert result["added"] == 1
+    ids = [r["id"] for r in rows]
+    assert ids == ["1", "99"]
+    assert rows[1]["survey_item"] == "3.1"
+
+
+def test_import_replace_mode_clears_unmatched(tmp_path, monkeypatch):
+    existing = [
+        {"id": "1", "concept_en": "hair", "survey_item": "1.1", "custom_order": "10"},
+        {"id": "2", "concept_en": "forehead", "survey_item": "1.2", "custom_order": "20"},
+    ]
+    upload = "id,concept_en,custom_order\n1,hair,1\n"
+    result, rows = _invoke(tmp_path, monkeypatch, existing, upload, mode="replace")
+
+    assert result["mode"] == "replace"
+    rows_by_id = {r["id"]: r for r in rows}
+    assert rows_by_id["1"]["custom_order"] == "1"
+    assert rows_by_id["2"]["custom_order"] == ""
+    # Replace clears both fields on every existing row, then merges upload values.
+    # Upload didn't provide survey_item for row 1 → stays cleared.
+    assert rows_by_id["1"]["survey_item"] == ""
+    assert rows_by_id["2"]["survey_item"] == ""
+
+
+def test_workspace_config_surfaces_survey_and_custom_order(tmp_path, monkeypatch):
+    (tmp_path / "project.json").write_text("{}", encoding="utf-8")
+    with open(tmp_path / "concepts.csv", "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["id", "concept_en", "survey_item", "custom_order"])
+        w.writeheader()
+        w.writerow({"id": "1", "concept_en": "hair", "survey_item": "1.1", "custom_order": "10"})
+        w.writerow({"id": "2", "concept_en": "forehead", "survey_item": "", "custom_order": ""})
+
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    cfg = server._workspace_frontend_config({})
+    concepts = cfg["concepts"]
+    assert concepts[0]["id"] == "1"
+    assert concepts[0]["survey_item"] == "1.1"
+    assert concepts[0]["custom_order"] == 10
+    assert "survey_item" not in concepts[1]
+    assert "custom_order" not in concepts[1]

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -12,7 +12,7 @@ import {
   Sun, Moon, XCircle
 } from 'lucide-react';
 import type { AnnotationInterval, AnnotationRecord, Tag as StoreTag } from './api/types';
-import { getLingPyExport, saveApiKey, getAuthStatus, pollAuth, startAuthFlow, startSTT, startCompute, startNormalize, pollSTT, pollNormalize, pollCompute } from './api/client';
+import { getLingPyExport, saveApiKey, getAuthStatus, pollAuth, startAuthFlow, startSTT, startCompute, startNormalize, pollSTT, pollNormalize, pollCompute, importConceptsCsv } from './api/client';
 import { useChatSession, type UseChatSessionResult } from './hooks/useChatSession';
 import { useSpectrogram } from './hooks/useSpectrogram';
 import { useWaveSurfer } from './hooks/useWaveSurfer';
@@ -44,7 +44,11 @@ interface Concept {
   key: string;
   name: string;
   tag: ConceptTag;
+  surveyItem?: string;
+  customOrder?: number;
 }
+
+type ConceptSortMode = 'az' | '1n' | 'survey' | 'custom';
 
 interface SpeakerForm {
   speaker: string; ipa: string; utterances: number;
@@ -1356,7 +1360,10 @@ export function ParseUI() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [query, setQuery] = useState('');
-  const [sortMode, setSortMode] = useState<'az'|'1n'>('1n');
+  const [sortMode, setSortMode] = useState<ConceptSortMode>('1n');
+  const [conceptImportError, setConceptImportError] = useState<string | null>(null);
+  const [conceptImportSummary, setConceptImportSummary] = useState<string | null>(null);
+  const conceptImportInputRef = useRef<HTMLInputElement>(null);
   const [tagFilter, setTagFilter] = useState<TagState>('all');
   const [conceptId, setConceptId] = useState(1);
   const [modeTab, setModeTab] = useState<ModeTab>('all');
@@ -1511,6 +1518,8 @@ export function ParseUI() {
       key: c.id,
       name: c.label,
       tag: getConceptStatus(getTagsForConcept(c.id)),
+      surveyItem: c.survey_item,
+      customOrder: c.custom_order,
     }));
   }, [rawConcepts, getTagsForConcept]);
 
@@ -1567,10 +1576,47 @@ export function ParseUI() {
     if (currentMode === 'annotate') {
       // No synthetic filtering — show the full concept list
     }
-    if (sortMode === 'az') list = [...list].sort((a,b) => a.name.localeCompare(b.name));
-    else list = [...list].sort((a,b) => a.id - b.id);
+    if (sortMode === 'az') {
+      list = [...list].sort((a, b) => a.name.localeCompare(b.name));
+    } else if (sortMode === 'survey') {
+      list = [...list].sort((a, b) => {
+        const av = a.surveyItem ?? '';
+        const bv = b.surveyItem ?? '';
+        if (av && !bv) return -1;
+        if (!av && bv) return 1;
+        // Try numeric (section.item) comparison, fall back to lex
+        const na = av.split('.').map(n => parseFloat(n));
+        const nb = bv.split('.').map(n => parseFloat(n));
+        for (let i = 0; i < Math.max(na.length, nb.length); i++) {
+          const xa = na[i] ?? 0;
+          const xb = nb[i] ?? 0;
+          if (Number.isFinite(xa) && Number.isFinite(xb) && xa !== xb) return xa - xb;
+        }
+        return av.localeCompare(bv);
+      });
+    } else if (sortMode === 'custom') {
+      list = list.filter(c => typeof c.customOrder === 'number');
+      list = [...list].sort((a, b) => (a.customOrder ?? 0) - (b.customOrder ?? 0));
+    } else {
+      list = [...list].sort((a, b) => a.id - b.id);
+    }
     return list;
   }, [query, tagFilter, sortMode, modeTab, currentMode, selectedSpeakers, enrichmentData, concepts]);
+
+  const hasSurveyItems = useMemo(() => concepts.some(c => !!c.surveyItem), [concepts]);
+  const hasCustomOrders = useMemo(() => concepts.some(c => typeof c.customOrder === 'number'), [concepts]);
+
+  const handleConceptImport = async (file: File) => {
+    setConceptImportError(null);
+    setConceptImportSummary(null);
+    try {
+      const result = await importConceptsCsv(file, 'merge');
+      setConceptImportSummary(`Imported: matched ${result.matched}, added ${result.added}, total ${result.total}`);
+      await loadConfig();
+    } catch (err) {
+      setConceptImportError(err instanceof Error ? err.message : String(err));
+    }
+  };
 
   const concept = concepts.find(c => c.id === conceptId) ?? concepts[0] ?? { id: 1, key: '1', name: '—', tag: 'untagged' as ConceptTag };
   const referenceForms = useMemo(
@@ -1764,6 +1810,13 @@ export function ParseUI() {
                     </button>
                     <div className="my-1 border-t border-slate-100"/>
                     <button
+                      data-testid="concept-import-menu"
+                      onClick={() => { setActionsMenuOpen(false); conceptImportInputRef.current?.click(); }}
+                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50"
+                    >
+                      <Upload className="h-3.5 w-3.5 text-slate-400"/> Import Concepts CSV…
+                    </button>
+                    <button
                       onClick={() => { setActionsMenuOpen(false); loadDecisionsMenuRef.current?.click(); }}
                       className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50"
                     >
@@ -1789,6 +1842,24 @@ export function ParseUI() {
                     </button>
                   </div>
                 </>
+              )}
+              <input
+                ref={conceptImportInputRef}
+                data-testid="concept-import-input"
+                type="file"
+                accept=".csv,text/csv"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) void handleConceptImport(file);
+                  if (conceptImportInputRef.current) conceptImportInputRef.current.value = '';
+                }}
+              />
+              {conceptImportSummary && (
+                <div data-testid="concept-import-summary" className="absolute right-0 top-full z-[70] mt-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1 text-[10px] text-emerald-700 shadow-sm">{conceptImportSummary}</div>
+              )}
+              {conceptImportError && (
+                <div data-testid="concept-import-error" className="absolute right-0 top-full z-[70] mt-1 rounded-md border border-rose-200 bg-rose-50 px-2 py-1 text-[10px] text-rose-700 shadow-sm">{conceptImportError}</div>
               )}
             </div>
 
@@ -1864,23 +1935,42 @@ export function ParseUI() {
               <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Search concepts…"
                 className="w-full rounded-lg border border-slate-200 bg-slate-50/60 py-1.5 pl-8 pr-3 text-xs text-slate-700 placeholder:text-slate-400 focus:border-indigo-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-100"/>
             </div>
-            <div className="mt-3 flex items-center justify-between">
+            <div className="mt-3 flex flex-wrap items-center gap-1.5">
               <div className="inline-flex rounded-md bg-slate-100 p-0.5">
-                <button onClick={() => setSortMode('az')} className={`px-2 py-0.5 text-[10px] font-semibold rounded ${sortMode==='az'?'bg-white text-slate-800 shadow-sm':'text-slate-500'}`}>A→Z</button>
-                <button onClick={() => setSortMode('1n')} className={`px-2 py-0.5 text-[10px] font-semibold rounded ${sortMode==='1n'?'bg-white text-slate-800 shadow-sm':'text-slate-500'}`}>1→N</button>
+                <button data-testid="concept-sort-az" onClick={() => setSortMode('az')} title="Sort alphabetically by label" className={`px-2 py-0.5 text-[10px] font-semibold rounded ${sortMode==='az'?'bg-white text-slate-800 shadow-sm':'text-slate-500'}`}>A→Z</button>
+                <button data-testid="concept-sort-1n" onClick={() => setSortMode('1n')} title="Sort by concept id" className={`px-2 py-0.5 text-[10px] font-semibold rounded ${sortMode==='1n'?'bg-white text-slate-800 shadow-sm':'text-slate-500'}`}>1→N</button>
+                <button
+                  data-testid="concept-sort-survey"
+                  onClick={() => setSortMode('survey')}
+                  disabled={!hasSurveyItems}
+                  title={hasSurveyItems ? 'Sort by original survey item (section.item)' : 'No survey_item values present in concepts.csv'}
+                  className={`px-2 py-0.5 text-[10px] font-semibold rounded ${sortMode==='survey'?'bg-white text-slate-800 shadow-sm':'text-slate-500'} ${!hasSurveyItems ? 'cursor-not-allowed opacity-40' : ''}`}
+                >Survey</button>
+                <button
+                  data-testid="concept-sort-custom"
+                  onClick={() => setSortMode('custom')}
+                  disabled={!hasCustomOrders}
+                  title={hasCustomOrders ? 'Sort and filter by custom_order (imported list)' : 'Import a custom list to enable this view'}
+                  className={`px-2 py-0.5 text-[10px] font-semibold rounded ${sortMode==='custom'?'bg-white text-slate-800 shadow-sm':'text-slate-500'} ${!hasCustomOrders ? 'cursor-not-allowed opacity-40' : ''}`}
+                >Custom</button>
               </div>
-              <span className="text-[10px] text-slate-400">{filtered.length} concepts</span>
+              <span className="ml-auto text-[10px] text-slate-400">{filtered.length} concepts</span>
             </div>
           </div>
           <nav className="flex-1 overflow-y-auto px-2 pb-6">
             {filtered.map(c => {
               const active = c.id === conceptId;
+              const badge =
+                sortMode === 'survey' && c.surveyItem ? c.surveyItem :
+                sortMode === 'custom' && typeof c.customOrder === 'number' ? String(c.customOrder) :
+                String(c.id);
+              const badgePrefix = sortMode === 'survey' ? 'Q' : '#';
               return (
                 <button key={c.id} onClick={() => setConceptId(c.id)}
                   className={`group mb-0.5 flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left transition ${active ? 'bg-indigo-50 text-indigo-900' : 'text-slate-600 hover:bg-slate-50'}`}>
                   <span className={`h-1.5 w-1.5 rounded-full ${tagDot[c.tag]}`} />
                   <span className={`flex-1 text-[13px] ${active ? 'font-semibold' : 'font-medium'}`}>{c.name}</span>
-                  <span className={`font-mono text-[10px] ${active ? 'text-indigo-400' : 'text-slate-300'}`}>#{c.id}</span>
+                  <span className={`font-mono text-[10px] ${active ? 'text-indigo-400' : 'text-slate-300'}`}>{badgePrefix}{badge}</span>
                 </button>
               );
             })}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -140,6 +140,34 @@ export async function updateConfig(patch: Partial<ProjectConfig>): Promise<void>
   });
 }
 
+export interface ImportConceptsResult {
+  ok: boolean;
+  matched: number;
+  added: number;
+  total: number;
+  mode: "merge" | "replace";
+}
+
+export async function importConceptsCsv(
+  file: File,
+  mode: "merge" | "replace" = "merge",
+): Promise<ImportConceptsResult> {
+  const form = new FormData();
+  form.append("csv", file);
+  form.append("mode", mode);
+  let response: Response;
+  try {
+    response = await fetch("/api/concepts/import", { method: "POST", body: form });
+  } catch (error) {
+    throw networkError("/api/concepts/import", { method: "POST" }, error);
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`API POST /api/concepts/import failed ${response.status}: ${text}`);
+  }
+  return response.json() as Promise<ImportConceptsResult>;
+}
+
 // Auth
 export async function getAuthStatus(): Promise<AuthStatus> {
   return apiFetch<AuthStatus>("/api/auth/status");

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -25,6 +25,8 @@ export interface AnnotationRecord {
 export interface ConceptEntry {
   id: string;
   label: string;
+  survey_item?: string;
+  custom_order?: number;
 }
 
 export interface ProjectConfig {


### PR DESCRIPTION
## Summary
- Concept sidebar gains two extra sort modes alongside `A→Z` and `1→N`:
  - **Survey** — sort by `survey_item` (e.g. KLQ section.item like `1.1.A`). Badge shows `Q<survey>`. Disabled until `concepts.csv` has survey_item values.
  - **Custom** — sort and *filter* by `custom_order` from an imported sublist (e.g. Oxford 85-concept subset). Badge shows `#<customOrder>`. Disabled until custom_order is present.
- `concepts.csv` gets optional `survey_item` / `custom_order` columns (back-compat), surfaced via `/api/config` as `ConceptEntry.survey_item` / `.custom_order`.
- New `POST /api/concepts/import` endpoint takes a multipart CSV upload. Matching: `id` first, then case-insensitive `concept_en`. Missing `id` on new rows is auto-assigned. `mode=replace` clears both fields on every existing row before merging; default `merge` preserves untouched fields.
- Frontend `importConceptsCsv(file, mode)` client helper + **Import Concepts CSV…** entry in the header Actions menu (file picker, toast for status).

## Context
Request was to let the user view and sort by the original survey item number (KLQ section.item) and by a custom list imported from a CSV (e.g. Oxford 85-concept sheet ordering). This PR keeps the left sidebar clean — sort toggles stay there, the import affordance lives in Actions.

## Test plan
- [x] `python3.12 -m pytest python/test_server_concepts_import.py` — 5 passing (merge by id, merge by label, add new, replace mode, /api/config surfacing)
- [x] `npx tsc --noEmit` — clean
- [x] End-to-end against a local workspace: upload CSV with 3 matches + 1 new row → `{matched:3, added:1, total:4}`; concepts.csv rewritten correctly; `/api/config` returns `survey_item` / `custom_order` fields.
- [ ] Against live PC workspace: populate Fail02's 131 concepts with survey_item values and verify Survey sort renders Q-badges in KLQ order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)