### PR TITLE
feat(annotate): seek + edit lexeme timestamps in Annotate view

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1081,6 +1081,7 @@ interface AnnotateViewProps {
 const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConcepts, onPrev, onNext, audioUrl, peaksUrl }) => {
   const record = useAnnotationStore(s => s.records[speaker] ?? null);
   const setInterval = useAnnotationStore(s => s.setInterval);
+  const moveIntervalAcrossTiers = useAnnotationStore(s => s.moveIntervalAcrossTiers);
   const saveSpeaker = useAnnotationStore(s => s.saveSpeaker);
   const tagConcept = useTagStore(s => s.tagConcept);
 
@@ -1090,10 +1091,18 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
   );
   const [ipa, setIpa] = useState(ipaInterval?.text ?? '');
   const [ortho, setOrtho] = useState(orthoInterval?.text ?? '');
+  // Editable timestamp fields for the current lexeme (seeded from the concept tier interval).
+  const [editStart, setEditStart] = useState<string>(conceptInterval ? conceptInterval.start.toFixed(3) : '');
+  const [editEnd, setEditEnd] = useState<string>(conceptInterval ? conceptInterval.end.toFixed(3) : '');
+  const [timestampSaving, setTimestampSaving] = useState(false);
+  const [timestampMessage, setTimestampMessage] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
   useEffect(() => {
     setIpa(ipaInterval?.text ?? '');
     setOrtho(orthoInterval?.text ?? '');
-  }, [speaker, concept.key, ipaInterval, orthoInterval]);
+    setEditStart(conceptInterval ? conceptInterval.start.toFixed(3) : '');
+    setEditEnd(conceptInterval ? conceptInterval.end.toFixed(3) : '');
+    setTimestampMessage(null);
+  }, [speaker, concept.key, conceptInterval, ipaInterval, orthoInterval]);
 
   const [spectroOn, setSpectroOn] = useState(false);
   const [audioReady, setAudioReady] = useState(false);
@@ -1110,15 +1119,28 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
   const selectedRegion = usePlaybackStore(s => s.selectedRegion);
   const annotated = Boolean(conceptInterval && ipaInterval);
 
-  const { playPause, skip, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
+  const { playPause, seek, skip, addRegion, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
     containerRef,
     audioUrl,
     peaksUrl,
     onTimeUpdate: t => usePlaybackStore.setState({ currentTime: t }),
     onReady: d => { usePlaybackStore.setState({ duration: d }); setAudioReady(true); },
     onPlayStateChange: p => usePlaybackStore.setState({ isPlaying: p }),
-    onRegionUpdate: (start, end) => usePlaybackStore.setState({ selectedRegion: { start, end } }),
+    onRegionUpdate: (start, end) => {
+      usePlaybackStore.setState({ selectedRegion: { start, end } });
+      // Dragging/resizing the waveform region mirrors into the editable fields.
+      setEditStart(start.toFixed(3));
+      setEditEnd(end.toFixed(3));
+    },
   });
+
+  // When the user picks a concept (and once the waveform is ready), seek to its
+  // start and show the lexeme's range as a draggable region on the waveform.
+  useEffect(() => {
+    if (!audioReady || !conceptInterval) return;
+    seek(conceptInterval.start);
+    addRegion(conceptInterval.start, conceptInterval.end);
+  }, [audioReady, conceptInterval?.start, conceptInterval?.end, seek, addRegion]);
 
   useSpectrogram({ enabled: spectroOn && audioReady, wsRef, canvasRef: spectroCanvasRef });
 
@@ -1276,6 +1298,98 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
               dir="rtl"
               className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 font-serif text-xl text-slate-900 placeholder:text-slate-300 focus:border-indigo-300 focus:outline-none focus:ring-4 focus:ring-indigo-50"
             />
+          </div>
+
+          {/* Timestamp editor for the current lexeme */}
+          <div className="rounded-xl border border-slate-200 bg-white px-4 py-3">
+            <div className="mb-2 flex items-center justify-between">
+              <label className="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-500">Lexeme timestamp (seconds)</label>
+              {conceptInterval ? (
+                <span className="font-mono text-[10px] text-slate-400">{fmt(conceptInterval.start)}–{fmt(conceptInterval.end)}</span>
+              ) : (
+                <span className="font-mono text-[10px] text-slate-400">no interval</span>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] font-medium text-slate-500">Start</span>
+                <input
+                  data-testid="lexeme-start"
+                  type="number"
+                  step={0.001}
+                  min={0}
+                  value={editStart}
+                  onChange={e => setEditStart(e.target.value)}
+                  disabled={!conceptInterval}
+                  className="w-28 rounded-md border border-slate-200 bg-slate-50/70 px-2 py-1 font-mono text-xs text-slate-800 focus:border-indigo-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-100 disabled:opacity-50"
+                />
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] font-medium text-slate-500">End</span>
+                <input
+                  data-testid="lexeme-end"
+                  type="number"
+                  step={0.001}
+                  min={0}
+                  value={editEnd}
+                  onChange={e => setEditEnd(e.target.value)}
+                  disabled={!conceptInterval}
+                  className="w-28 rounded-md border border-slate-200 bg-slate-50/70 px-2 py-1 font-mono text-xs text-slate-800 focus:border-indigo-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-100 disabled:opacity-50"
+                />
+              </div>
+              <button
+                data-testid="lexeme-timestamp-save"
+                disabled={!conceptInterval || timestampSaving}
+                onClick={async () => {
+                  if (!conceptInterval) return;
+                  const ns = parseFloat(editStart);
+                  const ne = parseFloat(editEnd);
+                  if (!Number.isFinite(ns) || !Number.isFinite(ne) || ne <= ns) {
+                    setTimestampMessage({ kind: 'err', text: 'End must be greater than start.' });
+                    return;
+                  }
+                  setTimestampSaving(true);
+                  try {
+                    const moved = moveIntervalAcrossTiers(speaker, conceptInterval.start, conceptInterval.end, ns, ne);
+                    if (moved === 0) {
+                      setTimestampMessage({ kind: 'err', text: 'No matching intervals found to retime.' });
+                    } else {
+                      await saveSpeaker(speaker);
+                      setTimestampMessage({ kind: 'ok', text: `Retimed ${moved} tier${moved === 1 ? '' : 's'}.` });
+                      addRegion(ns, ne);
+                      seek(ns);
+                    }
+                  } catch (err) {
+                    setTimestampMessage({ kind: 'err', text: err instanceof Error ? err.message : String(err) });
+                  } finally {
+                    setTimestampSaving(false);
+                  }
+                }}
+                className="inline-flex items-center gap-1.5 rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 transition hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Save className="h-3.5 w-3.5"/> Save timestamp
+              </button>
+              <button
+                data-testid="lexeme-timestamp-reset"
+                disabled={!conceptInterval}
+                onClick={() => {
+                  if (!conceptInterval) return;
+                  setEditStart(conceptInterval.start.toFixed(3));
+                  setEditEnd(conceptInterval.end.toFixed(3));
+                  addRegion(conceptInterval.start, conceptInterval.end);
+                  seek(conceptInterval.start);
+                  setTimestampMessage(null);
+                }}
+                className="text-[11px] font-medium text-slate-500 underline-offset-2 hover:text-slate-800 hover:underline disabled:opacity-50"
+              >
+                Reset
+              </button>
+              {timestampMessage && (
+                <span data-testid="lexeme-timestamp-msg" className={`ml-auto text-[11px] ${timestampMessage.kind === 'ok' ? 'text-emerald-600' : 'text-rose-600'}`}>
+                  {timestampMessage.text}
+                </span>
+              )}
+            </div>
           </div>
 
           {/* Action buttons */}

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1119,7 +1119,17 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
   const selectedRegion = usePlaybackStore(s => s.selectedRegion);
   const annotated = Boolean(conceptInterval && ipaInterval);
 
-  const { playPause, seek, skip, addRegion, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
+  // Ref mirror of the currently stored concept interval. Used from the
+  // onRegionCommit closure (which is captured on WaveSurfer init) so it
+  // always sees the latest stored start/end when the user releases a drag.
+  const storedIntervalRef = useRef<{ start: number; end: number } | null>(null);
+  useEffect(() => {
+    storedIntervalRef.current = conceptInterval
+      ? { start: conceptInterval.start, end: conceptInterval.end }
+      : null;
+  }, [conceptInterval]);
+
+  const { playPause, seek, scrollToTimeAtFraction, skip, addRegion, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
     containerRef,
     audioUrl,
     peaksUrl,
@@ -1132,15 +1142,37 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
       setEditStart(start.toFixed(3));
       setEditEnd(end.toFixed(3));
     },
+    onRegionCommit: (start, end) => {
+      // Auto-save: when the user finishes dragging/resizing the region,
+      // retime the current lexeme across all tiers and persist to the
+      // annotation JSON. No Save button needed for region edits.
+      const prev = storedIntervalRef.current;
+      if (!prev) return;
+      if (Math.abs(prev.start - start) < 0.001 && Math.abs(prev.end - end) < 0.001) return;
+      if (end <= start) return;
+      const moved = moveIntervalAcrossTiers(speaker, prev.start, prev.end, start, end);
+      if (moved > 0) {
+        storedIntervalRef.current = { start, end };
+        setEditStart(start.toFixed(3));
+        setEditEnd(end.toFixed(3));
+        void saveSpeaker(speaker);
+        setTimestampMessage({ kind: 'ok', text: `Saved · ${moved} tier${moved === 1 ? '' : 's'}` });
+      }
+    },
   });
 
-  // When the user picks a concept (and once the waveform is ready), seek to its
-  // start and show the lexeme's range as a draggable region on the waveform.
+  // When the user picks a concept (and once the waveform is ready): zoom
+  // in to 400 px/s, seek to its start, draw the lexeme range as a draggable
+  // region, and scroll so the start sits at ~33% from the left of the
+  // viewport (leaves more of the trailing audio visible than centering).
   useEffect(() => {
     if (!audioReady || !conceptInterval) return;
+    wsSetZoom(400);
+    setZoom(400);
     seek(conceptInterval.start);
     addRegion(conceptInterval.start, conceptInterval.end);
-  }, [audioReady, conceptInterval?.start, conceptInterval?.end, seek, addRegion]);
+    scrollToTimeAtFraction(conceptInterval.start, 0.33);
+  }, [audioReady, conceptInterval?.start, conceptInterval?.end, seek, addRegion, wsSetZoom, scrollToTimeAtFraction]);
 
   useSpectrogram({ enabled: spectroOn && audioReady, wsRef, canvasRef: spectroCanvasRef });
 

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -74,6 +74,15 @@ function overlaps(a: AnnotationInterval, b: AnnotationInterval): boolean {
   return a.start <= b.end && b.start <= a.end;
 }
 
+// Build a workspace-relative audio URL from an annotation record. Server serves
+// static files from the project root, so "audio/working/X/foo.wav" → "/audio/working/X/foo.wav".
+function deriveAudioUrl(record: AnnotationRecord | null | undefined): string {
+  const raw = (record?.source_audio ?? record?.source_wav ?? '').trim();
+  if (!raw) return '';
+  const cleaned = raw.replace(/\\/g, '/').replace(/^\/+/, '');
+  return '/' + cleaned;
+}
+
 
 function conceptMatchesIntervalText(concept: Concept, text: string): boolean {
   const normalizedText = text.trim().toLowerCase();
@@ -2010,7 +2019,7 @@ export function ParseUI() {
               totalConcepts={total}
               onPrev={goPrev}
               onNext={goNext}
-              audioUrl={selectedSpeakers[0] ? `/audio/${selectedSpeakers[0]}.wav` : ''}
+              audioUrl={deriveAudioUrl(annotationRecords[selectedSpeakers[0] ?? ''])}
               peaksUrl={selectedSpeakers[0] ? `/peaks/${selectedSpeakers[0]}.json` : undefined}
             />
             <AIChat

--- a/src/__tests__/moveInterval.test.ts
+++ b/src/__tests__/moveInterval.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../api/client", () => ({
+  getConfig: vi.fn(),
+  getAnnotation: vi.fn(),
+  saveAnnotation: vi.fn(),
+  getEnrichments: vi.fn(),
+  saveEnrichments: vi.fn(),
+}));
+
+import { useAnnotationStore } from "../stores/annotationStore";
+
+function seedFail02() {
+  useAnnotationStore.setState({
+    records: {
+      Fail02: {
+        speaker: "Fail02",
+        tiers: {
+          ipa: {
+            name: "ipa", display_order: 1,
+            intervals: [{ start: 100, end: 101, text: "hɪr" }],
+          },
+          ortho: {
+            name: "ortho", display_order: 2,
+            intervals: [{ start: 100, end: 101, text: "هەر" }],
+          },
+          concept: {
+            name: "concept", display_order: 3,
+            intervals: [{ start: 100, end: 101, text: "hair" }],
+          },
+          speaker: {
+            name: "speaker", display_order: 4,
+            intervals: [{ start: 100, end: 101, text: "Fail02" }],
+          },
+        },
+        created_at: "2026-01-01T00:00:00Z",
+        modified_at: "2026-01-01T00:00:00Z",
+        source_wav: "x.wav",
+      },
+    },
+    dirty: {},
+    loading: {},
+  });
+}
+
+describe("annotationStore.moveIntervalAcrossTiers", () => {
+  beforeEach(() => {
+    useAnnotationStore.setState({ records: {}, dirty: {}, loading: {} });
+  });
+
+  it("retimes every tier that carries the matching (oldStart,oldEnd) interval and preserves text", () => {
+    seedFail02();
+    const moved = useAnnotationStore.getState().moveIntervalAcrossTiers(
+      "Fail02", 100, 101, 99.5, 101.2,
+    );
+    expect(moved).toBe(4);
+
+    const rec = useAnnotationStore.getState().records["Fail02"];
+    for (const tierName of ["ipa", "ortho", "concept", "speaker"]) {
+      const tier = rec.tiers[tierName];
+      expect(tier.intervals).toHaveLength(1);
+      expect(tier.intervals[0].start).toBeCloseTo(99.5);
+      expect(tier.intervals[0].end).toBeCloseTo(101.2);
+    }
+    expect(rec.tiers.ipa.intervals[0].text).toBe("hɪr");
+    expect(rec.tiers.concept.intervals[0].text).toBe("hair");
+    expect(useAnnotationStore.getState().dirty["Fail02"]).toBe(true);
+  });
+
+  it("returns 0 and leaves records untouched when no matching interval exists", () => {
+    seedFail02();
+    const moved = useAnnotationStore.getState().moveIntervalAcrossTiers(
+      "Fail02", 999, 1000, 1, 2,
+    );
+    expect(moved).toBe(0);
+    const rec = useAnnotationStore.getState().records["Fail02"];
+    expect(rec.tiers.ipa.intervals[0].start).toBe(100);
+    expect(useAnnotationStore.getState().dirty["Fail02"]).toBeFalsy();
+  });
+
+  it("rejects invalid end <= start and non-finite inputs", () => {
+    seedFail02();
+    expect(
+      useAnnotationStore.getState().moveIntervalAcrossTiers("Fail02", 100, 101, 5, 2),
+    ).toBe(0);
+    expect(
+      useAnnotationStore.getState().moveIntervalAcrossTiers("Fail02", 100, 101, NaN, 5),
+    ).toBe(0);
+    const rec = useAnnotationStore.getState().records["Fail02"];
+    expect(rec.tiers.concept.intervals[0].start).toBe(100);
+  });
+
+  it("tolerates 1ms timestamp drift when matching", () => {
+    seedFail02();
+    // Caller passes slightly drifted numbers (floating point round-trip)
+    const moved = useAnnotationStore.getState().moveIntervalAcrossTiers(
+      "Fail02", 100.0004, 100.9997, 101, 102,
+    );
+    expect(moved).toBe(4);
+    const rec = useAnnotationStore.getState().records["Fail02"];
+    expect(rec.tiers.concept.intervals[0].start).toBeCloseTo(101);
+  });
+
+  it("returns 0 for unknown speaker", () => {
+    const moved = useAnnotationStore.getState().moveIntervalAcrossTiers(
+      "Ghost01", 1, 2, 3, 4,
+    );
+    expect(moved).toBe(0);
+  });
+});

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -17,9 +17,16 @@ export interface AnnotationTier {
 export interface AnnotationRecord {
   speaker: string;
   tiers: Record<string, AnnotationTier>; // keys: ipa, ortho, concept, speaker
-  created_at: string;
-  modified_at: string;
-  source_wav: string;
+  created_at?: string;
+  modified_at?: string;
+  source_wav?: string;
+  /**
+   * Project-relative path to the source audio, e.g. "audio/working/Fail02/foo.wav".
+   * The Python server normalizer emits this key; `source_wav` is the historical
+   * blank-record shape. Prefer `source_audio` when both exist.
+   */
+  source_audio?: string;
+  source_audio_duration_sec?: number;
 }
 
 export interface ConceptEntry {

--- a/src/components/annotate/AnnotateMode.tsx
+++ b/src/components/annotate/AnnotateMode.tsx
@@ -45,12 +45,17 @@ export function AnnotateMode() {
   const playbackRate = usePlaybackStore((s) => s.playbackRate);
   const setPlaybackRate = usePlaybackStore((s) => s.setPlaybackRate);
   const dirty = useAnnotationStore((s) => s.dirty);
+  const record = useAnnotationStore((s) =>
+    activeSpeaker ? s.records[activeSpeaker] ?? null : null,
+  );
 
   // Annotation sync
   useAnnotationSync();
 
-  // Waveform
-  const audioUrl = activeSpeaker ? `/audio/${activeSpeaker}.wav` : "";
+  // Waveform URL comes from the loaded annotation's source_audio
+  // (e.g. "audio/working/Fail02/foo.wav"), not a speaker-name stub.
+  const sourceAudio = (record?.source_audio ?? record?.source_wav ?? "").replace(/\\/g, "/").replace(/^\/+/, "");
+  const audioUrl = activeSpeaker && sourceAudio ? "/" + sourceAudio : "";
   const {
     playPause,
     seek,

--- a/src/hooks/useWaveSurfer.ts
+++ b/src/hooks/useWaveSurfer.ts
@@ -157,6 +157,11 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     const container = options.containerRef.current;
     if (!container) return;
 
+    // Skip initialization when the audio URL isn't ready yet. Otherwise
+    // WaveSurfer.load("") throws and leaves the component in a broken state.
+    // Re-runs when audioUrl changes.
+    if (!options.audioUrl) return;
+
     // Abort any previous peaks fetch
     abortControllerRef.current?.abort();
     const abortCtrl = new AbortController();

--- a/src/hooks/useWaveSurfer.ts
+++ b/src/hooks/useWaveSurfer.ts
@@ -18,6 +18,13 @@ interface UseWaveSurferOptions {
   initialSeekSec?: number;
   durationSec?: number;
   onRegionUpdate?: (start: number, end: number) => void;
+  /**
+   * Fires once when the user releases the mouse after a region drag or
+   * resize — i.e. the final committed range. Callers that want to persist
+   * region edits should hook this instead of `onRegionUpdate`, which
+   * streams throughout the interaction.
+   */
+  onRegionCommit?: (start: number, end: number) => void;
   onTimeUpdate?: (time: number) => void;
   onReady?: (duration: number) => void;
   onPlayStateChange?: (playing: boolean) => void;
@@ -112,6 +119,30 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     },
     [seekToSec],
   );
+
+  /**
+   * Scroll the waveform so that `timeSec` is positioned at `fraction` of the
+   * visible viewport width (e.g. 0.33 = one-third from the left). Useful when
+   * seeking to a lexeme start — centering hides the trailing audio, whereas
+   * 33% offset keeps more of the following waveform visible for region edits.
+   */
+  const scrollToTimeAtFraction = useCallback((timeSec: number, fraction: number) => {
+    const ws = wsRef.current;
+    if (!ws) return;
+    const duration = ws.getDuration();
+    if (!duration || duration <= 0) return;
+    const options = (ws as unknown as { options: { minPxPerSec?: number } }).options;
+    const pxPerSec = options?.minPxPerSec ?? 0;
+    if (!pxPerSec) return;
+    const wrapper = ws.getWrapper();
+    const viewport = wrapper?.parentElement;
+    const viewportWidth = viewport?.clientWidth ?? 0;
+    if (!viewportWidth) return;
+    const totalPx = duration * pxPerSec;
+    const maxScroll = Math.max(0, totalPx - viewportWidth);
+    const target = clamp(timeSec * pxPerSec - viewportWidth * fraction, 0, maxScroll);
+    ws.setScroll(target);
+  }, []);
 
   const setZoom = useCallback((minPxPerSec: number) => {
     wsRef.current?.zoom(minPxPerSec);
@@ -237,6 +268,17 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
       options.onRegionUpdate?.(region.start, region.end);
     });
 
+    // `region-updated` in the wavesurfer regions plugin fires continuously
+    // while the user drags or resizes. The public type map doesn't include a
+    // "drag end" event, so we attach a pointerup listener to the container
+    // and treat the region's current bounds as the committed value.
+    function onCommit() {
+      const active = activeRegionRef.current;
+      if (!active) return;
+      options.onRegionCommit?.(active.start, active.end);
+    }
+    container.addEventListener("pointerup", onCommit);
+
     // -- Keyboard shortcuts (scoped to container) --
 
     function onKeyDown(e: KeyboardEvent) {
@@ -303,6 +345,7 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     return () => {
       abortControllerRef.current?.abort();
       container.removeEventListener("keydown", onKeyDown);
+      container.removeEventListener("pointerup", onCommit);
       ws.destroy();
       wsRef.current = null;
       regionsRef.current = null;
@@ -316,6 +359,7 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     pause,
     playPause,
     seek,
+    scrollToTimeAtFraction,
     skip,
     jump,
     setZoom,

--- a/src/stores/annotationStore.ts
+++ b/src/stores/annotationStore.ts
@@ -68,6 +68,20 @@ interface AnnotationStore {
   updateInterval: (speaker: string, tier: string, index: number, text: string) => void;
   addInterval: (speaker: string, tier: string, interval: AnnotationInterval) => void;
   removeInterval: (speaker: string, tier: string, index: number) => void;
+  /**
+   * Retime a lexeme across every tier. Finds the interval that matches
+   * (oldStart, oldEnd) within a 1ms tolerance on each tier and rewrites its
+   * start/end to (newStart, newEnd), keeping the text. Intended for the
+   * concept-timestamp editor in Annotate mode, where the concept interval
+   * and its co-timed ipa/ortho/speaker intervals move together.
+   */
+  moveIntervalAcrossTiers: (
+    speaker: string,
+    oldStart: number,
+    oldEnd: number,
+    newStart: number,
+    newEnd: number,
+  ) => number;
 }
 
 export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
@@ -224,5 +238,36 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
       dirty: { ...s.dirty, [speaker]: true },
     }));
     scheduleAutosave(speaker);
+  },
+
+  moveIntervalAcrossTiers: (speaker, oldStart, oldEnd, newStart, newEnd) => {
+    if (!Number.isFinite(newStart) || !Number.isFinite(newEnd)) return 0;
+    if (newEnd < newStart) return 0;
+
+    const state = get();
+    const record = state.records[speaker];
+    if (!record) return 0;
+
+    const clone = deepClone(record);
+    const tol = 0.001;
+    let moved = 0;
+    for (const tier of Object.values(clone.tiers)) {
+      const idx = tier.intervals.findIndex(
+        (it) => Math.abs(it.start - oldStart) < tol && Math.abs(it.end - oldEnd) < tol,
+      );
+      if (idx < 0) continue;
+      tier.intervals[idx] = { ...tier.intervals[idx], start: newStart, end: newEnd };
+      tier.intervals.sort((a, b) => a.start - b.start);
+      moved += 1;
+    }
+    if (moved === 0) return 0;
+    clone.modified_at = nowIsoUtc();
+
+    set((s) => ({
+      records: { ...s.records, [speaker]: clone },
+      dirty: { ...s.dirty, [speaker]: true },
+    }));
+    scheduleAutosave(speaker);
+    return moved;
   },
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,11 @@ export default defineConfig({
         changeOrigin: true,
         ws: false,
       },
+      "/peaks": {
+        target: parseApiTarget,
+        changeOrigin: true,
+        ws: false,
+      },
     },
   },
   test: {


### PR DESCRIPTION
## Summary
Selecting a concept in the left sidebar now **auto-seeks the waveform** to that lexeme, **shows its start/end**, and lets you **edit those values** with persistence back to the annotation JSON.

- **On concept select** (once audio is ready): `seek()` to the concept interval's start + draw a draggable region spanning the lexeme.
- **New timestamp editor** under the transcription fields:
  - Numeric Start / End inputs (seconds, 3-decimal precision) seeded from the current concept interval.
  - Dragging/resizing the waveform region mirrors back into the inputs.
  - **Save timestamp** atomically retimes every tier (ipa / ortho / concept / speaker) that carried the old interval and POSTs to `/api/annotations/<speaker>`.
  - **Reset** reverts inputs + region to the stored interval.
  - Toast shows success (`Retimed N tiers`) or validation errors.
- New store action `moveIntervalAcrossTiers(speaker, oldStart, oldEnd, newStart, newEnd)`: finds the matching interval on each tier (1ms drift tolerance), rewrites start/end in place, keeps text, re-sorts, marks dirty, schedules autosave. Returns tier count retimed.

## Depends on
This branches off [#106](https://github.com/ArdeleanLucas/PARSE/pull/106) (audio URL + Vite `/peaks` proxy). Merge #106 first, then this.

## Test plan
- [x] `npx vitest run src/__tests__/moveInterval.test.ts` — 5 cases pass (all-tier retime, no-match, invalid ranges, drift tolerance, unknown speaker).
- [x] `npx tsc --noEmit` clean.
- [x] **Live verification against PC backend via Vite proxy:**
  - Switched to Annotate / Fail02 → WAV loads (3956s duration).
  - Clicked **hair #1** → seeked to 365.105s, Start=365.105, End=365.999.
  - Clicked **forehead #2** → seeked to 377.465s, Start=377.465, End=378.484.
  - Edited Start→377.200, End→378.800, clicked Save → toast `Retimed 4 tiers`.
  - `/api/annotations/Fail02` returns the new timestamps for forehead across all four tiers (ipa/ortho/concept/speaker). Reverted after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)