### PR TITLE
fix(actions): wire Run Orthographic STT and Run IPA to the active speaker

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -2338,6 +2338,108 @@ def _compute_contact_lexemes(job_id: str, payload: Dict[str, Any]) -> Dict[str, 
     }
 
 
+def _compute_speaker_ipa(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Fill missing IPA cells on a speaker's annotation from the ortho tier.
+
+    For each ortho interval with text, generate IPA via the configured IPA
+    provider. If an ipa interval at the same (start, end) is empty or
+    absent, write the generated IPA. Intervals with existing non-empty IPA
+    are left alone unless `overwrite=True`, so this can be run repeatedly
+    without clobbering manual edits.
+
+    Payload: `{ "speaker": "Fail02", "overwrite": false }`.
+    """
+    speaker = _normalize_speaker_id(payload.get("speaker"))
+    overwrite = bool(payload.get("overwrite", False))
+
+    canonical_path = _project_root() / _annotation_record_relative_path(speaker)
+    legacy_path = _project_root() / _annotation_legacy_record_relative_path(speaker)
+
+    if canonical_path.is_file():
+        annotation_path = canonical_path
+    elif legacy_path.is_file():
+        annotation_path = legacy_path
+    else:
+        raise RuntimeError("No annotation found for speaker {0!r}".format(speaker))
+
+    annotation = _read_json_file(annotation_path, {})
+    if not isinstance(annotation, dict):
+        raise RuntimeError("Annotation is not a JSON object")
+
+    tiers = annotation.get("tiers") or {}
+    ortho_tier = tiers.get("ortho") or {}
+    ortho_intervals = list(ortho_tier.get("intervals") or [])
+    if not ortho_intervals:
+        return {"speaker": speaker, "filled": 0, "skipped": 0, "total": 0, "message": "No ortho intervals."}
+
+    ipa_tier = tiers.setdefault("ipa", {"type": "interval", "display_order": 1, "intervals": []})
+    ipa_intervals: List[Dict[str, Any]] = list(ipa_tier.get("intervals") or [])
+
+    def _key(interval: Dict[str, Any]) -> Tuple[float, float]:
+        return (round(float(interval.get("start", 0.0)), 3), round(float(interval.get("end", 0.0)), 3))
+
+    ipa_by_key: Dict[Tuple[float, float], Dict[str, Any]] = {_key(i): i for i in ipa_intervals}
+
+    provider = get_ipa_provider()
+    metadata = annotation.get("metadata") if isinstance(annotation.get("metadata"), dict) else {}
+    language = str(metadata.get("language_code") or "und")
+
+    filled = 0
+    skipped = 0
+    total = len(ortho_intervals)
+
+    for idx, ortho in enumerate(ortho_intervals):
+        text = str(ortho.get("text") or "").strip()
+        key = _key(ortho)
+        existing = ipa_by_key.get(key)
+        existing_text = str((existing or {}).get("text") or "").strip()
+
+        if not text:
+            skipped += 1
+            continue
+        if existing_text and not overwrite:
+            skipped += 1
+            continue
+
+        try:
+            new_ipa = provider.to_ipa(text, language)
+        except Exception:
+            skipped += 1
+            continue
+
+        new_ipa = str(new_ipa or "").strip()
+        if not new_ipa:
+            skipped += 1
+            continue
+
+        if existing is not None:
+            existing["text"] = new_ipa
+        else:
+            new_interval = {"start": ortho["start"], "end": ortho["end"], "text": new_ipa}
+            ipa_intervals.append(new_interval)
+            ipa_by_key[key] = new_interval
+        filled += 1
+
+        progress = 5.0 + ((idx + 1) / total) * 90.0
+        _set_job_progress(job_id, progress, message="IPA {0}/{1}".format(idx + 1, total))
+
+    ipa_intervals.sort(key=lambda i: (float(i.get("start", 0.0)), float(i.get("end", 0.0))))
+    ipa_tier["intervals"] = ipa_intervals
+    tiers["ipa"] = ipa_tier
+    annotation["tiers"] = tiers
+    _annotation_touch_metadata(annotation, preserve_created=True)
+
+    _write_json_file(annotation_path, annotation)
+    # Keep both file shapes in sync (the server prefers .parse.json; external
+    # tooling sometimes writes the legacy .json).
+    if canonical_path != annotation_path:
+        _write_json_file(canonical_path, annotation)
+    if legacy_path != annotation_path:
+        _write_json_file(legacy_path, annotation)
+
+    return {"speaker": speaker, "filled": filled, "skipped": skipped, "total": total}
+
+
 def _run_compute_job(job_id: str, compute_type: str, payload: Dict[str, Any]) -> None:
     try:
         normalized_type = str(compute_type or "").strip().lower()
@@ -2347,6 +2449,8 @@ def _run_compute_job(job_id: str, compute_type: str, payload: Dict[str, Any]) ->
             result = _compute_cognates(job_id, payload)
         elif normalized_type == "contact-lexemes":
             result = _compute_contact_lexemes(job_id, payload)
+        elif normalized_type in {"ipa_only", "ipa-only", "ipa"}:
+            result = _compute_speaker_ipa(job_id, payload)
         else:
             raise RuntimeError("Unsupported compute type: {0}".format(normalized_type))
 

--- a/python/test_compute_speaker_ipa.py
+++ b/python/test_compute_speaker_ipa.py
@@ -1,0 +1,163 @@
+"""Unit tests for _compute_speaker_ipa (ipa_only compute type)."""
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+class _StubIpaProvider:
+    """Returns an uppercase ASCII mirror so tests can check exact output."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def to_ipa(self, text: str, language: str) -> str:
+        self.calls.append((text, language))
+        return "IPA:" + text.upper()
+
+
+def _seed_annotation(tmp_path: pathlib.Path, speaker: str, ortho: list[dict], ipa: list[dict]):
+    (tmp_path / "annotations").mkdir(exist_ok=True)
+    annotation = {
+        "version": 1,
+        "project_id": "t",
+        "speaker": speaker,
+        "source_audio": "x.wav",
+        "source_audio_duration_sec": 10.0,
+        "tiers": {
+            "ipa":     {"type": "interval", "display_order": 1, "intervals": ipa},
+            "ortho":   {"type": "interval", "display_order": 2, "intervals": ortho},
+            "concept": {"type": "interval", "display_order": 3, "intervals": []},
+            "speaker": {"type": "interval", "display_order": 4, "intervals": []},
+        },
+        "metadata": {"language_code": "sdh", "created": "2026-01-01T00:00:00Z", "modified": "2026-01-01T00:00:00Z"},
+    }
+    (tmp_path / "annotations" / f"{speaker}.parse.json").write_text(
+        json.dumps(annotation), encoding="utf-8",
+    )
+    return annotation
+
+
+def _load_canonical(tmp_path: pathlib.Path, speaker: str) -> dict:
+    return json.loads((tmp_path / "annotations" / f"{speaker}.parse.json").read_text("utf-8"))
+
+
+def test_fills_empty_ipa_slots_from_ortho(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    stub = _StubIpaProvider()
+    monkeypatch.setattr(server, "get_ipa_provider", lambda: stub)
+
+    ortho = [
+        {"start": 1.0, "end": 1.5, "text": "hair"},
+        {"start": 2.0, "end": 2.5, "text": "forehead"},
+        {"start": 3.0, "end": 3.5, "text": ""},   # empty ortho — skipped
+    ]
+    ipa = [{"start": 1.0, "end": 1.5, "text": ""}]  # only one empty ipa, second one absent
+    _seed_annotation(tmp_path, "Fail02", ortho, ipa)
+
+    result = server._compute_speaker_ipa("j1", {"speaker": "Fail02"})
+    assert result["filled"] == 2
+    assert result["skipped"] == 1
+    assert result["total"] == 3
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    ipa_intervals = ann["tiers"]["ipa"]["intervals"]
+    ipa_by_start = {round(i["start"], 3): i["text"] for i in ipa_intervals}
+    assert ipa_by_start[1.0] == "IPA:HAIR"
+    assert ipa_by_start[2.0] == "IPA:FOREHEAD"
+    assert stub.calls == [("hair", "sdh"), ("forehead", "sdh")]
+
+
+def test_preserves_existing_ipa_unless_overwrite(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    stub = _StubIpaProvider()
+    monkeypatch.setattr(server, "get_ipa_provider", lambda: stub)
+
+    ortho = [{"start": 1.0, "end": 1.5, "text": "hair"}]
+    ipa = [{"start": 1.0, "end": 1.5, "text": "manual-keep"}]
+    _seed_annotation(tmp_path, "Fail02", ortho, ipa)
+
+    result = server._compute_speaker_ipa("j1", {"speaker": "Fail02"})
+    assert result["filled"] == 0
+    assert result["skipped"] == 1
+    ann = _load_canonical(tmp_path, "Fail02")
+    assert ann["tiers"]["ipa"]["intervals"][0]["text"] == "manual-keep"
+    assert stub.calls == []
+
+
+def test_overwrite_true_replaces_existing_ipa(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    stub = _StubIpaProvider()
+    monkeypatch.setattr(server, "get_ipa_provider", lambda: stub)
+
+    ortho = [{"start": 1.0, "end": 1.5, "text": "hair"}]
+    ipa = [{"start": 1.0, "end": 1.5, "text": "manual-keep"}]
+    _seed_annotation(tmp_path, "Fail02", ortho, ipa)
+
+    result = server._compute_speaker_ipa("j1", {"speaker": "Fail02", "overwrite": True})
+    assert result["filled"] == 1
+    ann = _load_canonical(tmp_path, "Fail02")
+    assert ann["tiers"]["ipa"]["intervals"][0]["text"] == "IPA:HAIR"
+
+
+def test_run_compute_job_dispatches_ipa_only(tmp_path, monkeypatch):
+    """_run_compute_job should route compute_type='ipa_only' to _compute_speaker_ipa."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "get_ipa_provider", lambda: _StubIpaProvider())
+    _seed_annotation(
+        tmp_path, "Fail02",
+        [{"start": 1.0, "end": 1.5, "text": "hair"}], [],
+    )
+
+    captured: dict = {}
+
+    def fake_complete(job_id, result, **kwargs):
+        captured["result"] = result
+
+    def fake_error(job_id, err):
+        captured["error"] = err
+
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_set_job_complete", fake_complete)
+    monkeypatch.setattr(server, "_set_job_error", fake_error)
+
+    server._run_compute_job("j1", "ipa_only", {"speaker": "Fail02"})
+    assert "error" not in captured
+    assert captured["result"]["filled"] == 1
+
+    # Also try the hyphenated alias
+    captured.clear()
+    # Re-seed (previous call wrote to the same file)
+    _seed_annotation(
+        tmp_path, "Fail03",
+        [{"start": 2.0, "end": 2.5, "text": "ash"}], [],
+    )
+    server._run_compute_job("j2", "ipa-only", {"speaker": "Fail03"})
+    assert captured["result"]["filled"] == 1
+
+
+def test_missing_annotation_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    import pytest
+
+    with pytest.raises(RuntimeError, match="No annotation"):
+        server._compute_speaker_ipa("j1", {"speaker": "GhostSpeaker"})
+
+
+def test_skips_when_provider_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    class _EmptyProvider:
+        def to_ipa(self, text, lang):
+            return ""
+
+    monkeypatch.setattr(server, "get_ipa_provider", lambda: _EmptyProvider())
+    _seed_annotation(
+        tmp_path, "Fail02",
+        [{"start": 1.0, "end": 1.5, "text": "hair"}], [],
+    )
+    result = server._compute_speaker_ipa("j1", {"speaker": "Fail02"})
+    assert result["filled"] == 0
+    assert result["skipped"] == 1

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1576,7 +1576,14 @@ export function ParseUI() {
   const sttJob = useActionJob({
     start: () => {
       if (!activeActionSpeaker) return Promise.reject(new Error('No speaker selected'));
-      return startSTT(activeActionSpeaker, `${activeActionSpeaker}.wav`, 'ckb');
+      const record = annotationRecords[activeActionSpeaker];
+      const sourceWav = (record?.source_audio ?? record?.source_wav ?? '').trim();
+      if (!sourceWav) {
+        return Promise.reject(new Error(
+          `No source_audio on annotation for ${activeActionSpeaker}. Import or onboard the speaker first.`,
+        ));
+      }
+      return startSTT(activeActionSpeaker, sourceWav, 'ckb');
     },
     poll: (id) => pollSTT(id) as Promise<PollResult>,
     label: 'Running STT…',
@@ -1584,10 +1591,13 @@ export function ParseUI() {
   });
 
   const ipaJob = useActionJob({
-    start: () => startCompute('ipa_only'),
+    start: () => {
+      if (!activeActionSpeaker) return Promise.reject(new Error('No speaker selected'));
+      return startCompute('ipa_only', { speaker: activeActionSpeaker });
+    },
     poll: (id) => pollCompute('ipa_only', id),
     label: 'Transcribing IPA…',
-    onComplete: loadEnrichments,
+    onComplete: () => reloadSpeakerAnnotation(activeActionSpeaker),
   });
 
   const pipelineJob = useActionJob({
@@ -1942,7 +1952,7 @@ export function ParseUI() {
                     </button>
                     <button
                       onClick={() => { setActionsMenuOpen(false); void ipaJob.run(); }}
-                      disabled={ipaJob.state.status === 'running'}
+                      disabled={!activeActionSpeaker || ipaJob.state.status === 'running'}
                       className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Type className="h-3.5 w-3.5 text-slate-400"/>


### PR DESCRIPTION
## Summary
Actions menu items for **Run Orthographic STT** and **Run IPA Transcription** both failed on click (screenshot: "Starting compute job · Retry / Dismiss").

- **STT**: the frontend posted `sourceWav: "<speaker>.wav"`, but real files live at `audio/working/<speaker>/<filename>.wav`. The backend couldn't resolve the stub path → "Audio file not found".
- **IPA**: the frontend hit `/api/compute/ipa_only`, but `_run_compute_job` only knew `cognates` / `similarity` / `contact-lexemes` → "Unsupported compute type".

## Changes
### Frontend
- `sttJob.start` now sources the WAV path from `annotationRecords[activeActionSpeaker].source_audio` (falling back to `source_wav`), matching what #106 does for the waveform player. Rejects with a clear message when neither is set.
- `ipaJob.start` now posts `{ speaker: activeActionSpeaker }` and is gated on `activeActionSpeaker` in the menu.

### Backend
- New `_compute_speaker_ipa(job_id, payload)` worker. Walks the speaker's ortho tier; for each interval with text, calls `get_ipa_provider().to_ipa(text, language_code)` and writes the result into the co-timed ipa interval (or appends one). Existing non-empty IPA is preserved unless `overwrite=true` is passed. Writes both `.parse.json` (canonical) and `.json` (legacy) to keep things in sync.
- `_run_compute_job` routes `ipa_only` / `ipa-only` / `ipa` to the new worker.

### Tests (6 new, all pass)
`python/test_compute_speaker_ipa.py`:
- fills empty ipa slots, skips empty ortho rows
- preserves existing ipa unless `overwrite=true`
- `overwrite=true` replaces existing ipa
- `_run_compute_job` dispatches `ipa_only` and `ipa-only` aliases
- missing annotation raises RuntimeError
- empty provider output treated as skip

## Out of scope
**Run Full Pipeline** still routes to `compute/full_pipeline`, which is unimplemented — flagged but not fixed here; will need its own dispatch (normalize → STT → IPA) and is safer to do as a separate change.

## Test plan
- [x] `python3.12 -m pytest python/test_compute_speaker_ipa.py` — 6 passed.
- [x] `npx tsc --noEmit` — clean.
- [x] End-to-end against a local workspace:
  - `POST /api/compute/ipa_only {"speaker":"TestSpk"}` → 200, job `status:"complete"`, `filled:2`. `/api/annotations/TestSpk` reflects new ipa intervals.
  - `POST /api/stt {"speaker":"TestSpk","sourceWav":"audio/working/TestSpk/test.wav","language":"ckb"}` → worker reached the audio path (error becomes "faster-whisper dependency missing" on the Mac, where faster-whisper isn't installed — not the prior "Audio file not found"). On the PC where faster-whisper is installed, STT runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)