### PR TITLE
ui: rename actions menu entry to "Import Custom Tags"

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1815,7 +1815,7 @@ export function ParseUI() {
                       onClick={() => { setActionsMenuOpen(false); conceptImportInputRef.current?.click(); }}
                       className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50"
                     >
-                      <Upload className="h-3.5 w-3.5 text-slate-400"/> Import Custom Concept List
+                      <Upload className="h-3.5 w-3.5 text-slate-400"/> Import Custom Tags
                     </button>
                     <button
                       onClick={() => { setActionsMenuOpen(false); loadDecisionsMenuRef.current?.click(); }}


### PR DESCRIPTION
## Summary
- Rename Actions menu entry `"Import Custom Concept List"` → `"Import Custom Tags"`.
- Clearer name now that the pathway is tag-based (PR #104): the CSV creates a tag with auto-assigned concepts.

## Test plan
- [x] Live verify in preview — Actions menu renders "Import Custom Tags".

🤖 Generated with [Claude Code](https://claude.com/claude-code)