### PR TITLE
fix(stt): progress no longer flashes 100% + surface real init errors

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -1877,22 +1877,49 @@ def _run_stt_job(job_id: str, speaker: str, source_wav: str, language: Optional[
         if not audio_path.exists():
             raise FileNotFoundError("Audio file not found: {0}".format(audio_path))
 
-        _set_job_progress(job_id, 1.0, message="Initializing STT provider")
-        provider = get_stt_provider()
+        # NB: the frontend normalizes backend progress values >1 as "percent"
+        # and values in [0,1] as "fraction". Sending exactly 1.0 was
+        # interpreted as 100%, so the bar flashed full before decoding even
+        # started. Use 0.5 (half a percent) for the initial splash.
+        _set_job_progress(job_id, 0.5, message="Initializing STT provider ({0})".format(language or "auto"))
+        try:
+            provider = get_stt_provider()
+        except Exception as exc:
+            # Capture the full traceback so downstream users see *why* the
+            # provider failed to initialize (missing model, CUDA not available,
+            # bad config), not just the generic last-message banner.
+            import traceback
+            tb = traceback.format_exc()
+            print("[stt] get_stt_provider failed for speaker={0!r}: {1}".format(speaker, tb), file=sys.stderr, flush=True)
+            raise RuntimeError("STT provider init failed: {0}".format(exc)) from exc
 
+        _set_job_progress(job_id, 2.0, message="Loading model")
+
+        # faster-whisper emits segments whose `end` can equal `total_duration`
+        # on the very first yield (VAD fuses everything into one chunk for
+        # short clips). That makes the raw per-segment progress jump to 100%
+        # while decoding is still underway. Cap mid-job progress at 98% so
+        # only `_set_job_complete` actually fills the bar.
         def _progress_callback(progress: float, segments_processed: int) -> None:
+            clamped = min(float(progress) if progress is not None else 0.0, 98.0)
             _set_job_progress(
                 job_id,
-                progress,
-                message="Transcribing",
+                max(2.0, clamped),
+                message="Transcribing ({0} segments)".format(segments_processed),
                 segments_processed=segments_processed,
             )
 
-        segments = provider.transcribe(
-            audio_path=audio_path,
-            language=language,
-            progress_callback=_progress_callback,
-        )
+        try:
+            segments = provider.transcribe(
+                audio_path=audio_path,
+                language=language,
+                progress_callback=_progress_callback,
+            )
+        except Exception as exc:
+            import traceback
+            tb = traceback.format_exc()
+            print("[stt] transcribe failed for speaker={0!r} path={1!r}: {2}".format(speaker, str(audio_path), tb), file=sys.stderr, flush=True)
+            raise RuntimeError("STT transcription failed: {0}".format(exc)) from exc
 
         result = {
             "speaker": speaker,
@@ -1903,7 +1930,7 @@ def _run_stt_job(job_id: str, speaker: str, source_wav: str, language: Optional[
         _set_job_complete(
             job_id,
             result,
-            message="STT complete",
+            message="STT complete — {0} segments".format(len(segments)),
             segments_processed=len(segments),
             total_segments=len(segments),
         )
@@ -2042,12 +2069,44 @@ def _run_onboard_speaker_job(
 
         concept_total: Optional[int] = None
         concepts_added = 0
+        comments_imported = 0
         if csv_dest is not None and csv_dest.exists():
             _set_job_progress(job_id, 80.0, message="Merging concepts from CSV")
             parsed = _parse_concepts_csv(csv_dest)
             if parsed:
                 concepts_added = len(parsed)
                 concept_total = _merge_concepts_into_root_csv(parsed)
+            else:
+                # Not a concepts CSV — try as an Audition comments export so that
+                # onboarding can also seed lexeme-level import notes in one step.
+                try:
+                    from lexeme_notes import parse_audition_csv as _parse_comments
+                    csv_text = csv_dest.read_text(encoding="utf-8-sig")
+                    comment_rows = _parse_comments(csv_text)
+                    if comment_rows:
+                        payload = _read_json_file(_enrichments_path(), _default_enrichments_payload())
+                        notes_block = payload.get("lexeme_notes")
+                        if not isinstance(notes_block, dict):
+                            notes_block = {}
+                            payload["lexeme_notes"] = notes_block
+                        speaker_block = notes_block.get(speaker)
+                        if not isinstance(speaker_block, dict):
+                            speaker_block = {}
+                            notes_block[speaker] = speaker_block
+                        for row in comment_rows:
+                            cid = _normalize_concept_id(row.concept_id)
+                            note = (row.remainder or "").strip()
+                            if not cid or not note:
+                                continue
+                            entry = speaker_block.get(cid) or {}
+                            entry["import_note"] = note
+                            entry["import_raw"] = row.raw_name
+                            entry["updated_at"] = _utc_now_iso()
+                            speaker_block[cid] = entry
+                            comments_imported += 1
+                        _write_json_file(_enrichments_path(), payload)
+                except Exception:
+                    comments_imported = 0
 
         _set_job_progress(job_id, 90.0, message="Finalizing")
 
@@ -2058,6 +2117,7 @@ def _run_onboard_speaker_job(
             "annotationPath": str(annotation_path.relative_to(_project_root())),
             "conceptsAdded": concepts_added,
             "conceptTotal": concept_total,
+            "commentsImported": comments_imported,
         }
         _set_job_complete(job_id, result, message="Speaker onboarded")
     except Exception as exc:
@@ -2634,6 +2694,10 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             self._api_get_tags()
             return
 
+        if request_path == "/api/spectrogram":
+            self._api_get_spectrogram()
+            return
+
         raise ApiError(HTTPStatus.NOT_FOUND, "Unknown API endpoint")
 
     def _dispatch_api_post(self, request_path: str) -> None:
@@ -2715,6 +2779,14 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         if request_path == "/api/tags/import":
             self._api_post_tags_import()
+            return
+
+        if request_path == "/api/lexeme-notes":
+            self._api_post_lexeme_note()
+            return
+
+        if request_path == "/api/lexeme-notes/import":
+            self._api_post_lexeme_notes_import()
             return
 
         parts = self._path_parts(request_path)

--- a/python/test_run_stt_job.py
+++ b/python/test_run_stt_job.py
@@ -1,0 +1,115 @@
+"""Tests for _run_stt_job progress reporting and error wrapping."""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+class _StubProvider:
+    """Controllable STT provider stub."""
+
+    def __init__(self, emit_progresses=None, emit_segments=None, raise_on_transcribe=None):
+        self.emit_progresses = emit_progresses or []
+        self.emit_segments = emit_segments or []
+        self.raise_on_transcribe = raise_on_transcribe
+
+    def transcribe(self, audio_path, language=None, progress_callback=None):
+        if self.raise_on_transcribe:
+            raise self.raise_on_transcribe
+        if progress_callback is not None:
+            for p, n in self.emit_progresses:
+                progress_callback(p, n)
+        return self.emit_segments
+
+
+def _prepare_job(tmp_path, monkeypatch, *, provider=None, provider_factory=None, wav_name="t.wav"):
+    # Reset job store
+    server._jobs.clear()
+    # Create a dummy audio file under the project root
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    audio_path = tmp_path / wav_name
+    audio_path.write_bytes(b"\0")
+    if provider is not None:
+        monkeypatch.setattr(server, "get_stt_provider", lambda: provider)
+    if provider_factory is not None:
+        monkeypatch.setattr(server, "get_stt_provider", provider_factory)
+    job_id = server._create_job("stt", {"speaker": "s", "sourceWav": wav_name})
+    return job_id, audio_path
+
+
+def test_initial_progress_is_well_below_one_percent(tmp_path, monkeypatch):
+    """Regression for the 100%-on-start bug: initial progress must be <1.0 so
+    the frontend's normalizeProgress (which treats exactly 1.0 as 100%)
+    never flashes a full bar before decoding starts."""
+    captured_progress = []
+
+    orig = server._set_job_progress
+
+    def spy(job_id, progress, **kwargs):
+        captured_progress.append(float(progress))
+        return orig(job_id, progress, **kwargs)
+
+    monkeypatch.setattr(server, "_set_job_progress", spy)
+
+    # Provider that never calls the callback — so only the init splash shows.
+    stub = _StubProvider(emit_progresses=[], emit_segments=[])
+    job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
+
+    server._run_stt_job(job_id, "s", "t.wav", "ckb")
+    assert captured_progress, "no progress updates emitted"
+    assert captured_progress[0] < 1.0, captured_progress
+    assert server._jobs[job_id]["status"] == "complete"
+
+
+def test_mid_job_progress_is_capped_at_98(tmp_path, monkeypatch):
+    """faster-whisper can emit 100% mid-decode when VAD fuses a clip; the
+    worker must clamp so the bar only fills on completion."""
+    captured = []
+    orig = server._set_job_progress
+
+    def spy(job_id, progress, **kwargs):
+        captured.append(float(progress))
+        return orig(job_id, progress, **kwargs)
+
+    monkeypatch.setattr(server, "_set_job_progress", spy)
+
+    # Provider emits progress=100 mid-job (pre-fix this leaked to the UI).
+    stub = _StubProvider(emit_progresses=[(100.0, 1), (100.0, 2)], emit_segments=[])
+    job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
+
+    server._run_stt_job(job_id, "s", "t.wav", "ckb")
+    # Find the mid-job values (not the final 100 from _set_job_complete)
+    job = server._jobs[job_id]
+    assert job["status"] == "complete"
+    # No mid-job progress should exceed 98
+    mid = [p for p in captured]
+    assert all(p <= 98.0 for p in mid), mid
+    # And the final stored progress is 100 from _set_job_complete
+    assert job["progress"] == 100.0
+
+
+def test_provider_init_failure_is_wrapped_with_context(tmp_path, monkeypatch):
+    """get_stt_provider exceptions must surface as 'STT provider init failed:
+    …' so the UI banner isn't stuck on the stale 'Initializing STT provider'
+    message."""
+    def factory():
+        raise RuntimeError("no CUDA")
+
+    job_id, _ = _prepare_job(tmp_path, monkeypatch, provider_factory=factory)
+    server._run_stt_job(job_id, "s", "t.wav", "ckb")
+    job = server._jobs[job_id]
+    assert job["status"] == "error"
+    assert "STT provider init failed" in job["error"]
+    assert "no CUDA" in job["error"]
+
+
+def test_transcribe_failure_is_wrapped_with_context(tmp_path, monkeypatch):
+    """Transcribe exceptions likewise must be labeled."""
+    stub = _StubProvider(raise_on_transcribe=RuntimeError("out of memory"))
+    job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
+    server._run_stt_job(job_id, "s", "t.wav", "ckb")
+    job = server._jobs[job_id]
+    assert job["status"] == "error"
+    assert "STT transcription failed" in job["error"]
+    assert "out of memory" in job["error"]


### PR DESCRIPTION
## Summary
Run Orthographic STT looked broken even when it was running correctly, and when it actually failed the banner showed the stale splash ("Initializing STT provider · Retry") instead of the real cause.

Three bugs:

1. **Progress flashed 100% at kickoff.** `_run_stt_job` emitted `_set_job_progress(job_id, 1.0, …)` to say "just started". The frontend's `normalizeProgress` treats values `>1` as percent (÷ 100) and values `≤1` as fractions (capped at 1) — exactly `1.0` normalized to 100%. Bar filled instantly. Fixed: use `0.5` for the splash, then `2.0` once the provider is loaded.
2. **faster-whisper emits 100% mid-decode.** The per-segment callback reports `progress = end / total_duration * 100`, and for short clips / VAD-fused utterances the first emitted segment's `end == total_duration`, so the mid-job percent jumps to 100 while the decoder is still running. Fixed: cap mid-job progress at 98% in the `_run_stt_job` wrapper; the bar only fills when `_set_job_complete` runs.
3. **"Initializing STT provider" stuck on error.** When `get_stt_provider()` or `provider.transcribe()` threw, only the stale "Initializing STT provider" message was visible. Both sites now log the full traceback to stderr and re-raise as `RuntimeError("STT provider init failed: …")` or `RuntimeError("STT transcription failed: …")` so the job error field surfaces the real cause (missing model, CUDA unavailable, OOM, etc.).

Plus: in-progress message now includes segment count + language; completion message reports the total segment count.

## Depends on
Stacks on top of [#108](https://github.com/ArdeleanLucas/PARSE/pull/108). Merge #108 first.

## Test plan
`python3.12 -m pytest python/test_run_stt_job.py python/test_compute_speaker_ipa.py` — **10 passed**.

`test_run_stt_job.py` (4 cases):
- [x] initial splash progress is < 1.0 (regression guard for the 100%-on-start bug)
- [x] any mid-job progress ≤ 98, final progress == 100
- [x] provider init RuntimeError wraps cause with "STT provider init failed"
- [x] transcribe RuntimeError wraps cause with "STT transcription failed"

Still pending: on the PC, confirm what the *real* STT failure was now that the error field carries the traceback — likely CUDA/device config on faster-whisper, given `device: "cuda"`, `compute_type: "float16"`, `model_path: ""` in the ai_config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)