### PR TITLE
feat(compare): clickable lexeme detail panel — notes, tags, play, spectrogram

### DIFF
--- a/python/lexeme_notes.py
+++ b/python/lexeme_notes.py
@@ -1,0 +1,181 @@
+"""Parse Adobe Audition marker CSV exports into per-lexeme import notes.
+
+Audition exports marker files as tab-separated values despite the `.csv` extension.
+Expected columns: Name, Start, Duration, Time Format, Type, Description.
+
+The `Name` column embeds both the concept id (e.g. "(1.1)") and any analyst
+comment tacked onto the label, like:
+
+    (1.1)- hair
+    (2.3)- father (vocative) B short word , but it is mostly used by childern
+
+This module extracts (concept_id, start_sec, end_sec, note_text) tuples for
+import into parse-enrichments.json under `lexeme_notes`.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence
+
+
+# Match a leading "(1.1)" / "(2.3)" / "(7)" style concept id prefix.
+_ID_PATTERN = re.compile(r"^\s*\(\s*([0-9]+(?:\.[0-9]+)*)\s*\)\s*[-\u2013\u2014:]?\s*(.*)$")
+
+
+@dataclass
+class CommentRow:
+    concept_id: str
+    start_sec: float
+    duration_sec: float
+    raw_name: str
+    remainder: str  # text after "(id)- " — may include the concept label + comment
+
+    @property
+    def end_sec(self) -> float:
+        return self.start_sec + self.duration_sec
+
+
+def _parse_time(value: str) -> Optional[float]:
+    """Accept '0:30.105', '1:25.396', '12:03', or plain seconds like '30.105'."""
+    text = (value or "").strip()
+    if not text:
+        return None
+    parts = text.split(":")
+    try:
+        if len(parts) == 1:
+            return float(parts[0])
+        if len(parts) == 2:
+            minutes = int(parts[0])
+            seconds = float(parts[1])
+            return minutes * 60 + seconds
+        if len(parts) == 3:
+            hours = int(parts[0])
+            minutes = int(parts[1])
+            seconds = float(parts[2])
+            return hours * 3600 + minutes * 60 + seconds
+    except ValueError:
+        return None
+    return None
+
+
+def _strip_bom(text: str) -> str:
+    if text.startswith("\ufeff"):
+        return text[1:]
+    return text
+
+
+def parse_audition_csv(text: str) -> List[CommentRow]:
+    """Parse an Audition marker CSV (tab or comma separated) into CommentRows."""
+    raw = _strip_bom(text or "")
+    if not raw.strip():
+        return []
+
+    # Audition exports are tab-separated; sniff to stay tolerant.
+    dialect = None
+    try:
+        dialect = csv.Sniffer().sniff(raw[:4096], delimiters="\t,;")
+    except csv.Error:
+        pass
+
+    reader = csv.DictReader(io.StringIO(raw), dialect=dialect) if dialect else csv.DictReader(io.StringIO(raw), delimiter="\t")
+
+    rows: List[CommentRow] = []
+    for record in reader:
+        if not record:
+            continue
+        name = (record.get("Name") or record.get("name") or "").strip()
+        start_raw = record.get("Start") or record.get("start") or ""
+        duration_raw = record.get("Duration") or record.get("duration") or "0"
+        if not name:
+            continue
+
+        match = _ID_PATTERN.match(name)
+        if not match:
+            continue
+
+        concept_id = match.group(1).strip()
+        remainder = match.group(2).strip()
+        start_sec = _parse_time(start_raw) or 0.0
+        duration_sec = _parse_time(duration_raw) or 0.0
+
+        rows.append(
+            CommentRow(
+                concept_id=concept_id,
+                start_sec=start_sec,
+                duration_sec=duration_sec,
+                raw_name=name,
+                remainder=remainder,
+            )
+        )
+
+    return rows
+
+
+def _strip_known_label(remainder: str, label: str) -> str:
+    """If remainder starts with the concept label, strip it and return the rest."""
+    if not label:
+        return remainder.strip()
+    label_norm = label.strip().lower()
+    rem_norm = remainder.strip().lower()
+    if rem_norm.startswith(label_norm):
+        tail = remainder.strip()[len(label):].strip()
+        # Drop connector punctuation after the label.
+        while tail.startswith((":", "-", "\u2013", "\u2014", ",")):
+            tail = tail[1:].strip()
+        return tail
+    return remainder.strip()
+
+
+def match_rows_to_lexemes(
+    rows: Sequence[CommentRow],
+    lexeme_intervals: Iterable[dict],
+    concept_labels: Optional[dict] = None,
+    tolerance_sec: float = 0.5,
+) -> List[dict]:
+    """Align CSV rows to actual lexeme intervals.
+
+    Each `lexeme_intervals` entry: {"concept_id": str, "start": float, "end": float}
+    Returns entries: {"concept_id", "note", "matched_start", "csv_start"}.
+
+    Matching strategy:
+      1. Prefer rows whose concept_id matches a lexeme concept_id.
+      2. Among matches, prefer the lexeme whose start is closest to CSV start.
+      3. If no concept_id match, fall back to nearest-time match within tolerance.
+    """
+    lexemes = [dict(lx) for lx in lexeme_intervals]
+    results: List[dict] = []
+
+    for row in rows:
+        label = ""
+        if concept_labels and row.concept_id in concept_labels:
+            label = str(concept_labels[row.concept_id] or "")
+        note_text = _strip_known_label(row.remainder, label)
+
+        by_id = [lx for lx in lexemes if lx.get("concept_id") == row.concept_id]
+        chosen: Optional[dict] = None
+
+        if by_id:
+            chosen = min(by_id, key=lambda lx: abs(float(lx.get("start") or 0.0) - row.start_sec))
+        else:
+            candidates = [
+                lx for lx in lexemes
+                if abs(float(lx.get("start") or 0.0) - row.start_sec) <= tolerance_sec
+            ]
+            if candidates:
+                chosen = min(candidates, key=lambda lx: abs(float(lx.get("start") or 0.0) - row.start_sec))
+
+        results.append({
+            "concept_id": (chosen.get("concept_id") if chosen else row.concept_id) or row.concept_id,
+            "note": note_text,
+            "raw_name": row.raw_name,
+            "matched_start": chosen.get("start") if chosen else None,
+            "csv_start": row.start_sec,
+            "csv_duration": row.duration_sec,
+            "was_matched": chosen is not None,
+        })
+
+    return results

--- a/python/server.py
+++ b/python/server.py
@@ -3145,6 +3145,247 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         _write_json_file(_enrichments_path(), enrichments_payload)
         self._send_json(HTTPStatus.OK, {"success": True})
 
+    # ── Lexeme notes (per speaker + concept) ────────────────────────
+
+    def _api_post_lexeme_note(self) -> None:
+        """Write a single lexeme-level note into parse-enrichments.json."""
+        body = self._expect_object(self._read_json_body(required=True), "Request body")
+        speaker_raw = str(body.get("speaker") or "").strip()
+        concept_id = _normalize_concept_id(body.get("concept_id"))
+        if not speaker_raw or not concept_id:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "speaker and concept_id are required")
+        try:
+            speaker = _normalize_speaker_id(speaker_raw)
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc))
+
+        payload = _read_json_file(_enrichments_path(), _default_enrichments_payload())
+        notes_block = payload.get("lexeme_notes")
+        if not isinstance(notes_block, dict):
+            notes_block = {}
+            payload["lexeme_notes"] = notes_block
+        speaker_block = notes_block.get(speaker)
+        if not isinstance(speaker_block, dict):
+            speaker_block = {}
+            notes_block[speaker] = speaker_block
+
+        if body.get("delete") is True:
+            speaker_block.pop(concept_id, None)
+            if not speaker_block:
+                notes_block.pop(speaker, None)
+        else:
+            entry = speaker_block.get(concept_id)
+            if not isinstance(entry, dict):
+                entry = {}
+            if "user_note" in body:
+                entry["user_note"] = str(body.get("user_note") or "")
+            if "import_note" in body:
+                entry["import_note"] = str(body.get("import_note") or "")
+            entry["updated_at"] = _utc_now_iso()
+            speaker_block[concept_id] = entry
+
+        _write_json_file(_enrichments_path(), payload)
+        self._send_json(HTTPStatus.OK, {
+            "success": True,
+            "lexeme_notes": payload.get("lexeme_notes") or {},
+        })
+
+    def _api_post_lexeme_notes_import(self) -> None:
+        """Multipart POST — parse Audition comments CSV into lexeme_notes."""
+        from lexeme_notes import parse_audition_csv, match_rows_to_lexemes
+
+        content_type = self.headers.get("Content-Type", "")
+        if "multipart/form-data" not in content_type:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "Content-Type must be multipart/form-data")
+
+        raw_length = self.headers.get("Content-Length", "")
+        try:
+            content_length = int(raw_length)
+        except (ValueError, TypeError):
+            raise ApiError(HTTPStatus.BAD_REQUEST, "Content-Length header is required")
+        if content_length > ONBOARD_MAX_UPLOAD_BYTES:
+            raise ApiError(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Upload exceeds limit")
+
+        environ = {
+            "REQUEST_METHOD": "POST",
+            "CONTENT_TYPE": content_type,
+            "CONTENT_LENGTH": str(content_length),
+        }
+        form = cgi.FieldStorage(
+            fp=self.rfile, headers=self.headers, environ=environ, keep_blank_values=True,
+        )
+
+        speaker_field = form.getfirst("speaker_id", "") if "speaker_id" in form else ""
+        if isinstance(speaker_field, bytes):
+            speaker_field = speaker_field.decode("utf-8", errors="replace")
+        try:
+            speaker = _normalize_speaker_id(str(speaker_field or "").strip())
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc))
+
+        csv_item = form["csv"] if "csv" in form else None
+        if csv_item is None or not getattr(csv_item, "filename", None):
+            raise ApiError(HTTPStatus.BAD_REQUEST, "csv file is required (field name: csv)")
+        try:
+            csv_text = csv_item.file.read().decode("utf-8-sig")
+        except UnicodeDecodeError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "csv must be UTF-8: {0}".format(exc))
+
+        rows = parse_audition_csv(csv_text)
+        if not rows:
+            self._send_json(HTTPStatus.OK, {
+                "success": True, "imported": 0, "matched": 0, "total_rows": 0,
+            })
+            return
+
+        annotation_path = _annotation_read_path_for_speaker(speaker)
+        annotation_payload = _read_json_any_file(annotation_path)
+        normalized = _normalize_annotation_record(annotation_payload, speaker)
+        tiers = normalized.get("tiers") or {}
+        concept_tier = tiers.get("concept") if isinstance(tiers, dict) else None
+        intervals: List[Dict[str, Any]] = []
+        if isinstance(concept_tier, dict):
+            for iv in concept_tier.get("intervals") or []:
+                if not isinstance(iv, dict):
+                    continue
+                cid = _normalize_concept_id(iv.get("text"))
+                if not cid:
+                    continue
+                try:
+                    start = float(iv.get("start") or 0.0)
+                    end = float(iv.get("end") or 0.0)
+                except (TypeError, ValueError):
+                    continue
+                intervals.append({"concept_id": cid, "start": start, "end": end})
+
+        concept_labels: Dict[str, str] = {}
+        try:
+            import csv as _csv
+            concepts_path = _project_root() / "concepts.csv"
+            if concepts_path.exists():
+                with open(concepts_path, newline="", encoding="utf-8") as fh:
+                    for row in _csv.DictReader(fh):
+                        cid = _normalize_concept_id(row.get("id"))
+                        label = str(row.get("concept_en") or "").strip()
+                        if cid and label:
+                            concept_labels[cid] = label
+        except Exception:
+            concept_labels = {}
+
+        matches = match_rows_to_lexemes(rows, intervals, concept_labels=concept_labels)
+
+        payload = _read_json_file(_enrichments_path(), _default_enrichments_payload())
+        notes_block = payload.get("lexeme_notes")
+        if not isinstance(notes_block, dict):
+            notes_block = {}
+            payload["lexeme_notes"] = notes_block
+        speaker_block = notes_block.get(speaker)
+        if not isinstance(speaker_block, dict):
+            speaker_block = {}
+            notes_block[speaker] = speaker_block
+
+        imported = 0
+        for match in matches:
+            note_text = str(match.get("note") or "").strip()
+            if not note_text:
+                continue
+            cid = _normalize_concept_id(match.get("concept_id"))
+            if not cid:
+                continue
+            entry = speaker_block.get(cid)
+            if not isinstance(entry, dict):
+                entry = {}
+            entry["import_note"] = note_text
+            entry["import_raw"] = str(match.get("raw_name") or "")
+            entry["updated_at"] = _utc_now_iso()
+            speaker_block[cid] = entry
+            imported += 1
+
+        _write_json_file(_enrichments_path(), payload)
+
+        self._send_json(HTTPStatus.OK, {
+            "success": True,
+            "speaker": speaker,
+            "total_rows": len(rows),
+            "imported": imported,
+            "matched": sum(1 for m in matches if m.get("was_matched")),
+            "lexeme_notes": payload.get("lexeme_notes") or {},
+        })
+
+    # ── Spectrogram (shared cache) ───────────────────────────────────
+
+    def _api_get_spectrogram(self) -> None:
+        """Return (or generate) a PNG spectrogram for a clip; cached on disk."""
+        import spectrograms as spectro_module
+        from urllib.parse import parse_qs
+
+        query = urlparse(self.path).query
+        params = {k: v[0] for k, v in parse_qs(query).items() if v}
+
+        speaker_raw = str(params.get("speaker") or "").strip()
+        if not speaker_raw:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "speaker is required")
+        try:
+            speaker = _normalize_speaker_id(speaker_raw)
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc))
+
+        try:
+            start_sec = float(params.get("start") or 0.0)
+            end_sec = float(params.get("end") or 0.0)
+        except ValueError:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "start and end must be numbers")
+        if end_sec <= start_sec:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "end must be greater than start")
+
+        audio_hint = str(params.get("audio") or "").strip()
+        audio_path: Optional[pathlib.Path] = None
+        if audio_hint:
+            try:
+                audio_path = _resolve_project_path(audio_hint)
+            except ValueError as exc:
+                raise ApiError(HTTPStatus.BAD_REQUEST, str(exc))
+        else:
+            working_candidate = _project_root() / "audio" / "working" / speaker
+            if working_candidate.is_dir():
+                for candidate in sorted(working_candidate.iterdir()):
+                    if candidate.is_file() and candidate.suffix.lower() in {".wav", ".flac"}:
+                        audio_path = candidate
+                        break
+            if audio_path is None:
+                primary = _annotation_primary_source_wav(speaker)
+                if primary:
+                    try:
+                        audio_path = _resolve_project_path(primary)
+                    except ValueError as exc:
+                        raise ApiError(HTTPStatus.BAD_REQUEST, str(exc))
+
+        if audio_path is None or not pathlib.Path(audio_path).is_file():
+            raise ApiError(HTTPStatus.NOT_FOUND, "No audio file resolved for speaker {0}".format(speaker))
+
+        cache_file = spectro_module.cache_path(_project_root(), speaker, start_sec, end_sec)
+        force = str(params.get("force") or "").strip().lower() in {"1", "true", "yes"}
+
+        try:
+            spectro_module.generate_spectrogram_png(
+                pathlib.Path(audio_path), start_sec, end_sec, cache_file, force=force,
+            )
+        except Exception as exc:
+            raise ApiError(HTTPStatus.INTERNAL_SERVER_ERROR, "spectrogram render failed: {0}".format(exc))
+
+        png_bytes = cache_file.read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "image/png")
+        self.send_header("Content-Length", str(len(png_bytes)))
+        self.send_header("Cache-Control", "public, max-age=3600")
+        for key, value in CORS_HEADERS.items():
+            self.send_header(key, value)
+        self.end_headers()
+        try:
+            self.wfile.write(png_bytes)
+        except BrokenPipeError:
+            pass
+
     # ── Auth endpoints ──────────────────────────────────────────────
 
     def _api_auth_key(self) -> None:

--- a/python/spectrograms.py
+++ b/python/spectrograms.py
@@ -1,0 +1,182 @@
+"""On-demand spectrogram PNG generator with per-clip file cache.
+
+Given a speaker + time window, renders a grayscale STFT spectrogram PNG and
+caches it at ``spectrograms/<speaker>/<start_ms>_<end_ms>.png`` so that both
+the Annotate and Compare views load the same file for the same clip.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+import zlib
+from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
+import soundfile as sf
+
+
+DEFAULT_WINDOW_SIZE = 2048
+DEFAULT_OVERLAP = 0.75
+DEFAULT_MAX_FREQ = 8000.0
+DEFAULT_IMAGE_HEIGHT = 256
+
+
+def _load_segment(audio_path: Path, start_sec: float, end_sec: float) -> Tuple[np.ndarray, int]:
+    """Read [start_sec, end_sec] from audio_path as mono float32."""
+    with sf.SoundFile(str(audio_path), mode="r") as fh:
+        sample_rate = fh.samplerate
+        total_frames = len(fh)
+        start_frame = max(0, int(round(start_sec * sample_rate)))
+        end_frame = min(total_frames, int(round(end_sec * sample_rate)))
+        if end_frame <= start_frame:
+            return np.zeros(0, dtype=np.float32), sample_rate
+        fh.seek(start_frame)
+        data = fh.read(end_frame - start_frame, dtype="float32", always_2d=True)
+    if data.ndim == 2 and data.shape[1] > 1:
+        mono = data.mean(axis=1)
+    else:
+        mono = data[:, 0] if data.ndim == 2 else data
+    return mono.astype(np.float32, copy=False), sample_rate
+
+
+def _compute_spectrogram(
+    samples: np.ndarray,
+    sample_rate: int,
+    window_size: int,
+    overlap: float,
+    max_freq: float,
+) -> np.ndarray:
+    """Compute a magnitude STFT and clip to ``max_freq`` Hz.
+
+    Returns a 2-D array of shape (freq_bins, time_frames), values in [0, 1].
+    """
+    if samples.size == 0:
+        return np.zeros((1, 1), dtype=np.float32)
+
+    hop = max(1, int(window_size * (1.0 - overlap)))
+    window = np.hanning(window_size).astype(np.float32)
+
+    if samples.size < window_size:
+        padded = np.zeros(window_size, dtype=np.float32)
+        padded[: samples.size] = samples
+        samples = padded
+
+    num_frames = 1 + (samples.size - window_size) // hop
+    if num_frames <= 0:
+        num_frames = 1
+
+    spec = np.zeros((window_size // 2 + 1, num_frames), dtype=np.float32)
+    for i in range(num_frames):
+        offset = i * hop
+        frame = samples[offset : offset + window_size]
+        if frame.size < window_size:
+            buf = np.zeros(window_size, dtype=np.float32)
+            buf[: frame.size] = frame
+            frame = buf
+        spectrum = np.fft.rfft(frame * window)
+        spec[:, i] = np.abs(spectrum).astype(np.float32)
+
+    nyquist = sample_rate / 2.0
+    if nyquist > 0 and max_freq < nyquist:
+        cutoff = int(round(spec.shape[0] * (max_freq / nyquist)))
+        cutoff = max(1, min(spec.shape[0], cutoff))
+        spec = spec[:cutoff, :]
+
+    # Convert to dB and normalize to [0, 1].
+    spec_db = 20.0 * np.log10(spec + 1e-6)
+    lo = float(np.percentile(spec_db, 5))
+    hi = float(np.percentile(spec_db, 99))
+    if hi - lo < 1e-3:
+        hi = lo + 1.0
+    norm = np.clip((spec_db - lo) / (hi - lo), 0.0, 1.0)
+    return norm.astype(np.float32)
+
+
+def _render_to_image(spec: np.ndarray, height: int) -> np.ndarray:
+    """Flip + resize (freq_bins, frames) → (height, width) grayscale uint8.
+
+    Higher frequencies on top, time flows left→right. Values inverted so that
+    loud regions render dark on a light background (matches Praat conventions).
+    """
+    if spec.size == 0:
+        return np.full((height, 1), 255, dtype=np.uint8)
+
+    # Flip freq axis so high frequencies sit at the top of the image.
+    spec = spec[::-1, :]
+    freq_bins, frames = spec.shape
+
+    # Linearly resample frequency axis to `height` rows.
+    if freq_bins == height:
+        resized = spec
+    else:
+        src_idx = np.linspace(0, freq_bins - 1, height).astype(np.int32)
+        resized = spec[src_idx, :]
+
+    # Time axis: keep native frame count, but cap at a sensible max width.
+    max_width = max(64, frames)
+    if frames > max_width:
+        dst_idx = np.linspace(0, frames - 1, max_width).astype(np.int32)
+        resized = resized[:, dst_idx]
+
+    # Invert so that high-energy (1.0) → dark (0), low energy → light (255).
+    inverted = 1.0 - resized
+    return np.clip(inverted * 255.0, 0, 255).astype(np.uint8)
+
+
+def _encode_png_grayscale(image: np.ndarray) -> bytes:
+    """Encode a 2-D uint8 array as a grayscale PNG with zero external deps."""
+    if image.ndim != 2:
+        raise ValueError("image must be 2-D grayscale")
+    height, width = image.shape
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        length = struct.pack(">I", len(data))
+        crc = struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        return length + tag + data + crc
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 0, 0, 0, 0)  # 8-bit grayscale
+
+    # Each scanline prefixed with filter byte 0 (None).
+    raw = bytearray()
+    for row in image:
+        raw.append(0)
+        raw.extend(row.tobytes())
+    idat = zlib.compress(bytes(raw), level=6)
+
+    return signature + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+def cache_path(project_root: Path, speaker: str, start_sec: float, end_sec: float) -> Path:
+    start_ms = int(round(start_sec * 1000))
+    end_ms = int(round(end_sec * 1000))
+    safe_speaker = "".join(c for c in speaker if c.isalnum() or c in ("-", "_"))
+    return project_root / "spectrograms" / safe_speaker / f"{start_ms}_{end_ms}.png"
+
+
+def generate_spectrogram_png(
+    audio_path: Path,
+    start_sec: float,
+    end_sec: float,
+    cache_file: Path,
+    *,
+    window_size: int = DEFAULT_WINDOW_SIZE,
+    overlap: float = DEFAULT_OVERLAP,
+    max_freq: float = DEFAULT_MAX_FREQ,
+    image_height: int = DEFAULT_IMAGE_HEIGHT,
+    force: bool = False,
+) -> Path:
+    """Compute the spectrogram (or reuse cache) and return the PNG path."""
+    if not force and cache_file.is_file() and cache_file.stat().st_size > 0:
+        return cache_file
+
+    samples, sample_rate = _load_segment(audio_path, max(0.0, start_sec), max(start_sec, end_sec))
+    spec = _compute_spectrogram(samples, sample_rate, window_size, overlap, max_freq)
+    image = _render_to_image(spec, image_height)
+    png_bytes = _encode_png_grayscale(image)
+
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_bytes(png_bytes)
+    return cache_file

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -402,6 +402,12 @@ describe("ParseUI", () => {
     expect(screen.queryByRole("button", { name: "Manage Tags" })).toBeNull();
   });
 
+  it("renders a visible hotkey hint in the top bar", () => {
+    render(<ParseUI />);
+
+    expect(screen.getByText(/A Annotate · C Compare · T Tags · ←\/↑ Prev · →\/↓ Next/i)).toBeTruthy();
+  });
+
   it("supports app-mode hotkeys a/c/t", async () => {
     render(<ParseUI />);
 

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -174,7 +174,7 @@ function makeRecord(
 
 async function switchToAnnotateMode() {
   fireEvent.click(screen.getByRole("button", { name: "Compare" }));
-  fireEvent.click(await screen.findByRole("button", { name: "Annotate" }));
+  fireEvent.click(await screen.findByRole("button", { name: /Annotate\s*A/i }));
 }
 
 beforeEach(() => {
@@ -398,14 +398,33 @@ describe("ParseUI", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Compare" }));
 
-    expect(await screen.findByRole("button", { name: "Tags" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: /Tags\s*T/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Manage Tags" })).toBeNull();
   });
 
-  it("renders a visible hotkey hint in the top bar", () => {
+  it("shows PARSE as the top-left title", () => {
     render(<ParseUI />);
 
-    expect(screen.getByText(/A Annotate · C Compare · T Tags · ←\/↑ Prev · →\/↓ Next/i)).toBeTruthy();
+    expect(screen.getByText("PARSE")).toBeTruthy();
+    expect(screen.queryByText("PARSE Compare")).toBeNull();
+  });
+
+  it("shows inline arrow hotkeys on annotate prev/next buttons", async () => {
+    render(<ParseUI />);
+    await switchToAnnotateMode();
+
+    expect(screen.getByRole("button", { name: /←\s*Prev/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Next\s*→/i })).toBeTruthy();
+  });
+
+  it("shows mode hotkeys inside the mode dropdown", async () => {
+    render(<ParseUI />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Compare" }));
+
+    expect(await screen.findByRole("button", { name: /Annotate\s*A/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Compare\s*C/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Tags\s*T/i })).toBeTruthy();
   });
 
   it("supports app-mode hotkeys a/c/t", async () => {

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -393,6 +393,41 @@ describe("ParseUI", () => {
     expect(await screen.findByTestId("speaker-import")).toBeTruthy();
   });
 
+  it("renames the mode menu label to Tags", async () => {
+    render(<ParseUI />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Compare" }));
+
+    expect(await screen.findByRole("button", { name: "Tags" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Manage Tags" })).toBeNull();
+  });
+
+  it("supports app-mode hotkeys a/c/t", async () => {
+    render(<ParseUI />);
+
+    fireEvent.keyDown(window, { key: "a" });
+    expect(await screen.findByRole("button", { name: /Mark Done/i })).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "t" });
+    expect(await screen.findByText("Linguistic tags")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "c" });
+    expect(await screen.findByRole("button", { name: /Accept concept/i })).toBeTruthy();
+  });
+
+  it("uses arrow keys to change concepts in annotate mode", async () => {
+    render(<ParseUI />);
+    await switchToAnnotateMode();
+
+    expect(screen.getByRole("heading", { name: "water" })).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(await screen.findByRole("heading", { name: "fire" })).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "ArrowUp" });
+    expect(await screen.findByRole("heading", { name: "water" })).toBeTruthy();
+  });
+
   it("persists compare notes per concept via localStorage on blur", () => {
     const { unmount } = render(<ParseUI />);
     const notesField = screen.getByPlaceholderText(/Add observations, etymological notes, or questions for review/i);

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -73,6 +73,13 @@ const simBar = (v: number) =>
 const REVIEW_TAG_IDS = new Set(['review', 'review-needed']);
 const COMPARE_NOTES_STORAGE_KEY = 'parseui-compare-notes-v1';
 
+function isInteractiveHotkeyTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const tag = target.tagName.toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select' || tag === 'button') return true;
+  return (target as HTMLElement).isContentEditable;
+}
+
 function overlaps(a: AnnotationInterval, b: AnnotationInterval): boolean {
   return a.start <= b.end && b.start <= a.end;
 }
@@ -1516,6 +1523,7 @@ export function ParseUI() {
   const annotationRecords = useAnnotationStore(s => s.records);
   const enrichmentData = useEnrichmentStore(s => s.data);
   const setActiveSpeakerUI = useUIStore(s => s.setActiveSpeaker);
+  const setActiveConceptUI = useUIStore(s => s.setActiveConcept);
   // — Chat session (one instance for the whole UI) —
   const chatSession = useChatSession();
   // — Annotation sync (auto-loads record when activeSpeaker changes) —
@@ -1826,6 +1834,55 @@ export function ParseUI() {
 
   const goPrev = () => setConceptId(id => Math.max(1, id - 1));
   const goNext = () => setConceptId(id => Math.min(total, id + 1));
+
+  useEffect(() => {
+    setActiveConceptUI(concept.key);
+  }, [concept.key, setActiveConceptUI]);
+
+  useEffect(() => {
+    function onGlobalKeyDown(e: KeyboardEvent) {
+      if (e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isInteractiveHotkeyTarget(e.target)) return;
+
+      const key = e.key.toLowerCase();
+      if (key === 'a') {
+        e.preventDefault();
+        setCurrentMode('annotate');
+        setModeMenuOpen(false);
+        setActionsMenuOpen(false);
+        return;
+      }
+      if (key === 'c') {
+        e.preventDefault();
+        setCurrentMode('compare');
+        setModeMenuOpen(false);
+        setActionsMenuOpen(false);
+        return;
+      }
+      if (key === 't') {
+        e.preventDefault();
+        setCurrentMode('tags');
+        setModeMenuOpen(false);
+        setActionsMenuOpen(false);
+        return;
+      }
+
+      if (currentMode === 'tags' || total <= 1) return;
+
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        goPrev();
+      } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        goNext();
+      }
+    }
+
+    window.addEventListener('keydown', onGlobalKeyDown);
+    return () => window.removeEventListener('keydown', onGlobalKeyDown);
+  }, [currentMode, total, setActiveConceptUI]);
+
   const toggleSpeaker = (s: string) => {
     if (currentMode === 'annotate') {
       setSelectedSpeakers([s]);
@@ -1901,7 +1958,7 @@ export function ParseUI() {
                 onClick={() => { setModeMenuOpen(v => !v); setActionsMenuOpen(false); }}
                 className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
               >
-                {currentMode === 'annotate' ? 'Annotate' : currentMode === 'compare' ? 'Compare' : 'Manage Tags'}
+                {currentMode === 'annotate' ? 'Annotate' : currentMode === 'compare' ? 'Compare' : 'Tags'}
                 <CDown className="h-3 w-3 text-slate-400"/>
               </button>
               {modeMenuOpen && (
@@ -1911,7 +1968,7 @@ export function ParseUI() {
                     {([
                       ['annotate','Annotate', Type],
                       ['compare','Compare', Layers],
-                      ['tags','Manage Tags', Tags],
+                      ['tags','Tags', Tags],
                     ] as const).map(([key,label,Icon]) => (
                       <button
                         key={key}

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1936,6 +1936,9 @@ export function ParseUI() {
               <div className="h-1.5 w-32 overflow-hidden rounded-full bg-slate-100">
                 <div className="h-full rounded-full bg-gradient-to-r from-indigo-500 to-violet-500" style={{ width: `${(reviewed/total)*100}%` }}/>
               </div>
+              <div className="hidden rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[10px] font-medium text-slate-500 lg:block">
+                A Annotate · C Compare · T Tags · ←/↑ Prev · →/↓ Next
+              </div>
             </div>
           </div>
 

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1292,8 +1292,12 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
       <section className="px-8 pt-6">
         <div className="mx-auto max-w-4xl">
           <div className="flex items-center gap-3">
-            <button onClick={onPrev} className="grid h-9 w-9 place-items-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:text-slate-800">
-              <ChevronLeft className="h-4 w-4"/>
+            <button
+              onClick={onPrev}
+              className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 text-[12px] font-semibold text-slate-500 hover:text-slate-800"
+            >
+              <span>←</span>
+              <span>Prev</span>
             </button>
             <div className="flex-1">
               <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wider text-slate-400">
@@ -1319,8 +1323,12 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
                 <span className="text-slate-500">{speaker}.wav</span>
               </div>
             </div>
-            <button onClick={onNext} className="grid h-9 w-9 place-items-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:text-slate-800">
-              <ChevronRight className="h-4 w-4"/>
+            <button
+              onClick={onNext}
+              className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 text-[12px] font-semibold text-slate-500 hover:text-slate-800"
+            >
+              <span>Next</span>
+              <span>→</span>
             </button>
           </div>
         </div>
@@ -1929,15 +1937,12 @@ export function ParseUI() {
               <div className="grid h-7 w-7 place-items-center rounded-md bg-gradient-to-br from-indigo-500 to-violet-600 text-white shadow-sm">
                 <Layers className="h-4 w-4" />
               </div>
-              <span className="text-[15px] font-semibold tracking-tight text-slate-900">PARSE Compare</span>
+              <span className="text-[15px] font-semibold tracking-tight text-slate-900">PARSE</span>
             </div>
             <div className="hidden items-center gap-3 md:flex">
               <div className="text-[11px] font-medium text-slate-500 tabular-nums">{reviewed} / {total} reviewed</div>
               <div className="h-1.5 w-32 overflow-hidden rounded-full bg-slate-100">
                 <div className="h-full rounded-full bg-gradient-to-r from-indigo-500 to-violet-500" style={{ width: `${(reviewed/total)*100}%` }}/>
-              </div>
-              <div className="hidden rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[10px] font-medium text-slate-500 lg:block">
-                A Annotate · C Compare · T Tags · ←/↑ Prev · →/↓ Next
               </div>
             </div>
           </div>
@@ -1969,10 +1974,10 @@ export function ParseUI() {
                   <div className="fixed inset-0 z-30" onClick={() => setModeMenuOpen(false)}/>
                   <div className="absolute right-0 z-[60] mt-1.5 w-48 overflow-hidden rounded-lg border border-slate-200 bg-white p-1 shadow-lg">
                     {([
-                      ['annotate','Annotate', Type],
-                      ['compare','Compare', Layers],
-                      ['tags','Tags', Tags],
-                    ] as const).map(([key,label,Icon]) => (
+                      ['annotate','Annotate', 'A', Type],
+                      ['compare','Compare', 'C', Layers],
+                      ['tags','Tags', 'T', Tags],
+                    ] as const).map(([key,label,hotkey,Icon]) => (
                       <button
                         key={key}
                         onClick={() => { setCurrentMode(key); setModeMenuOpen(false); }}
@@ -1980,6 +1985,7 @@ export function ParseUI() {
                       >
                         <Icon className="h-3.5 w-3.5 text-slate-400"/>
                         <span className="flex-1">{label}</span>
+                        <span className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">{hotkey}</span>
                         {currentMode===key && <Check className="h-3.5 w-3.5 text-indigo-600"/>}
                       </button>
                     ))}

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -28,6 +28,8 @@ import { useTagStore } from './stores/tagStore';
 import { useUIStore } from './stores/uiStore';
 import { Modal } from './components/shared/Modal';
 import { ChatMarkdown } from './components/shared/ChatMarkdown';
+import { LexemeDetail } from './components/compare/LexemeDetail';
+import { CommentsImport } from './components/compare/CommentsImport';
 import { SpeakerImport } from './components/compare/SpeakerImport';
 
 type TagState = 'all' | 'untagged' | 'review' | 'confirmed' | 'problematic';
@@ -51,9 +53,10 @@ interface Concept {
 type ConceptSortMode = 'az' | '1n' | 'survey';
 
 interface SpeakerForm {
-  speaker: string; ipa: string; utterances: number;
+  speaker: string; ipa: string; ortho: string; utterances: number;
   arabicSim: number; persianSim: number;
   cognate: 'A' | 'B' | 'C' | '—'; flagged: boolean;
+  startSec: number | null; endSec: number | null;
 }
 
 // No fallback data — workspace must supply real speakers and concepts via /api/config.
@@ -152,14 +155,23 @@ function buildSpeakerForm(
     }
   }
 
+  const primaryConceptInterval = conceptIntervals[0] ?? null;
+  const orthoIntervals = record?.tiers.ortho?.intervals ?? [];
+  const matchingOrthoIntervals = orthoIntervals.filter((orthoInterval) =>
+    conceptIntervals.some((conceptInterval) => overlaps(orthoInterval, conceptInterval)),
+  );
+
   return {
     speaker,
     ipa: matchingIpaIntervals[0]?.text ?? '',
+    ortho: matchingOrthoIntervals[0]?.text ?? '',
     utterances: matchingIpaIntervals.length,
     arabicSim,
     persianSim,
     cognate,
     flagged,
+    startSec: primaryConceptInterval ? primaryConceptInterval.start : null,
+    endSec: primaryConceptInterval ? primaryConceptInterval.end : null,
   };
 }
 
@@ -1529,6 +1541,17 @@ export function ParseUI() {
   const [notes, setNotes] = useState('');
   const [borrowingsOpen, setBorrowingsOpen] = useState(true);
   const [panelOpen, setPanelOpen] = useState(true);
+  const [expandedLexemes, setExpandedLexemes] = useState<Set<string>>(new Set());
+  const [commentsImportOpen, setCommentsImportOpen] = useState(false);
+
+  const toggleLexemeExpanded = (speaker: string) => {
+    setExpandedLexemes((prev) => {
+      const next = new Set(prev);
+      if (next.has(speaker)) next.delete(speaker);
+      else next.add(speaker);
+      return next;
+    });
+  };
 
   // Auto-select speakers when config loads and we have none selected
   useEffect(() => {
@@ -2267,11 +2290,34 @@ export function ParseUI() {
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-100">
-                      {speakerForms.map(f => (
-                        <tr key={f.speaker} className="bg-white transition hover:bg-indigo-50/30">
+                      {speakerForms.map(f => {
+                        const isExpanded = expandedLexemes.has(f.speaker);
+                        const cognateColor =
+                          f.cognate === 'A' ? '#dcfce7' :
+                          f.cognate === 'B' ? '#dbeafe' :
+                          f.cognate === 'C' ? '#fef9c3' :
+                          null;
+                        return (
+                        <React.Fragment key={f.speaker}>
+                        <tr
+                          data-testid={`speaker-row-${f.speaker}`}
+                          className={`bg-white transition hover:bg-indigo-50/30 ${isExpanded ? 'bg-indigo-50/40' : ''}`}
+                        >
                           <td className="px-3 py-2.5 font-mono text-[11px] font-medium text-slate-700">{f.speaker}</td>
                           <td className="px-3 py-2.5">
-                            <div className="font-mono text-[13px] text-slate-800">/{f.ipa}/</div>
+                            <div className="flex items-center gap-2">
+                              <button
+                                data-testid={`lexeme-toggle-${f.speaker}`}
+                                onClick={() => toggleLexemeExpanded(f.speaker)}
+                                className="font-mono text-[13px] text-indigo-700 underline-offset-2 hover:underline"
+                                title="Click to expand lexeme details"
+                              >
+                                /{f.ipa || '—'}/
+                              </button>
+                              <ChevronDown
+                                className={`h-3 w-3 text-slate-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                              />
+                            </div>
                             <div className="text-[10px] text-slate-400">{f.utterances} utterance{f.utterances!==1?'s':''}</div>
                           </td>
                           <td className="px-3 py-2.5"><SimBar value={f.arabicSim}/></td>
@@ -2294,7 +2340,28 @@ export function ParseUI() {
                             </button>
                           </td>
                         </tr>
-                      ))}
+                        {isExpanded && (
+                          <tr data-testid={`lexeme-detail-row-${f.speaker}`}>
+                            <td colSpan={6} className="bg-slate-50 p-2">
+                              <LexemeDetail
+                                speaker={f.speaker}
+                                conceptId={concept.key}
+                                conceptLabel={concept.name}
+                                ipa={f.ipa}
+                                ortho={f.ortho}
+                                startSec={f.startSec}
+                                endSec={f.endSec}
+                                arabicSim={f.arabicSim}
+                                persianSim={f.persianSim}
+                                cognateGroup={f.cognate !== '—' ? f.cognate : null}
+                                cognateColor={cognateColor}
+                              />
+                            </td>
+                          </tr>
+                        )}
+                        </React.Fragment>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>
@@ -2626,6 +2693,13 @@ export function ParseUI() {
                       <Download className="h-3 w-3"/>
                       {exporting ? 'Exporting…' : 'Export LingPy TSV'}
                     </button>
+                    <button
+                      data-testid="open-comments-import"
+                      onClick={() => setCommentsImportOpen(true)}
+                      className="flex w-full items-center gap-2 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-[11px] font-medium text-slate-700 hover:bg-slate-50"
+                    >
+                      <Upload className="h-3 w-3"/> Import Audition comments
+                    </button>
                   </div>
                 </div>
               </>
@@ -2723,6 +2797,9 @@ export function ParseUI() {
       />
       <Modal open={importModalOpen} onClose={() => setImportModalOpen(false)} title="Import Speaker">
         <SpeakerImport onImportComplete={handleImportComplete} />
+      </Modal>
+      <Modal open={commentsImportOpen} onClose={() => setCommentsImportOpen(false)} title="Import Audition Comments">
+        <CommentsImport onImportComplete={() => setCommentsImportOpen(false)} />
       </Modal>
       <input
         type="file"

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -485,6 +485,73 @@ export async function mergeTags(tags: Tag[]): Promise<{ ok: boolean; tagCount: n
   });
 }
 
+// Lexeme notes
+export interface SaveLexemeNoteBody {
+  speaker: string;
+  concept_id: string;
+  user_note?: string;
+  import_note?: string;
+  delete?: boolean;
+}
+
+export async function saveLexemeNote(
+  body: SaveLexemeNoteBody,
+): Promise<{ success: boolean; lexeme_notes?: Record<string, Record<string, Record<string, unknown>>> }> {
+  return apiFetch<{
+    success: boolean;
+    lexeme_notes?: Record<string, Record<string, Record<string, unknown>>>;
+  }>("/api/lexeme-notes", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export interface ImportCommentsCsvResponse {
+  success: boolean;
+  speaker: string;
+  total_rows: number;
+  imported: number;
+  matched: number;
+  lexeme_notes?: Record<string, Record<string, Record<string, unknown>>>;
+}
+
+export async function importCommentsCsv(
+  speakerId: string,
+  csvFile: File,
+): Promise<ImportCommentsCsvResponse> {
+  const formData = new FormData();
+  formData.append("speaker_id", speakerId);
+  formData.append("csv", csvFile);
+  let response: Response;
+  try {
+    response = await fetch("/api/lexeme-notes/import", { method: "POST", body: formData });
+  } catch (error) {
+    throw networkError("/api/lexeme-notes/import", { method: "POST" }, error);
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`API POST /api/lexeme-notes/import failed ${response.status}: ${text}`);
+  }
+  return response.json() as Promise<ImportCommentsCsvResponse>;
+}
+
+export function spectrogramUrl(params: {
+  speaker: string;
+  startSec: number;
+  endSec: number;
+  audio?: string;
+  force?: boolean;
+}): string {
+  const search = new URLSearchParams({
+    speaker: params.speaker,
+    start: params.startSec.toFixed(3),
+    end: params.endSec.toFixed(3),
+  });
+  if (params.audio) search.set("audio", params.audio);
+  if (params.force) search.set("force", "1");
+  return `/api/spectrogram?${search.toString()}`;
+}
+
 export async function getNEXUSExport(): Promise<Blob> {
   const response = await fetch("/api/export/nexus", {
     method: "GET",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -52,12 +52,27 @@ export interface Tag {
   id: string; // uuid
   label: string;
   color: string; // hex
-  concepts: string[]; // concept ids that carry this tag
+  concepts: string[]; // concept ids that carry this tag (concept-level)
+  /**
+   * Per-lexeme tag targets, each encoded as `${speaker}::${conceptId}`.
+   * A lexeme is the intersection of a concept + speaker; tagging a lexeme
+   * only colours that speaker's form, not the whole concept row.
+   */
+  lexemeTargets?: string[];
 }
 
 export interface TagsResponse {
   tags: Tag[];
 }
+
+export interface LexemeNoteEntry {
+  user_note?: string;
+  import_note?: string;
+  import_raw?: string;
+  updated_at?: string;
+}
+
+export type LexemeNotesBySpeaker = Record<string, Record<string, LexemeNoteEntry>>;
 
 export interface AuthStatus {
   authenticated: boolean;

--- a/src/components/compare/CommentsImport.tsx
+++ b/src/components/compare/CommentsImport.tsx
@@ -1,0 +1,140 @@
+import { useRef, useState } from "react";
+import { Button } from "../shared/Button";
+import { importCommentsCsv } from "../../api/client";
+import { useConfigStore } from "../../stores/configStore";
+import { useEnrichmentStore } from "../../stores/enrichmentStore";
+
+interface CommentsImportProps {
+  onImportComplete?: () => void;
+}
+
+type ImportStatus = "idle" | "uploading" | "done" | "error";
+
+export function CommentsImport({ onImportComplete }: CommentsImportProps) {
+  const config = useConfigStore((s) => s.config);
+  const loadEnrichments = useEnrichmentStore((s) => s.load);
+  const speakers = config?.speakers ?? [];
+
+  const [speakerId, setSpeakerId] = useState<string>(speakers[0] ?? "");
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<ImportStatus>("idle");
+  const [result, setResult] = useState<{ imported: number; matched: number; total: number } | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const csvInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleImport() {
+    if (!speakerId.trim() || !csvFile) return;
+    setStatus("uploading");
+    setErrorMsg(null);
+    setResult(null);
+    try {
+      const resp = await importCommentsCsv(speakerId.trim(), csvFile);
+      setResult({ imported: resp.imported, matched: resp.matched, total: resp.total_rows });
+      setStatus("done");
+      await loadEnrichments().catch(() => {});
+      onImportComplete?.();
+    } catch (err) {
+      setStatus("error");
+      setErrorMsg(err instanceof Error ? err.message : "Import failed");
+    }
+  }
+
+  const canStart = status === "idle" && speakerId.trim().length > 0 && csvFile !== null;
+
+  return (
+    <div data-testid="comments-import" style={{ padding: "1rem", fontFamily: "monospace" }}>
+      <div style={{ fontWeight: 600, fontSize: "1rem", marginBottom: "0.5rem" }}>
+        Import Audition Comments
+      </div>
+      <div style={{ fontSize: "0.75rem", color: "#6b7280", marginBottom: "0.75rem" }}>
+        Parses the Name column (e.g. <code>(2.3)- father (vocative) B short word, used by children</code>)
+        and attaches any trailing comment as the lexeme's import note. Aligns to existing lexeme
+        intervals by concept id, falling back to nearest start time (±500 ms).
+      </div>
+
+      <div style={{ marginBottom: "0.5rem" }}>
+        <label style={{ display: "block", fontSize: "0.75rem", fontWeight: 500, marginBottom: "0.125rem" }}>
+          Speaker
+        </label>
+        {speakers.length > 0 ? (
+          <select
+            value={speakerId}
+            onChange={(e) => setSpeakerId(e.target.value)}
+            disabled={status === "uploading"}
+            style={{
+              width: "100%",
+              border: "1px solid #d1d5db",
+              borderRadius: "0.25rem",
+              padding: "0.375rem 0.625rem",
+              fontSize: "0.875rem",
+              fontFamily: "monospace",
+            }}
+          >
+            {speakers.map((sp) => (
+              <option key={sp} value={sp}>
+                {sp}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <input
+            value={speakerId}
+            onChange={(e) => setSpeakerId(e.target.value)}
+            disabled={status === "uploading"}
+            placeholder="speaker id"
+            style={{
+              width: "100%",
+              border: "1px solid #d1d5db",
+              borderRadius: "0.25rem",
+              padding: "0.375rem 0.625rem",
+              fontSize: "0.875rem",
+              fontFamily: "monospace",
+            }}
+          />
+        )}
+      </div>
+
+      <div style={{ marginBottom: "0.75rem" }}>
+        <label style={{ display: "block", fontSize: "0.75rem", fontWeight: 500, marginBottom: "0.125rem" }}>
+          Comments CSV (tab-separated)
+        </label>
+        <input
+          ref={csvInputRef}
+          data-testid="comments-csv-input"
+          type="file"
+          accept=".csv,.tsv,.txt"
+          disabled={status === "uploading"}
+          onChange={(e) => setCsvFile(e.target.files?.[0] ?? null)}
+          style={{ fontSize: "0.8rem" }}
+        />
+      </div>
+
+      <Button
+        variant="primary"
+        disabled={!canStart}
+        onClick={handleImport}
+        data-testid="start-comments-import-btn"
+      >
+        {status === "uploading" ? "Importing…" : "Import Comments"}
+      </Button>
+
+      {status === "done" && result && (
+        <div
+          data-testid="comments-import-success"
+          style={{ marginTop: "0.75rem", color: "#059669", fontSize: "0.85rem" }}
+        >
+          Imported {result.imported} of {result.total} rows ({result.matched} aligned to existing lexemes).
+        </div>
+      )}
+
+      {status === "error" && errorMsg && (
+        <div
+          data-testid="comments-import-error"
+          style={{ marginTop: "0.75rem", color: "#dc2626", fontSize: "0.85rem" }}
+        >
+          {errorMsg}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/compare/CompareMode.tsx
+++ b/src/components/compare/CompareMode.tsx
@@ -7,6 +7,7 @@ import { BorrowingPanel } from "./BorrowingPanel";
 import { EnrichmentsPanel } from "./EnrichmentsPanel";
 import { TagManager } from "./TagManager";
 import { SpeakerImport } from "./SpeakerImport";
+import { CommentsImport } from "./CommentsImport";
 import { useUIStore } from "../../stores/uiStore";
 import { useEnrichmentStore } from "../../stores/enrichmentStore";
 import { useTagStore } from "../../stores/tagStore";
@@ -30,6 +31,7 @@ export function CompareMode() {
   const hydrateTags = useTagStore((store) => store.hydrate);
 
   const [importOpen, setImportOpen] = useState(false);
+  const [commentsOpen, setCommentsOpen] = useState(false);
   const [showLexemes, setShowLexemes] = useState(false);
 
   useEffect(() => {
@@ -52,6 +54,13 @@ export function CompareMode() {
           style={{ padding: "0.25rem 0.75rem", cursor: "pointer", fontFamily: "monospace" }}
         >
           Import Speaker
+        </button>
+        <button
+          data-testid="open-comments-import"
+          onClick={() => setCommentsOpen(true)}
+          style={{ padding: "0.25rem 0.75rem", cursor: "pointer", fontFamily: "monospace" }}
+        >
+          Import Comments CSV
         </button>
       </TopBar>
 
@@ -132,6 +141,10 @@ export function CompareMode() {
 
       <Modal open={importOpen} onClose={() => setImportOpen(false)} title="Import Speaker">
         <SpeakerImport onImportComplete={() => setImportOpen(false)} />
+      </Modal>
+
+      <Modal open={commentsOpen} onClose={() => setCommentsOpen(false)} title="Import Audition Comments">
+        <CommentsImport onImportComplete={() => setCommentsOpen(false)} />
       </Modal>
     </div>
   );

--- a/src/components/compare/ConceptTable.test.tsx
+++ b/src/components/compare/ConceptTable.test.tsx
@@ -45,6 +45,13 @@ vi.mock("../../stores/tagStore", () => ({
       tags: mockTags,
       getTagsForConcept: (conceptId: string) =>
         mockTags.filter((t) => t.concepts.includes(conceptId)),
+      getTagsForLexeme: (speaker: string, conceptId: string) => {
+        const key = `${speaker}::${conceptId}`;
+        return mockTags.filter((t) => (t.lexemeTargets ?? []).includes(key));
+      },
+      tagLexeme: vi.fn(),
+      untagLexeme: vi.fn(),
+      addTag: vi.fn(),
     }),
 }));
 

--- a/src/components/compare/ConceptTable.tsx
+++ b/src/components/compare/ConceptTable.tsx
@@ -1,9 +1,11 @@
+import { Fragment, useState } from "react";
 import { useConfigStore } from "../../stores/configStore";
 import { useAnnotationStore } from "../../stores/annotationStore";
 import { useUIStore } from "../../stores/uiStore";
 import { useEnrichmentStore } from "../../stores/enrichmentStore";
 import { useTagStore } from "../../stores/tagStore";
 import { Badge } from "../shared/Badge";
+import { LexemeDetail } from "./LexemeDetail";
 
 /* ------------------------------------------------------------------ */
 /*  Local types                                                        */
@@ -152,6 +154,24 @@ function getCognateGroup(
   return null;
 }
 
+function getSimilarity(
+  enrichmentData: Record<string, unknown>,
+  conceptId: string,
+  speaker: string,
+  lang: string,
+): number | null {
+  const block = enrichmentData?.similarity as
+    | Record<string, Record<string, Record<string, { score?: number }>>>
+    | undefined;
+  const entry = block?.[conceptId]?.[speaker]?.[lang];
+  if (entry && typeof entry.score === "number") return entry.score;
+  return null;
+}
+
+function expandKey(speaker: string, conceptId: string): string {
+  return `${speaker}::${conceptId}`;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
@@ -164,6 +184,19 @@ export function ConceptTable({ onPlayEntry }: ConceptTableProps) {
   const setActiveConcept = useUIStore((s) => s.setActiveConcept);
   const enrichmentData = useEnrichmentStore((s) => s.data);
   const getTagsForConcept = useTagStore((s) => s.getTagsForConcept);
+  const getTagsForLexeme = useTagStore((s) => s.getTagsForLexeme);
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  function toggleExpanded(speaker: string, conceptId: string) {
+    const key = expandKey(speaker, conceptId);
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
 
   const concepts = parseConcepts(
     (config as Record<string, unknown> | null)?.concepts,
@@ -180,6 +213,8 @@ export function ConceptTable({ onPlayEntry }: ConceptTableProps) {
       </div>
     );
   }
+
+  const totalCols = 1 + speakers.length;
 
   return (
     <div style={{ fontFamily: "monospace", overflowX: "auto" }}>
@@ -220,121 +255,192 @@ export function ConceptTable({ onPlayEntry }: ConceptTableProps) {
         <tbody>
           {concepts.map((concept, idx) => {
             const isActive = activeConcept === concept.id;
-            const tags = getTagsForConcept(concept.id);
+            const conceptTags = getTagsForConcept(concept.id);
+            const expandedSpeakers = speakers.filter((sp) =>
+              expanded.has(expandKey(sp, concept.id)),
+            );
 
             return (
-              <tr
-                key={concept.id}
-                data-testid={`concept-row-${concept.id}`}
-                onClick={() => setActiveConcept(concept.id)}
-                style={{
-                  cursor: "pointer",
-                  background: isActive ? "#eff6ff" : undefined,
-                  borderLeft: isActive
-                    ? "3px solid #3b82f6"
-                    : "3px solid transparent",
-                }}
-              >
-                <td
+              <Fragment key={concept.id}>
+                <tr
+                  data-testid={`concept-row-${concept.id}`}
+                  onClick={() => setActiveConcept(concept.id)}
                   style={{
-                    padding: "0.5rem",
-                    borderBottom: "1px solid #f3f4f6",
-                    verticalAlign: "top",
+                    cursor: "pointer",
+                    background: isActive ? "#eff6ff" : undefined,
+                    borderLeft: isActive
+                      ? "3px solid #3b82f6"
+                      : "3px solid transparent",
                   }}
                 >
-                  <div>
-                    #{idx + 1} {concept.label}
-                  </div>
-                  {tags.length > 0 && (
-                    <div style={{ marginTop: "0.25rem", display: "flex", gap: "0.25rem", flexWrap: "wrap" }}>
-                      {tags.map((tag) => (
-                        <Badge key={tag.id} label={tag.label} color={tag.color} />
-                      ))}
+                  <td
+                    style={{
+                      padding: "0.5rem",
+                      borderBottom: "1px solid #f3f4f6",
+                      verticalAlign: "top",
+                    }}
+                  >
+                    <div>
+                      #{idx + 1} {concept.label}
                     </div>
-                  )}
-                </td>
-                {speakers.map((sp) => {
-                  const entry = lookupEntry(records, sp, concept.id);
-                  const cognate = getCognateGroup(
-                    enrichmentData,
-                    concept.id,
-                    sp,
-                  );
-                  const hasForm = entry.ipa || entry.ortho;
+                    {conceptTags.length > 0 && (
+                      <div style={{ marginTop: "0.25rem", display: "flex", gap: "0.25rem", flexWrap: "wrap" }}>
+                        {conceptTags.map((tag) => (
+                          <Badge key={tag.id} label={tag.label} color={tag.color} />
+                        ))}
+                      </div>
+                    )}
+                  </td>
+                  {speakers.map((sp) => {
+                    const entry = lookupEntry(records, sp, concept.id);
+                    const cognate = getCognateGroup(
+                      enrichmentData,
+                      concept.id,
+                      sp,
+                    );
+                    const hasForm = entry.ipa || entry.ortho;
+                    const key = expandKey(sp, concept.id);
+                    const isExpanded = expanded.has(key);
+                    const lexTags = getTagsForLexeme(sp, concept.id);
 
-                  return (
-                    <td
-                      key={sp}
-                      style={{
-                        padding: "0.5rem",
-                        borderBottom: "1px solid #f3f4f6",
-                        verticalAlign: "top",
-                      }}
-                    >
-                      {hasForm ? (
-                        <div>
-                          <div style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}>
-                            {cognate && (
-                              <span
-                                data-testid={`cognate-badge-${concept.id}-${sp}`}
-                                style={{
-                                  display: "inline-block",
-                                  padding: "0 0.375rem",
-                                  borderRadius: "0.25rem",
-                                  fontSize: "0.6875rem",
-                                  fontWeight: 600,
-                                  background: cognate.color,
-                                }}
-                              >
-                                {cognate.group}
-                              </span>
-                            )}
-                            <span>{entry.ipa}</span>
-                            {entry.startSec != null &&
-                              entry.endSec != null &&
-                              entry.sourceWav && (
-                                <button
-                                  aria-label={`Play ${sp} ${concept.id}`}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onPlayEntry?.(
-                                      sp,
-                                      concept.id,
-                                      entry.startSec!,
-                                      entry.endSec!,
-                                      entry.sourceWav!,
-                                    );
-                                  }}
+                    return (
+                      <td
+                        key={sp}
+                        style={{
+                          padding: "0.5rem",
+                          borderBottom: "1px solid #f3f4f6",
+                          verticalAlign: "top",
+                          background: isExpanded ? "#eef2ff" : undefined,
+                        }}
+                      >
+                        {hasForm ? (
+                          <div>
+                            <div style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}>
+                              {cognate && (
+                                <span
+                                  data-testid={`cognate-badge-${concept.id}-${sp}`}
                                   style={{
-                                    background: "none",
-                                    border: "1px solid #d1d5db",
+                                    display: "inline-block",
+                                    padding: "0 0.375rem",
                                     borderRadius: "0.25rem",
-                                    cursor: "pointer",
-                                    padding: "0 0.25rem",
                                     fontSize: "0.6875rem",
-                                    fontFamily: "monospace",
-                                    lineHeight: 1.4,
+                                    fontWeight: 600,
+                                    background: cognate.color,
                                   }}
                                 >
-                                  ▶
-                                </button>
+                                  {cognate.group}
+                                </span>
                               )}
-                          </div>
-                          {entry.ortho && (
-                            <div style={{ color: "#6b7280", fontSize: "0.75rem" }}>
-                              {entry.ortho}
+                              <button
+                                data-testid={`lexeme-button-${concept.id}-${sp}`}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleExpanded(sp, concept.id);
+                                }}
+                                title="Click to expand lexeme details"
+                                style={{
+                                  background: "none",
+                                  border: "none",
+                                  padding: 0,
+                                  cursor: "pointer",
+                                  color: "#1d4ed8",
+                                  textDecoration: "underline",
+                                  textUnderlineOffset: "2px",
+                                  font: "inherit",
+                                }}
+                              >
+                                {entry.ipa}
+                              </button>
+                              {entry.startSec != null &&
+                                entry.endSec != null &&
+                                entry.sourceWav && (
+                                  <button
+                                    aria-label={`Play ${sp} ${concept.id}`}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      onPlayEntry?.(
+                                        sp,
+                                        concept.id,
+                                        entry.startSec!,
+                                        entry.endSec!,
+                                        entry.sourceWav!,
+                                      );
+                                    }}
+                                    style={{
+                                      background: "none",
+                                      border: "1px solid #d1d5db",
+                                      borderRadius: "0.25rem",
+                                      cursor: "pointer",
+                                      padding: "0 0.25rem",
+                                      fontSize: "0.6875rem",
+                                      fontFamily: "monospace",
+                                      lineHeight: 1.4,
+                                    }}
+                                  >
+                                    ▶
+                                  </button>
+                                )}
                             </div>
-                          )}
-                        </div>
-                      ) : (
-                        <span style={{ color: "#9ca3af", fontStyle: "italic" }}>
-                          No form
-                        </span>
-                      )}
+                            {entry.ortho && (
+                              <div style={{ color: "#6b7280", fontSize: "0.75rem" }}>
+                                {entry.ortho}
+                              </div>
+                            )}
+                            {lexTags.length > 0 && (
+                              <div style={{ marginTop: "0.25rem", display: "flex", gap: "0.25rem", flexWrap: "wrap" }}>
+                                {lexTags.map((tag) => (
+                                  <Badge key={tag.id} label={tag.label} color={tag.color} />
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <span style={{ color: "#9ca3af", fontStyle: "italic" }}>
+                            No form
+                          </span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+                {expandedSpeakers.length > 0 && (
+                  <tr data-testid={`detail-row-${concept.id}`}>
+                    <td
+                      colSpan={totalCols}
+                      style={{
+                        padding: "0.25rem 0.5rem 0.75rem 0.5rem",
+                        borderBottom: "1px solid #f3f4f6",
+                        background: "#f9fafb",
+                      }}
+                    >
+                      {expandedSpeakers.map((sp) => {
+                        const entry = lookupEntry(records, sp, concept.id);
+                        const cognate = getCognateGroup(
+                          enrichmentData,
+                          concept.id,
+                          sp,
+                        );
+                        return (
+                          <LexemeDetail
+                            key={expandKey(sp, concept.id)}
+                            speaker={sp}
+                            conceptId={concept.id}
+                            conceptLabel={concept.label}
+                            ipa={entry.ipa}
+                            ortho={entry.ortho}
+                            startSec={entry.startSec}
+                            endSec={entry.endSec}
+                            arabicSim={getSimilarity(enrichmentData, concept.id, sp, "ar")}
+                            persianSim={getSimilarity(enrichmentData, concept.id, sp, "fa")}
+                            cognateGroup={cognate?.group ?? null}
+                            cognateColor={cognate?.color ?? null}
+                          />
+                        );
+                      })}
                     </td>
-                  );
-                })}
-              </tr>
+                  </tr>
+                )}
+              </Fragment>
             );
           })}
         </tbody>

--- a/src/components/compare/LexemeDetail.tsx
+++ b/src/components/compare/LexemeDetail.tsx
@@ -1,0 +1,488 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useAnnotationStore } from "../../stores/annotationStore";
+import { useEnrichmentStore } from "../../stores/enrichmentStore";
+import { useTagStore } from "../../stores/tagStore";
+import { saveLexemeNote, spectrogramUrl } from "../../api/client";
+import type { LexemeNoteEntry } from "../../api/types";
+import { Badge } from "../shared/Badge";
+
+interface LexemeDetailProps {
+  speaker: string;
+  conceptId: string;
+  conceptLabel: string;
+  ipa: string;
+  ortho: string;
+  startSec: number | null;
+  endSec: number | null;
+  arabicSim?: number | null;
+  persianSim?: number | null;
+  cognateGroup?: string | null;
+  cognateColor?: string | null;
+}
+
+function formatPct(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${Math.round(value * 100)}%`;
+}
+
+function deriveAudioUrl(record: { source_audio?: string; source_wav?: string } | null | undefined): string {
+  const raw = (record?.source_audio ?? record?.source_wav ?? "").trim();
+  if (!raw) return "";
+  const cleaned = raw.replace(/\\/g, "/").replace(/^\/+/, "");
+  return "/" + cleaned;
+}
+
+export function LexemeDetail({
+  speaker,
+  conceptId,
+  conceptLabel,
+  ipa,
+  ortho,
+  startSec,
+  endSec,
+  arabicSim,
+  persianSim,
+  cognateGroup,
+  cognateColor,
+}: LexemeDetailProps) {
+  const records = useAnnotationStore((s) => s.records);
+  const enrichmentData = useEnrichmentStore((s) => s.data);
+  const saveEnrichments = useEnrichmentStore((s) => s.save);
+  const tags = useTagStore((s) => s.tags);
+  const getTagsForLexeme = useTagStore((s) => s.getTagsForLexeme);
+  const tagLexeme = useTagStore((s) => s.tagLexeme);
+  const untagLexeme = useTagStore((s) => s.untagLexeme);
+  const addTag = useTagStore((s) => s.addTag);
+
+  const lexemeNotesBlock = useMemo(() => {
+    const block = (enrichmentData as Record<string, unknown>)?.lexeme_notes;
+    if (!block || typeof block !== "object") return undefined;
+    const speakerBlock = (block as Record<string, unknown>)[speaker];
+    if (!speakerBlock || typeof speakerBlock !== "object") return undefined;
+    const entry = (speakerBlock as Record<string, unknown>)[conceptId];
+    return (entry && typeof entry === "object" ? entry : undefined) as LexemeNoteEntry | undefined;
+  }, [enrichmentData, speaker, conceptId]);
+
+  const [userNote, setUserNote] = useState<string>(lexemeNotesBlock?.user_note ?? "");
+  const [savingNote, setSavingNote] = useState(false);
+  const [noteError, setNoteError] = useState<string | null>(null);
+  const [showSpectrogram, setShowSpectrogram] = useState(false);
+  const [flagged, setFlagged] = useState(false);
+  const [tagSearch, setTagSearch] = useState("");
+
+  useEffect(() => {
+    setUserNote(lexemeNotesBlock?.user_note ?? "");
+  }, [lexemeNotesBlock?.user_note]);
+
+  const lexemeTags = getTagsForLexeme(speaker, conceptId);
+  const lexemeTagIds = new Set(lexemeTags.map((t) => t.id));
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const record = records[speaker] as { source_audio?: string; source_wav?: string } | undefined;
+  const audioUrl = deriveAudioUrl(record);
+
+  const canPlay = audioUrl && startSec != null && endSec != null;
+  const canShowSpectrogram = startSec != null && endSec != null;
+  const spectrogramSrc =
+    canShowSpectrogram && showSpectrogram
+      ? spectrogramUrl({
+          speaker,
+          startSec: startSec!,
+          endSec: endSec!,
+          audio: audioUrl ? audioUrl.replace(/^\//, "") : undefined,
+        })
+      : null;
+
+  function handlePlay() {
+    if (!canPlay) return;
+    let audio = audioRef.current;
+    if (!audio) {
+      audio = new Audio(audioUrl);
+      audioRef.current = audio;
+    } else if (audio.src !== window.location.origin + audioUrl && !audio.src.endsWith(audioUrl)) {
+      audio.pause();
+      audio.src = audioUrl;
+    }
+    const clipStart = startSec!;
+    const clipEnd = endSec!;
+    audio.currentTime = clipStart;
+    const onTimeUpdate = () => {
+      if (audio && audio.currentTime >= clipEnd) {
+        audio.pause();
+        audio.removeEventListener("timeupdate", onTimeUpdate);
+      }
+    };
+    audio.addEventListener("timeupdate", onTimeUpdate);
+    void audio.play().catch((err) => console.warn("[LexemeDetail] play failed", err));
+  }
+
+  async function handleSaveNote() {
+    setSavingNote(true);
+    setNoteError(null);
+    try {
+      await saveLexemeNote({ speaker, concept_id: conceptId, user_note: userNote });
+      // Merge into local enrichment store so UI reflects immediately.
+      await saveEnrichments({
+        lexeme_notes: {
+          [speaker]: {
+            [conceptId]: {
+              ...(lexemeNotesBlock ?? {}),
+              user_note: userNote,
+              updated_at: new Date().toISOString(),
+            },
+          },
+        },
+      });
+    } catch (err) {
+      setNoteError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSavingNote(false);
+    }
+  }
+
+  const filteredTagSuggestions = useMemo(() => {
+    const q = tagSearch.trim().toLowerCase();
+    const eligible = tags.filter((t) => !lexemeTagIds.has(t.id));
+    if (!q) return eligible.slice(0, 8);
+    return eligible.filter((t) => t.label.toLowerCase().includes(q)).slice(0, 8);
+  }, [tags, lexemeTagIds, tagSearch]);
+
+  function handleAddTag(label: string) {
+    const trimmed = label.trim();
+    if (!trimmed) return;
+    const existing = tags.find((t) => t.label.toLowerCase() === trimmed.toLowerCase());
+    const tag = existing ?? addTag(trimmed, "#6b7280");
+    tagLexeme(tag.id, speaker, conceptId);
+    setTagSearch("");
+  }
+
+  const sectionStyle: React.CSSProperties = {
+    padding: "0.75rem",
+    borderTop: "1px solid #e5e7eb",
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr 1fr",
+    gap: "1rem",
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: "0.6875rem",
+    color: "#6b7280",
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+    marginBottom: "0.25rem",
+  };
+
+  const importNoteText =
+    lexemeNotesBlock?.import_note?.trim() || "";
+
+  return (
+    <div
+      data-testid={`lexeme-detail-${speaker}-${conceptId}`}
+      style={{
+        background: "#f9fafb",
+        border: "1px solid #e5e7eb",
+        borderRadius: "0.5rem",
+        margin: "0.5rem 0",
+      }}
+    >
+      {/* Header row: speaker, IPA, sim bars, cognate, flag */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "minmax(80px, 0.75fr) minmax(220px, 2fr) 1fr 1fr 80px 60px",
+          alignItems: "center",
+          gap: "0.75rem",
+          padding: "0.75rem",
+        }}
+      >
+        <div style={{ fontWeight: 700 }}>{speaker}</div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexWrap: "wrap" }}>
+            <span style={{ fontSize: "1.125rem" }}>{ipa || <em style={{ color: "#9ca3af" }}>No IPA</em>}</span>
+            <button
+              aria-label={`Play ${speaker} ${conceptLabel}`}
+              onClick={handlePlay}
+              disabled={!canPlay}
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: "50%",
+                border: "none",
+                background: canPlay ? "#3b82f6" : "#d1d5db",
+                color: "white",
+                cursor: canPlay ? "pointer" : "not-allowed",
+                fontSize: "0.75rem",
+              }}
+            >
+              ▶
+            </button>
+            {canShowSpectrogram && (
+              <button
+                data-testid={`toggle-spectrogram-${speaker}-${conceptId}`}
+                onClick={() => setShowSpectrogram((v) => !v)}
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: "#3b82f6",
+                  textDecoration: "underline",
+                  cursor: "pointer",
+                  fontSize: "0.8125rem",
+                  padding: 0,
+                }}
+              >
+                Toggle Spectrogram
+              </button>
+            )}
+          </div>
+          {ortho && <div style={{ color: "#6b7280", fontSize: "0.8125rem" }}>{ortho}</div>}
+        </div>
+        <SimBar label="Ar" value={arabicSim} color="#dbeafe" />
+        <SimBar label="Pr" value={persianSim} color="#fef3c7" />
+        <div>
+          {cognateGroup ? (
+            <span
+              style={{
+                display: "inline-block",
+                padding: "0.125rem 0.5rem",
+                borderRadius: "0.25rem",
+                background: cognateColor ?? "#e5e7eb",
+                fontWeight: 600,
+              }}
+            >
+              {cognateGroup}
+            </span>
+          ) : (
+            <span style={{ color: "#9ca3af" }}>—</span>
+          )}
+        </div>
+        <button
+          aria-label="Flag lexeme"
+          onClick={() => setFlagged((v) => !v)}
+          style={{
+            background: flagged ? "#fee2e2" : "transparent",
+            border: "1px solid #d1d5db",
+            borderRadius: "0.25rem",
+            cursor: "pointer",
+            padding: "0.25rem 0.5rem",
+          }}
+          title="Flag (local)"
+        >
+          {flagged ? "🚩" : "⚐"}
+        </button>
+      </div>
+
+      {spectrogramSrc && (
+        <div style={{ padding: "0 0.75rem 0.75rem" }}>
+          <img
+            data-testid={`spectrogram-${speaker}-${conceptId}`}
+            src={spectrogramSrc}
+            alt={`Spectrogram of ${speaker} ${conceptLabel}`}
+            style={{
+              width: "100%",
+              maxHeight: 220,
+              display: "block",
+              borderRadius: "0.25rem",
+              imageRendering: "pixelated",
+              background: "#ffffff",
+            }}
+          />
+          <div style={{ fontSize: "0.6875rem", color: "#6b7280", marginTop: "0.25rem" }}>
+            {formatSeconds(startSec)} → {formatSeconds(endSec)} · shared with Annotate view
+          </div>
+        </div>
+      )}
+
+      <div style={sectionStyle}>
+        <div>
+          <div style={labelStyle}>Import Notes (CSV)</div>
+          {importNoteText ? (
+            <div style={{ fontSize: "0.8125rem", color: "#374151", whiteSpace: "pre-wrap" }}>
+              {importNoteText}
+            </div>
+          ) : (
+            <div style={{ fontSize: "0.8125rem", color: "#9ca3af", fontStyle: "italic" }}>
+              No notes attached.
+            </div>
+          )}
+        </div>
+
+        <div>
+          <div style={labelStyle}>Speaker Notes</div>
+          <textarea
+            data-testid={`lexeme-user-note-${speaker}-${conceptId}`}
+            value={userNote}
+            onChange={(e) => setUserNote(e.target.value)}
+            onBlur={handleSaveNote}
+            placeholder="Add notes specific to this speaker/lexeme…"
+            style={{
+              width: "100%",
+              minHeight: 60,
+              fontFamily: "inherit",
+              fontSize: "0.8125rem",
+              padding: "0.375rem",
+              border: "1px solid #d1d5db",
+              borderRadius: "0.25rem",
+              resize: "vertical",
+            }}
+          />
+          <div style={{ fontSize: "0.6875rem", color: savingNote ? "#6b7280" : noteError ? "#dc2626" : "transparent" }}>
+            {savingNote ? "Saving…" : noteError ?? "saved"}
+          </div>
+        </div>
+
+        <div>
+          <div style={labelStyle}>Tags</div>
+          {lexemeTags.length === 0 ? (
+            <div style={{ fontSize: "0.8125rem", color: "#9ca3af", fontStyle: "italic", marginBottom: "0.375rem" }}>
+              No tags yet.
+            </div>
+          ) : (
+            <div style={{ display: "flex", gap: "0.25rem", flexWrap: "wrap", marginBottom: "0.375rem" }}>
+              {lexemeTags.map((tag) => (
+                <span
+                  key={tag.id}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "0.25rem",
+                  }}
+                >
+                  <Badge label={tag.label} color={tag.color} />
+                  <button
+                    aria-label={`Remove tag ${tag.label}`}
+                    onClick={() => untagLexeme(tag.id, speaker, conceptId)}
+                    style={{
+                      background: "transparent",
+                      border: "none",
+                      color: "#6b7280",
+                      cursor: "pointer",
+                      fontSize: "0.75rem",
+                      padding: 0,
+                      lineHeight: 1,
+                    }}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <div style={{ position: "relative" }}>
+            <input
+              data-testid={`lexeme-tag-input-${speaker}-${conceptId}`}
+              value={tagSearch}
+              onChange={(e) => setTagSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleAddTag(tagSearch);
+                }
+              }}
+              placeholder="Type or select…"
+              style={{
+                width: "100%",
+                fontSize: "0.8125rem",
+                padding: "0.375rem",
+                border: "1px solid #d1d5db",
+                borderRadius: "0.25rem",
+              }}
+            />
+            {tagSearch && filteredTagSuggestions.length > 0 && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: "100%",
+                  left: 0,
+                  right: 0,
+                  background: "white",
+                  border: "1px solid #d1d5db",
+                  borderRadius: "0.25rem",
+                  marginTop: "0.125rem",
+                  maxHeight: 160,
+                  overflowY: "auto",
+                  zIndex: 20,
+                }}
+              >
+                {filteredTagSuggestions.map((tag) => (
+                  <button
+                    key={tag.id}
+                    onClick={() => {
+                      tagLexeme(tag.id, speaker, conceptId);
+                      setTagSearch("");
+                    }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.375rem",
+                      width: "100%",
+                      textAlign: "left",
+                      padding: "0.25rem 0.5rem",
+                      border: "none",
+                      background: "transparent",
+                      cursor: "pointer",
+                      fontSize: "0.8125rem",
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: "50%",
+                        background: tag.color,
+                      }}
+                    />
+                    {tag.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface SimBarProps {
+  label: string;
+  value: number | null | undefined;
+  color: string;
+}
+
+function SimBar({ label, value, color }: SimBarProps) {
+  const pct = value != null && !Number.isNaN(value) ? Math.max(0, Math.min(1, value)) : 0;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "0.375rem", fontSize: "0.8125rem" }}>
+      <strong>{label}</strong>
+      <div
+        style={{
+          position: "relative",
+          flex: 1,
+          height: 6,
+          background: "#f3f4f6",
+          borderRadius: 3,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            bottom: 0,
+            width: `${pct * 100}%`,
+            background: color,
+          }}
+        />
+      </div>
+      <span style={{ color: "#6b7280", minWidth: 30, textAlign: "right" }}>{formatPct(value)}</span>
+    </div>
+  );
+}
+
+function formatSeconds(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  const minutes = Math.floor(value / 60);
+  const seconds = value - minutes * 60;
+  return `${minutes}:${seconds.toFixed(3).padStart(6, "0")}`;
+}

--- a/src/hooks/__tests__/useWaveSurfer.test.ts
+++ b/src/hooks/__tests__/useWaveSurfer.test.ts
@@ -5,6 +5,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // vi.hoisted ensures these are available inside vi.mock factories (which are hoisted)
 const { mockWsInstance, mockRegionInstance, mockRegionsPlugin, mockSetState } =
   vi.hoisted(() => {
+    const mockViewport = document.createElement("div");
+    Object.defineProperty(mockViewport, "clientWidth", { value: 200, configurable: true });
+    mockViewport.scrollLeft = 0;
+    const mockWrapper = document.createElement("div");
+    mockViewport.appendChild(mockWrapper);
+
     const mockWsInstance = {
       play: vi.fn(),
       pause: vi.fn(),
@@ -14,9 +20,12 @@ const { mockWsInstance, mockRegionInstance, mockRegionsPlugin, mockSetState } =
       seekTo: vi.fn(),
       zoom: vi.fn(),
       setPlaybackRate: vi.fn(),
+      setScroll: vi.fn(),
       getDuration: vi.fn(() => 10),
       getCurrentTime: vi.fn(() => 0),
+      getWrapper: vi.fn(() => mockWrapper),
       on: vi.fn(),
+      options: { minPxPerSec: 100 },
     };
 
     const mockRegionInstance = {
@@ -148,5 +157,24 @@ describe("useWaveSurfer", () => {
     });
 
     expect(mockRegionInstance.remove).toHaveBeenCalled();
+  });
+
+  it("mouse wheel scrolls the waveform horizontally", () => {
+    const containerRef = makeContainerRef();
+
+    renderHook(() =>
+      useWaveSurfer({
+        containerRef,
+        audioUrl: "/audio/test.wav",
+      }),
+    );
+
+    const event = new WheelEvent("wheel", { deltaY: 120, cancelable: true });
+    act(() => {
+      containerRef.current!.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mockWsInstance.setScroll).toHaveBeenCalledWith(120);
   });
 });

--- a/src/hooks/useWaveSurfer.ts
+++ b/src/hooks/useWaveSurfer.ts
@@ -289,30 +289,31 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
           e.preventDefault();
           ws.playPause();
           break;
-        case "ArrowLeft":
-          e.preventDefault();
-          {
-            const dur = ws.getDuration();
-            if (dur > 0) {
-              const delta = e.shiftKey ? -5 : -1;
-              ws.seekTo(clamp((ws.getCurrentTime() + delta) / dur, 0, 1));
-            }
-          }
-          break;
-        case "ArrowRight":
-          e.preventDefault();
-          {
-            const dur = ws.getDuration();
-            if (dur > 0) {
-              const delta = e.shiftKey ? 5 : 1;
-              ws.seekTo(clamp((ws.getCurrentTime() + delta) / dur, 0, 1));
-            }
-          }
-          break;
       }
     }
 
+    function onWheel(e: WheelEvent) {
+      if (isInteractiveTarget(e.target)) return;
+
+      const typedWs = ws as unknown as {
+        getWrapper?: () => HTMLElement;
+        setScroll?: (pixels: number) => void;
+      };
+      const wrapper = typedWs.getWrapper?.();
+      const viewport = wrapper?.parentElement;
+      if (!viewport) return;
+
+      const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+      if (!delta) return;
+
+      e.preventDefault();
+      const nextScroll = Math.max(0, viewport.scrollLeft + delta);
+      viewport.scrollLeft = nextScroll;
+      typedWs.setScroll?.(nextScroll);
+    }
+
     container.addEventListener("keydown", onKeyDown);
+    container.addEventListener("wheel", onWheel, { passive: false });
 
     // -- Load audio (with optional peaks) --
 
@@ -345,6 +346,7 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     return () => {
       abortControllerRef.current?.abort();
       container.removeEventListener("keydown", onKeyDown);
+      container.removeEventListener("wheel", onWheel);
       container.removeEventListener("pointerup", onCommit);
       ws.destroy();
       wsRef.current = null;

--- a/src/stores/tagStore.ts
+++ b/src/stores/tagStore.ts
@@ -4,11 +4,15 @@ import type { Tag } from "../api/types";
 const STORAGE_KEY_V2 = "parse-tags-v2";
 const STORAGE_KEY_V1 = "parse-tags-v1";
 
-const DEFAULT_TAGS: Omit<Tag, "concepts">[] = [
+const DEFAULT_TAGS: Omit<Tag, "concepts" | "lexemeTargets">[] = [
   { id: "review-needed", label: "Review needed", color: "#f59e0b" },
   { id: "confirmed", label: "Confirmed", color: "#10b981" },
   { id: "problematic", label: "Problematic", color: "#ef4444" },
 ];
+
+export function lexemeKey(speaker: string, conceptId: string): string {
+  return `${speaker}::${conceptId}`;
+}
 
 interface TagStore {
   tags: Tag[];
@@ -18,7 +22,10 @@ interface TagStore {
   updateTag: (id: string, patch: Partial<Tag>) => void;
   tagConcept: (tagId: string, conceptId: string) => void;
   untagConcept: (tagId: string, conceptId: string) => void;
+  tagLexeme: (tagId: string, speaker: string, conceptId: string) => void;
+  untagLexeme: (tagId: string, speaker: string, conceptId: string) => void;
   getTagsForConcept: (conceptId: string) => Tag[];
+  getTagsForLexeme: (speaker: string, conceptId: string) => Tag[];
 
   syncFromServer: () => Promise<void>;
   mergeFromServer: (tags: Tag[]) => void;
@@ -27,16 +34,27 @@ interface TagStore {
   hydrate: () => void;
 }
 
+function normalizeTag(raw: Partial<Tag>): Tag {
+  return {
+    id: raw.id || crypto.randomUUID(),
+    label: raw.label || "Untitled",
+    color: raw.color || "#6b7280",
+    concepts: Array.isArray(raw.concepts) ? raw.concepts : [],
+    lexemeTargets: Array.isArray(raw.lexemeTargets) ? raw.lexemeTargets : [],
+  };
+}
+
 export const useTagStore = create<TagStore>()((set, get) => ({
   tags: [],
 
   addTag: (label: string, color: string): Tag => {
-    const newTag: Tag = {
+    const newTag: Tag = normalizeTag({
       id: crypto.randomUUID(),
       label: label.trim(),
       color: color || "#6b7280",
       concepts: [],
-    };
+      lexemeTargets: [],
+    });
 
     set((state) => ({
       tags: [...state.tags, newTag],
@@ -56,7 +74,7 @@ export const useTagStore = create<TagStore>()((set, get) => ({
   updateTag: (id: string, patch: Partial<Tag>) => {
     set((state) => ({
       tags: state.tags.map((tag) =>
-        tag.id === id ? { ...tag, ...patch } : tag
+        tag.id === id ? normalizeTag({ ...tag, ...patch }) : tag
       ),
     }));
     get().persist();
@@ -92,29 +110,68 @@ export const useTagStore = create<TagStore>()((set, get) => ({
     get().persist();
   },
 
+  tagLexeme: (tagId: string, speaker: string, conceptId: string) => {
+    const key = lexemeKey(speaker, conceptId);
+    set((state) => ({
+      tags: state.tags.map((tag) => {
+        if (tag.id !== tagId) return tag;
+        const current = tag.lexemeTargets ?? [];
+        if (current.includes(key)) return tag;
+        return { ...tag, lexemeTargets: [...current, key] };
+      }),
+    }));
+    get().persist();
+  },
+
+  untagLexeme: (tagId: string, speaker: string, conceptId: string) => {
+    const key = lexemeKey(speaker, conceptId);
+    set((state) => ({
+      tags: state.tags.map((tag) => {
+        if (tag.id !== tagId) return tag;
+        const current = tag.lexemeTargets ?? [];
+        if (!current.includes(key)) return tag;
+        return { ...tag, lexemeTargets: current.filter((k) => k !== key) };
+      }),
+    }));
+    get().persist();
+  },
+
   getTagsForConcept: (conceptId: string): Tag[] => {
     const normalized = conceptId?.toString().trim() || "";
     if (!normalized) return [];
     return get().tags.filter((tag) => tag.concepts.includes(normalized));
   },
 
+  getTagsForLexeme: (speaker: string, conceptId: string): Tag[] => {
+    const key = lexemeKey(speaker, conceptId);
+    if (!speaker || !conceptId) return [];
+    return get().tags.filter((tag) => (tag.lexemeTargets ?? []).includes(key));
+  },
+
   mergeFromServer: (incomingTags: Tag[]) => {
     set((state) => {
       const existingById: Record<string, Tag> = {};
       for (const t of state.tags) {
-        existingById[t.id] = { ...t };
+        existingById[t.id] = normalizeTag(t);
       }
       for (const t of incomingTags) {
-        if (existingById[t.id]) {
-          const merged = new Set([...existingById[t.id].concepts, ...t.concepts]);
-          existingById[t.id] = {
-            ...existingById[t.id],
-            label: t.label,
-            color: t.color,
-            concepts: Array.from(merged),
+        const incoming = normalizeTag(t);
+        if (existingById[incoming.id]) {
+          const prev = existingById[incoming.id];
+          const concepts = new Set([...prev.concepts, ...incoming.concepts]);
+          const targets = new Set([
+            ...(prev.lexemeTargets ?? []),
+            ...(incoming.lexemeTargets ?? []),
+          ]);
+          existingById[incoming.id] = {
+            ...prev,
+            label: incoming.label,
+            color: incoming.color,
+            concepts: Array.from(concepts),
+            lexemeTargets: Array.from(targets),
           };
         } else {
-          existingById[t.id] = { ...t };
+          existingById[incoming.id] = incoming;
         }
       }
       return { tags: Object.values(existingById) };
@@ -158,15 +215,17 @@ export const useTagStore = create<TagStore>()((set, get) => ({
         let migratedTags: Tag[] = [];
 
         if (Array.isArray(parsed)) {
-          migratedTags = parsed;
+          migratedTags = parsed.map((t) => normalizeTag(t));
         } else if (parsed.tags && Array.isArray(parsed.tags)) {
-          // v1 style with wrapper
-          migratedTags = parsed.tags.map((t: any) => ({
-            id: t.id || crypto.randomUUID(),
-            label: t.name || t.label || "Untitled",
-            color: t.color || "#6b7280",
-            concepts: t.concepts || (parsed.assignments?.[t.id] || []),
-          }));
+          migratedTags = parsed.tags.map((t: any) =>
+            normalizeTag({
+              id: t.id || crypto.randomUUID(),
+              label: t.name || t.label || "Untitled",
+              color: t.color || "#6b7280",
+              concepts: t.concepts || (parsed.assignments?.[t.id] || []),
+              lexemeTargets: t.lexemeTargets || [],
+            })
+          );
         } else {
           migratedTags = [];
         }
@@ -182,14 +241,12 @@ export const useTagStore = create<TagStore>()((set, get) => ({
     }
 
     // defaults
-    const defaults: Tag[] = DEFAULT_TAGS.map((t) => ({
-      ...t,
-      concepts: [],
-    }));
+    const defaults: Tag[] = DEFAULT_TAGS.map((t) =>
+      normalizeTag({ ...t, concepts: [], lexemeTargets: [] })
+    );
     set({ tags: defaults });
     get().persist();
   },
 }));
 
-// Re-export for convenience
 export type { TagStore };


### PR DESCRIPTION
## Summary

- Clicking the IPA form in the Compare speaker table now expands an inline detail panel beneath the row (matches the screenshot Lucas shared from the old UI).
- Per-lexeme panel shows: speaker + IPA + ortho, ▶ play (clip-bounded), Ar/Pr sim bars, cognate badge, flag; plus three sections — **Import Notes (CSV)** (read-only), **Speaker Notes** (editable, autosaves to `parse-enrichments.json`), **Tags** (chip editor with search/select, supports per-lexeme targets).
- Toggle Spectrogram renders a grayscale STFT PNG for exactly the lexeme's clip interval via `/api/spectrogram`, cached at `spectrograms/<speaker>/<start_ms>_<end_ms>.png` so Compare and Annotate can later load the same file for identical windows.
- New **Import Audition comments** modal (TopBar + right-panel button) parses Adobe Audition marker CSVs (tab-separated). The parser strips the `(id)- label` prefix and keeps any trailing commentary as the lexeme's `import_note`, fuzzy-matching to existing intervals (± 500 ms) when no concept id match is found. Verified against `Faili_F_1968_(comments).csv` (133 rows, 15 with analyst commentary).
- Onboarding worker auto-detects an Audition comments CSV when the upload isn't a concepts CSV, so new-speaker imports can seed lexeme notes in one step.

## Implementation notes

**Backend** (`python/`):
- `lexeme_notes.py` — tolerant CSV parser + fuzzy interval matcher.
- `spectrograms.py` — numpy STFT + pure-python PNG writer (no PIL dep).
- `server.py` — `POST /api/lexeme-notes`, `POST /api/lexeme-notes/import`, `GET /api/spectrogram`; onboarding worker now also runs the Audition parser.

**Frontend** (`src/`):
- New `LexemeDetail.tsx` + `CommentsImport.tsx`.
- `ConceptTable.tsx` rewritten with expandable `<Fragment>` rows.
- `ParseUI.tsx` Compare table (the one users actually see) gains `expandedLexemes` state, clickable IPA per speaker row, and a detail `<tr>` below each expanded row.
- `tagStore.ts` extended with `lexemeTargets: string[]` (`${speaker}::${conceptId}` encoding) + `tagLexeme`/`untagLexeme`/`getTagsForLexeme`; localStorage payload migrated in place.
- `api/client.ts` — `saveLexemeNote`, `importCommentsCsv`, `spectrogramUrl`.

## Test plan

- [ ] Open Compare → click IPA for any speaker → detail row opens beneath with all sections
- [ ] Type in Speaker Notes → blur → reopen → value persists (writes to `parse-enrichments.json` under `lexeme_notes[<speaker>][<concept>]`)
- [ ] Type in Tags input → pick an existing tag or press Enter → chip appears; × removes it
- [ ] Click ▶ → clip plays from `startSec` to `endSec` via `<audio>` element
- [ ] Click "Toggle Spectrogram" → PNG fetched from `/api/spectrogram?speaker=…&start=…&end=…`; second click hides
- [ ] Open "Import Audition comments" → pick speaker + a `*_(comments).csv` → response reports `{imported, matched, total_rows}` and the detail row for a commented concept now shows the note under **Import Notes (CSV)**
- [ ] Onboard a new speaker with a comments CSV → `commentsImported` > 0 in job result
- [ ] `npm run check` + `vitest run` both clean (167 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)