### PR TITLE
Add timestamp-offset detect/apply action + MCP tools

### DIFF
--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -4,10 +4,11 @@
 Starts a stdio MCP server that lets any MCP client (Claude Code, Cursor, Codex,
 Windsurf, etc.) call PARSE's linguistic analysis tools programmatically.
 
-Tools exposed (15):
+Tools exposed (17):
   project_context_read, annotation_read, read_csv_preview,
   cognate_compute_preview, cross_speaker_match_preview, spectrogram_preview,
   contact_lexeme_lookup, stt_start, stt_status,
+  detect_timestamp_offset, apply_timestamp_offset,
   import_tag_csv, prepare_tag_import,
   onboard_speaker_import, import_processed_speaker,
   parse_memory_read, parse_memory_upsert_section
@@ -698,6 +699,69 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         if maxSegments is not None:
             args["maxSegments"] = maxSegments
         result = tools.execute("stt_status", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def detect_timestamp_offset(
+        speaker: str,
+        sttJobId: Optional[str] = None,
+        nAnchors: Optional[int] = None,
+        bucketSec: Optional[float] = None,
+        minMatchScore: Optional[float] = None,
+    ) -> str:
+        """Detect a constant timestamp offset between a speaker's annotation
+        intervals and STT segments for the same audio. Read-only.
+
+        Use case: a working WAV is missing leading audio (e.g. an intro was
+        trimmed) so every CSV-derived lexeme timestamp is uniformly later than
+        the true position in the truncated WAV. detect_timestamp_offset reports
+        the constant shift that brings them back into alignment.
+
+        Args:
+            speaker: Speaker ID whose annotation tiers provide the anchors
+            sttJobId: Required. The jobId of a completed stt_start run for the
+                same speaker — its segments are matched against annotation
+                anchors to compute the offset.
+            nAnchors: Number of earliest annotation intervals to use (2–50, default 12)
+            bucketSec: Offset clustering bucket size in seconds (default 1.0)
+            minMatchScore: Minimum token similarity to accept a match (0.0–1.0, default 0.56)
+        """
+        args: Dict[str, Any] = {"speaker": speaker}
+        if sttJobId is not None:
+            args["sttJobId"] = sttJobId
+        if nAnchors is not None:
+            args["nAnchors"] = nAnchors
+        if bucketSec is not None:
+            args["bucketSec"] = bucketSec
+        if minMatchScore is not None:
+            args["minMatchScore"] = minMatchScore
+        result = tools.execute("detect_timestamp_offset", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def apply_timestamp_offset(
+        speaker: str,
+        offsetSec: float,
+        dryRun: bool,
+    ) -> str:
+        """Shift every annotation interval (start and end) by ``offsetSec`` for
+        the given speaker. Mutates annotations/<speaker>.parse.json.
+
+        Use dryRun=true first to preview the shift (returns a sample of
+        before/after intervals), then dryRun=false to write the change.
+
+        Args:
+            speaker: Speaker ID whose annotation will be shifted
+            offsetSec: Seconds to add to every interval start and end (negative
+                values pull timestamps earlier; clamped at 0).
+            dryRun: Required. If true, return preview only. If false, write.
+        """
+        args: Dict[str, Any] = {
+            "speaker": speaker,
+            "offsetSec": offsetSec,
+            "dryRun": dryRun,
+        }
+        result = tools.execute("apply_timestamp_offset", args)
         return json.dumps(result, indent=2, ensure_ascii=False)
 
     @mcp.tool()

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -46,6 +46,7 @@ WRITE_ALLOWED_TOOL_NAMES = frozenset({
     "onboard_speaker_import",
     "import_processed_speaker",
     "parse_memory_upsert_section",
+    "apply_timestamp_offset",
 })
 TEXT_PREVIEW_EXTENSIONS = frozenset({".md", ".markdown", ".txt", ".rst"})
 ONBOARD_AUDIO_EXTENSIONS = frozenset({".wav", ".flac", ".mp3", ".ogg", ".m4a"})
@@ -376,6 +377,44 @@ class ParseChatTools:
                             },
                         },
                         "maxIntervals": {"type": "integer", "minimum": 1, "maximum": 5000},
+                    },
+                },
+            ),
+            "detect_timestamp_offset": ChatToolSpec(
+                name="detect_timestamp_offset",
+                description=(
+                    "Detect a constant timestamp offset between a speaker's annotation "
+                    "intervals and STT segments for the same audio. Read-only — returns "
+                    "offsetSec and confidence so the caller can decide whether to apply."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["speaker"],
+                    "properties": {
+                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "sttJobId": {"type": "string", "minLength": 1, "maxLength": 128},
+                        "nAnchors": {"type": "integer", "minimum": 2, "maximum": 50},
+                        "bucketSec": {"type": "number", "minimum": 0.1, "maximum": 30.0},
+                        "minMatchScore": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                    },
+                },
+            ),
+            "apply_timestamp_offset": ChatToolSpec(
+                name="apply_timestamp_offset",
+                description=(
+                    "Shift every annotation interval (start and end) by offsetSec for the "
+                    "given speaker. Mutates annotations/<speaker>.parse.json. Use dryRun=true "
+                    "first to preview the shift, then dryRun=false to write."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["speaker", "offsetSec", "dryRun"],
+                    "properties": {
+                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "offsetSec": {"type": "number"},
+                        "dryRun": {"type": "boolean"},
                     },
                 },
             ),
@@ -1313,6 +1352,271 @@ class ParseChatTools:
             payload["segmentCount"] = len(segments)
 
         return payload
+
+    def _tool_detect_timestamp_offset(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Proxy detect_offset against the speaker's annotation + STT job.
+
+        Pulls anchors from the on-disk annotation tiers (preferring ortho/ipa);
+        STT segments come from an explicit ``sttJobId`` if given, otherwise from
+        the most recent complete STT job for the same speaker that this process
+        can see via ``get_job_snapshot``.
+        """
+        try:
+            from compare import (
+                anchors_from_intervals,
+                detect_offset,
+                load_rules_from_file,
+                segments_from_raw,
+            )
+        except Exception as exc:
+            raise ChatToolExecutionError(
+                "compare/offset_detect.py is not importable: {0}".format(exc)
+            )
+
+        speaker_raw = str(args.get("speaker") or "").strip()
+        if not speaker_raw or not SPEAKER_PATTERN.match(speaker_raw):
+            raise ChatToolValidationError("speaker is required and must match {0}".format(SPEAKER_PATTERN.pattern))
+        speaker = speaker_raw
+
+        annotation_path = self._annotation_path_for_speaker(speaker)
+        if annotation_path is None or not annotation_path.is_file():
+            raise ChatToolValidationError(
+                "No annotation file found for speaker '{0}'".format(speaker)
+            )
+
+        try:
+            record = json.loads(annotation_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ChatToolExecutionError("Failed to read annotation: {0}".format(exc))
+
+        intervals = self._collect_offset_anchor_intervals(record)
+        if not intervals:
+            raise ChatToolValidationError(
+                "Speaker '{0}' has no annotated intervals to use as offset anchors".format(speaker)
+            )
+
+        n_anchors = max(2, min(50, int(args.get("nAnchors") or 12)))
+        bucket_sec = max(0.1, float(args.get("bucketSec") or 1.0))
+        min_match_score = max(0.0, min(1.0, float(args.get("minMatchScore") or 0.56)))
+
+        stt_segments: Optional[List[Any]] = None
+        stt_job_id = str(args.get("sttJobId") or "").strip()
+        if stt_job_id:
+            if self._get_job_snapshot is None:
+                raise ChatToolExecutionError("Job snapshot callback is unavailable")
+            snapshot = self._get_job_snapshot(stt_job_id)
+            if snapshot is None:
+                raise ChatToolValidationError("Unknown sttJobId")
+            if snapshot.get("type") != "stt":
+                raise ChatToolValidationError("sttJobId is not an STT job")
+            if snapshot.get("status") != "complete":
+                raise ChatToolValidationError("STT job has not completed")
+            result = snapshot.get("result") if isinstance(snapshot.get("result"), dict) else {}
+            seg_payload = result.get("segments")
+            if isinstance(seg_payload, list):
+                stt_segments = seg_payload
+
+        if stt_segments is None:
+            raise ChatToolValidationError(
+                "sttJobId is required for detect_timestamp_offset; pass the jobId of a "
+                "completed stt_start run for this speaker"
+            )
+
+        rules_path = self.phonetic_rules_path
+        try:
+            rules = load_rules_from_file(rules_path) if rules_path.exists() else []
+        except Exception:
+            rules = []
+
+        anchors = anchors_from_intervals(intervals, n_anchors)
+        if not anchors:
+            raise ChatToolValidationError(
+                "No usable anchors with both timestamp and text in annotation"
+            )
+        segments = segments_from_raw(stt_segments)
+        if not segments:
+            raise ChatToolValidationError("STT input contained no usable segments")
+
+        try:
+            offset_sec, confidence, n_matched = detect_offset(
+                anchors=anchors,
+                segments=segments,
+                rules=rules,
+                bucket_sec=bucket_sec,
+                min_match_score=min_match_score,
+            )
+        except ValueError as exc:
+            raise ChatToolExecutionError(str(exc))
+
+        return {
+            "readOnly": True,
+            "speaker": speaker,
+            "offsetSec": float(offset_sec),
+            "confidence": float(confidence),
+            "nAnchors": int(n_matched),
+            "totalAnchors": len(anchors),
+            "totalSegments": len(segments),
+            "method": "keyword_alignment",
+            "annotationPath": str(annotation_path.relative_to(self.project_root)),
+        }
+
+    def _tool_apply_timestamp_offset(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Add ``offsetSec`` to every interval start/end in the speaker's annotation.
+
+        Negative offsets clamp to 0. ``dryRun=true`` returns a preview of the
+        first few shifted intervals without writing.
+        """
+        speaker_raw = str(args.get("speaker") or "").strip()
+        if not speaker_raw or not SPEAKER_PATTERN.match(speaker_raw):
+            raise ChatToolValidationError("speaker is required and must match {0}".format(SPEAKER_PATTERN.pattern))
+        speaker = speaker_raw
+
+        if "offsetSec" not in args:
+            raise ChatToolValidationError("offsetSec is required")
+        try:
+            offset_sec = float(args.get("offsetSec"))
+        except (TypeError, ValueError):
+            raise ChatToolValidationError("offsetSec must be a number")
+        import math as _math
+        if not _math.isfinite(offset_sec):
+            raise ChatToolValidationError("offsetSec must be a finite number")
+        if abs(offset_sec) < 1e-6:
+            raise ChatToolValidationError("offsetSec is effectively zero — nothing to apply")
+
+        if "dryRun" not in args:
+            raise ChatToolValidationError("dryRun is required (use true to preview)")
+        dry_run = bool(args.get("dryRun"))
+
+        annotation_path = self._annotation_path_for_speaker(speaker)
+        if annotation_path is None or not annotation_path.is_file():
+            raise ChatToolValidationError(
+                "No annotation file found for speaker '{0}'".format(speaker)
+            )
+
+        try:
+            record = json.loads(annotation_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ChatToolExecutionError("Failed to read annotation: {0}".format(exc))
+
+        shifted_count, preview = self._shift_annotation_intervals(record, offset_sec)
+        if shifted_count == 0:
+            raise ChatToolValidationError("No intervals were shifted")
+
+        if dry_run:
+            return {
+                "readOnly": True,
+                "dryRun": True,
+                "speaker": speaker,
+                "offsetSec": offset_sec,
+                "wouldShiftIntervals": shifted_count,
+                "preview": preview,
+            }
+
+        if isinstance(record, dict):
+            metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
+            metadata["modified"] = _utc_now_iso()
+            record["metadata"] = metadata
+
+        try:
+            annotation_path.write_text(
+                json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        except OSError as exc:
+            raise ChatToolExecutionError("Failed to write annotation: {0}".format(exc))
+
+        return {
+            "readOnly": False,
+            "dryRun": False,
+            "speaker": speaker,
+            "appliedOffsetSec": offset_sec,
+            "shiftedIntervals": shifted_count,
+            "annotationPath": str(annotation_path.relative_to(self.project_root)),
+        }
+
+    def _annotation_path_for_speaker(self, speaker: str) -> Optional[Path]:
+        canonical = self.annotations_dir / "{0}{1}".format(speaker, ANNOTATION_FILENAME_SUFFIX)
+        if canonical.is_file():
+            return canonical
+        legacy = self.annotations_dir / "{0}{1}".format(speaker, ANNOTATION_LEGACY_FILENAME_SUFFIX)
+        if legacy.is_file():
+            return legacy
+        return canonical
+
+    def _collect_offset_anchor_intervals(self, record: Any) -> List[Dict[str, Any]]:
+        if not isinstance(record, dict):
+            return []
+        tiers = record.get("tiers")
+        if not isinstance(tiers, dict):
+            return []
+        for tier_key in ("ortho", "ipa", "concept"):
+            tier = tiers.get(tier_key)
+            if not isinstance(tier, dict):
+                continue
+            intervals = tier.get("intervals")
+            if not isinstance(intervals, list):
+                continue
+            collected: List[Dict[str, Any]] = []
+            for raw in intervals:
+                if not isinstance(raw, dict):
+                    continue
+                start = raw.get("start", raw.get("xmin"))
+                end = raw.get("end", raw.get("xmax"))
+                text = raw.get("text")
+                try:
+                    start_f = float(start) if start is not None else None
+                    end_f = float(end) if end is not None else None
+                except (TypeError, ValueError):
+                    continue
+                if start_f is None or end_f is None or end_f < start_f:
+                    continue
+                if not str(text or "").strip():
+                    continue
+                collected.append({"start": start_f, "end": end_f, "text": str(text).strip()})
+            if collected:
+                return collected
+        return []
+
+    def _shift_annotation_intervals(
+        self, record: Any, offset_sec: float
+    ) -> Tuple[int, List[Dict[str, Any]]]:
+        if not isinstance(record, dict):
+            return 0, []
+        tiers = record.get("tiers")
+        if not isinstance(tiers, dict):
+            return 0, []
+
+        shifted = 0
+        preview: List[Dict[str, Any]] = []
+        for tier_key, tier in tiers.items():
+            if not isinstance(tier, dict):
+                continue
+            intervals = tier.get("intervals")
+            if not isinstance(intervals, list):
+                continue
+            for raw in intervals:
+                if not isinstance(raw, dict):
+                    continue
+                try:
+                    start_f = float(raw.get("start", raw.get("xmin")))
+                    end_f = float(raw.get("end", raw.get("xmax")))
+                except (TypeError, ValueError):
+                    continue
+                new_start = max(0.0, start_f + offset_sec)
+                new_end = max(new_start, end_f + offset_sec)
+                raw["start"] = new_start
+                raw["end"] = new_end
+                if "xmin" in raw:
+                    raw["xmin"] = new_start
+                if "xmax" in raw:
+                    raw["xmax"] = new_end
+                shifted += 1
+                if len(preview) < 5:
+                    preview.append({
+                        "tier": tier_key,
+                        "from": [start_f, end_f],
+                        "to": [new_start, new_end],
+                    })
+        return shifted, preview
 
     def _tool_cognate_compute_preview(self, args: Dict[str, Any]) -> Dict[str, Any]:
         if cognate_compute_module is None:

--- a/python/compare/__init__.py
+++ b/python/compare/__init__.py
@@ -2,7 +2,11 @@
 
 from .cognate_compute import compute_similarity_scores
 from .cross_speaker_match import compute_matches
-from .offset_detect import detect_offset
+from .offset_detect import (
+    anchors_from_intervals,
+    detect_offset,
+    segments_from_raw,
+)
 from .phonetic_rules import (
     PhoneticRule,
     apply_rules,
@@ -14,7 +18,9 @@ from .phonetic_rules import (
 __all__ = [
     "compute_similarity_scores",
     "compute_matches",
+    "anchors_from_intervals",
     "detect_offset",
+    "segments_from_raw",
     "PhoneticRule",
     "apply_rules",
     "are_phonetically_equivalent",

--- a/python/compare/offset_detect.py
+++ b/python/compare/offset_detect.py
@@ -335,10 +335,13 @@ def load_anchors_from_csv(csv_path: Path, n_anchors: int) -> Tuple[str, List[Anc
     return (speaker, anchors)
 
 
-def load_stt_segments(stt_path: Path) -> List[Segment]:
-    raw = _load_json(stt_path)
-    raw_segments: List[Any]
+def segments_from_raw(raw: Any) -> List[Segment]:
+    """Build Segment list from already-loaded STT data (dict, list, or job result).
 
+    Same shape acceptance as ``load_stt_segments`` but skips disk I/O so callers
+    (HTTP server, MCP adapter) can pass an in-memory job result directly.
+    """
+    raw_segments: List[Any]
     if isinstance(raw, list):
         raw_segments = raw
     elif isinstance(raw, dict):
@@ -346,6 +349,8 @@ def load_stt_segments(stt_path: Path) -> List[Segment]:
             raw_segments = raw["segments"]
         elif isinstance(raw.get("items"), list):
             raw_segments = raw["items"]
+        elif isinstance(raw.get("result"), dict) and isinstance(raw["result"].get("segments"), list):
+            raw_segments = raw["result"]["segments"]
         else:
             raw_segments = []
     else:
@@ -378,6 +383,56 @@ def load_stt_segments(stt_path: Path) -> List[Segment]:
     for new_index, segment in enumerate(segments):
         segment.index = new_index
     return segments
+
+
+def anchors_from_intervals(
+    intervals: Iterable[Mapping[str, Any]],
+    n_anchors: int,
+) -> List[Anchor]:
+    """Build Anchor list from annotation tier intervals (start/end/text dicts).
+
+    Used when timestamp anchors live in an annotation record rather than a
+    standalone CSV — same role as ``load_anchors_from_csv`` but for in-memory
+    annotation tiers.
+    """
+    anchors: List[Anchor] = []
+    for index, raw in enumerate(intervals or []):
+        if not isinstance(raw, Mapping):
+            continue
+
+        start_value = _pick_value(
+            raw,
+            ["start", "start_sec", "startSec", "xmin", "t0"],
+            None,
+        )
+        if start_value is None:
+            continue
+
+        start_sec = _parse_float(start_value)
+        if start_sec < 0:
+            continue
+
+        text = _normalize_space(
+            _pick_value(raw, ["text", "ortho", "orth", "ipa", "concept", "label"], "")
+        )
+        if not text:
+            continue
+
+        tokens = _dedupe_tokens(_tokenize(text))
+        if not tokens:
+            continue
+
+        anchors.append(Anchor(index=index, start_sec=start_sec, text=text, tokens=tokens))
+
+    if not anchors:
+        return []
+
+    anchors.sort(key=lambda item: item.start_sec)
+    return anchors[: max(1, int(n_anchors))]
+
+
+def load_stt_segments(stt_path: Path) -> List[Segment]:
+    return segments_from_raw(_load_json(stt_path))
 
 
 def _anchor_to_segment_similarity(anchor_token: str, segment_token: str, rules: Sequence[Any]) -> float:

--- a/python/server.py
+++ b/python/server.py
@@ -5,6 +5,7 @@ import copy
 import http.server
 import io
 import json
+import math
 import os
 import pathlib
 import re
@@ -867,6 +868,106 @@ def _annotation_collect_speaker_intervals(record: Dict[str, Any]) -> List[Dict[s
         fallback.append({"start": interval["start"], "end": interval["end"]})
 
     return fallback
+
+
+def _annotation_offset_anchor_intervals(record: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return interval dicts (start/end/text) suitable as offset-detection anchors.
+
+    Prefers ``ortho`` and ``ipa`` tiers (transcribed forms that should match
+    STT output); falls back to ``concept`` only if neither is populated.
+    """
+    if not isinstance(record, dict):
+        return []
+    tiers = record.get("tiers")
+    if not isinstance(tiers, dict):
+        return []
+
+    for tier_key in ("ortho", "ipa", "concept"):
+        tier = tiers.get(tier_key)
+        if not isinstance(tier, dict):
+            continue
+        intervals_raw = tier.get("intervals")
+        if not isinstance(intervals_raw, list):
+            continue
+
+        collected: List[Dict[str, Any]] = []
+        for raw in intervals_raw:
+            normalized = _annotation_normalize_interval(raw)
+            if normalized is None:
+                continue
+            text = str(normalized.get("text") or "").strip()
+            if not text:
+                continue
+            collected.append({"start": normalized["start"], "end": normalized["end"], "text": text})
+        if collected:
+            return collected
+
+    return []
+
+
+def _annotation_shift_intervals(record: Dict[str, Any], offset_sec: float) -> int:
+    """Add ``offset_sec`` to every interval's start/end. Negative values clamp to 0.
+
+    Mutates the record in place. Returns the count of intervals shifted.
+    """
+    if not isinstance(record, dict):
+        return 0
+    tiers = record.get("tiers")
+    if not isinstance(tiers, dict):
+        return 0
+
+    shifted = 0
+    for tier in tiers.values():
+        if not isinstance(tier, dict):
+            continue
+        intervals = tier.get("intervals")
+        if not isinstance(intervals, list):
+            continue
+        for raw in intervals:
+            if not isinstance(raw, dict):
+                continue
+            start = _coerce_finite_float(raw.get("start", raw.get("xmin")))
+            end = _coerce_finite_float(raw.get("end", raw.get("xmax")))
+            if start is None or end is None:
+                continue
+            new_start = max(0.0, float(start) + float(offset_sec))
+            new_end = max(new_start, float(end) + float(offset_sec))
+            raw["start"] = new_start
+            raw["end"] = new_end
+            if "xmin" in raw:
+                raw["xmin"] = new_start
+            if "xmax" in raw:
+                raw["xmax"] = new_end
+            shifted += 1
+    _annotation_sort_all_intervals(record)
+    return shifted
+
+
+def _latest_stt_segments_for_speaker(speaker: str) -> Optional[List[Dict[str, Any]]]:
+    """Find the most recent completed STT job for ``speaker`` and return its segments."""
+    speaker_norm = str(speaker or "").strip()
+    if not speaker_norm:
+        return None
+    candidates: List[Tuple[float, List[Dict[str, Any]]]] = []
+    with _jobs_lock:
+        for job in _jobs.values():
+            if str(job.get("type") or "") != "stt":
+                continue
+            if str(job.get("status") or "") != "complete":
+                continue
+            meta = job.get("meta") if isinstance(job.get("meta"), dict) else {}
+            if str(meta.get("speaker") or "") != speaker_norm:
+                continue
+            result = job.get("result") if isinstance(job.get("result"), dict) else {}
+            segments = result.get("segments")
+            if not isinstance(segments, list) or not segments:
+                continue
+            ts = float(job.get("completed_ts") or job.get("updated_ts") or 0.0)
+            candidates.append((ts, copy.deepcopy(segments)))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
 
 
 def _annotation_sync_speaker_tier(record: Dict[str, Any]) -> None:
@@ -2814,6 +2915,14 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             self._api_post_lexeme_notes_import()
             return
 
+        if request_path == "/api/offset/detect":
+            self._api_post_offset_detect()
+            return
+
+        if request_path == "/api/offset/apply":
+            self._api_post_offset_apply()
+            return
+
         parts = self._path_parts(request_path)
 
         if len(parts) == 3 and parts[0] == "api" and parts[1] == "annotations":
@@ -3037,6 +3146,170 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
                 "job_id": job_id,
                 "jobId": job_id,
                 "status": "running",
+            },
+        )
+
+    def _api_post_offset_detect(self) -> None:
+        """Synchronously detect a constant timestamp offset for a speaker.
+
+        Compares anchors taken from the speaker's annotation tiers against STT
+        segments (passed inline via ``sttSegments``, pulled from a completed
+        STT job by ``sttJobId``, or auto-discovered as the speaker's most
+        recent complete STT job). Returns the median offset and a confidence —
+        does not mutate any files.
+        """
+        body = self._expect_object(self._read_json_body(), "Request body")
+
+        try:
+            speaker = _normalize_speaker_id(body.get("speaker"))
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc))
+
+        try:
+            n_anchors = max(2, min(50, int(body.get("nAnchors") or body.get("n_anchors") or 12)))
+        except (TypeError, ValueError):
+            n_anchors = 12
+
+        try:
+            bucket_sec = max(0.1, float(body.get("bucketSec") or body.get("bucket_sec") or 1.0))
+        except (TypeError, ValueError):
+            bucket_sec = 1.0
+
+        try:
+            min_match_score = max(
+                0.0,
+                min(1.0, float(body.get("minMatchScore") or body.get("min_match_score") or 0.56)),
+            )
+        except (TypeError, ValueError):
+            min_match_score = 0.56
+
+        annotation_path = _annotation_read_path_for_speaker(speaker)
+        annotation = _normalize_annotation_record(_read_json_any_file(annotation_path), speaker)
+        intervals = _annotation_offset_anchor_intervals(annotation)
+        if not intervals:
+            raise ApiError(
+                HTTPStatus.BAD_REQUEST,
+                "Speaker '{0}' has no annotated intervals to use as offset anchors".format(speaker),
+            )
+
+        stt_segments_payload = body.get("sttSegments") or body.get("stt_segments")
+        stt_job_id = str(body.get("sttJobId") or body.get("stt_job_id") or "").strip()
+
+        if stt_segments_payload is None and stt_job_id:
+            job = _get_job_snapshot(stt_job_id)
+            if job is None:
+                raise ApiError(HTTPStatus.NOT_FOUND, "Unknown sttJobId")
+            if str(job.get("type") or "") != "stt":
+                raise ApiError(HTTPStatus.BAD_REQUEST, "sttJobId is not an STT job")
+            if str(job.get("status") or "") != "complete":
+                raise ApiError(HTTPStatus.BAD_REQUEST, "STT job has not completed")
+            result = job.get("result") if isinstance(job.get("result"), dict) else {}
+            stt_segments_payload = result.get("segments")
+
+        if stt_segments_payload is None:
+            stt_segments_payload = _latest_stt_segments_for_speaker(speaker)
+
+        if not stt_segments_payload:
+            raise ApiError(
+                HTTPStatus.BAD_REQUEST,
+                "No STT segments available. Run STT first or pass sttJobId / sttSegments.",
+            )
+
+        from compare import (
+            anchors_from_intervals as _anchors_from_intervals,
+            detect_offset as _detect_offset,
+            load_rules_from_file as _load_rules,
+            segments_from_raw as _segments_from_raw,
+        )
+
+        rules_path = _project_root() / "config" / "phonetic_rules.json"
+        try:
+            rules = _load_rules(rules_path) if rules_path.exists() else []
+        except Exception:
+            rules = []
+
+        anchors = _anchors_from_intervals(intervals, n_anchors)
+        if not anchors:
+            raise ApiError(
+                HTTPStatus.BAD_REQUEST,
+                "No usable anchors with both timestamp and text in annotation",
+            )
+        segments = _segments_from_raw(stt_segments_payload)
+        if not segments:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "STT input contained no usable segments")
+
+        try:
+            offset_sec, confidence, n_matched = _detect_offset(
+                anchors=anchors,
+                segments=segments,
+                rules=rules,
+                bucket_sec=bucket_sec,
+                min_match_score=min_match_score,
+            )
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.UNPROCESSABLE_ENTITY, str(exc))
+
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "speaker": speaker,
+                "offsetSec": float(offset_sec),
+                "confidence": float(confidence),
+                "nAnchors": int(n_matched),
+                "totalAnchors": len(anchors),
+                "totalSegments": len(segments),
+                "method": "keyword_alignment",
+            },
+        )
+
+    def _api_post_offset_apply(self) -> None:
+        """Shift every annotation interval by ``offsetSec`` (start/end += offset).
+
+        For the typical "WAV missing leading audio" case the detected offset is
+        negative, so applying it pulls every CSV-sourced timestamp earlier so
+        the lexemes line up with the truncated recording.
+        """
+        body = self._expect_object(self._read_json_body(), "Request body")
+
+        try:
+            speaker = _normalize_speaker_id(body.get("speaker"))
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc))
+
+        offset_raw = body.get("offsetSec")
+        if offset_raw is None:
+            offset_raw = body.get("offset_sec")
+        if offset_raw is None:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "offsetSec is required")
+
+        try:
+            offset_sec = float(offset_raw)
+        except (TypeError, ValueError):
+            raise ApiError(HTTPStatus.BAD_REQUEST, "offsetSec must be a number")
+
+        if not math.isfinite(offset_sec):
+            raise ApiError(HTTPStatus.BAD_REQUEST, "offsetSec must be a finite number")
+
+        if abs(offset_sec) < 1e-6:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "offsetSec is effectively zero — nothing to apply")
+
+        annotation_path = _annotation_read_path_for_speaker(speaker)
+        annotation = _normalize_annotation_record(_read_json_any_file(annotation_path), speaker)
+
+        shifted_count = _annotation_shift_intervals(annotation, offset_sec)
+        if shifted_count == 0:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "No intervals were shifted")
+
+        _annotation_touch_metadata(annotation, preserve_created=True)
+        write_path = _annotation_record_path_for_speaker(speaker)
+        _write_json_file(write_path, annotation)
+
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "speaker": speaker,
+                "appliedOffsetSec": offset_sec,
+                "shiftedIntervals": shifted_count,
             },
         )
 

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -12,7 +12,8 @@ import {
   Sun, Moon, XCircle
 } from 'lucide-react';
 import type { AnnotationInterval, AnnotationRecord, Tag as StoreTag } from './api/types';
-import { getLingPyExport, saveApiKey, getAuthStatus, pollAuth, startAuthFlow, startSTT, startCompute, startNormalize, pollSTT, pollNormalize, pollCompute, importTagCsv } from './api/client';
+import { getLingPyExport, saveApiKey, getAuthStatus, pollAuth, startAuthFlow, startSTT, startCompute, startNormalize, pollSTT, pollNormalize, pollCompute, importTagCsv, detectTimestampOffset, applyTimestampOffset } from './api/client';
+import type { OffsetDetectResult } from './api/client';
 import { useChatSession, type UseChatSessionResult } from './hooks/useChatSession';
 import { useSpectrogram } from './hooks/useSpectrogram';
 import { useWaveSurfer } from './hooks/useWaveSurfer';
@@ -1657,6 +1658,49 @@ export function ParseUI() {
   const activeJobs = allJobs.filter(j => j.state.status !== 'idle');
 
   const [importModalOpen, setImportModalOpen] = useState(false);
+
+  const [offsetState, setOffsetState] = useState<
+    | { phase: 'idle' }
+    | { phase: 'detecting' }
+    | { phase: 'detected'; result: OffsetDetectResult }
+    | { phase: 'applying'; result: OffsetDetectResult }
+    | { phase: 'applied'; result: OffsetDetectResult; shifted: number }
+    | { phase: 'error'; message: string }
+  >({ phase: 'idle' });
+
+  const detectOffsetForSpeaker = async () => {
+    setActionsMenuOpen(false);
+    if (!activeActionSpeaker) {
+      setOffsetState({ phase: 'error', message: 'Select a speaker first.' });
+      return;
+    }
+    setOffsetState({ phase: 'detecting' });
+    try {
+      const result = await detectTimestampOffset(activeActionSpeaker);
+      setOffsetState({ phase: 'detected', result });
+    } catch (err) {
+      setOffsetState({
+        phase: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const applyDetectedOffset = async () => {
+    if (offsetState.phase !== 'detected') return;
+    const { result } = offsetState;
+    setOffsetState({ phase: 'applying', result });
+    try {
+      const apply = await applyTimestampOffset(result.speaker, result.offsetSec);
+      await reloadSpeakerAnnotation(result.speaker);
+      setOffsetState({ phase: 'applied', result, shifted: apply.shiftedIntervals });
+    } catch (err) {
+      setOffsetState({
+        phase: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
   const [exporting, setExporting] = useState(false);
 
   const resetProject = () => {
@@ -2062,6 +2106,15 @@ export function ParseUI() {
                     >
                       <Network className="h-3.5 w-3.5 text-slate-400"/>
                       {crossSpeakerJob.state.status === 'running' ? 'Matching…' : 'Run Cross-Speaker Match'}
+                    </button>
+                    <button
+                      onClick={() => { void detectOffsetForSpeaker(); }}
+                      disabled={!activeActionSpeaker || offsetState.phase === 'detecting' || offsetState.phase === 'applying'}
+                      data-testid="actions-detect-offset"
+                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Anchor className="h-3.5 w-3.5 text-slate-400"/>
+                      {offsetState.phase === 'detecting' ? 'Detecting offset…' : 'Detect Timestamp Offset'}
                     </button>
                     <div className="my-1 border-t border-slate-100"/>
                     <button
@@ -2892,6 +2945,87 @@ export function ParseUI() {
       />
       <Modal open={importModalOpen} onClose={() => setImportModalOpen(false)} title="Import Speaker">
         <SpeakerImport onImportComplete={handleImportComplete} />
+      </Modal>
+      <Modal
+        open={offsetState.phase !== 'idle'}
+        onClose={() => setOffsetState({ phase: 'idle' })}
+        title="Timestamp Offset"
+      >
+        <div className="space-y-3 text-sm" data-testid="offset-modal">
+          {offsetState.phase === 'detecting' && (
+            <div className="flex items-center gap-2 text-slate-600">
+              <Loader2 className="h-4 w-4 animate-spin"/> Detecting offset…
+            </div>
+          )}
+          {offsetState.phase === 'detected' && (
+            <>
+              <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-xs">
+                <div className="font-mono text-base text-slate-900" data-testid="offset-value">
+                  {offsetState.result.offsetSec >= 0 ? '+' : ''}{offsetState.result.offsetSec.toFixed(3)} s
+                </div>
+                <div className="mt-1 text-slate-600">
+                  Confidence {(offsetState.result.confidence * 100).toFixed(0)}% from {offsetState.result.nAnchors}/{offsetState.result.totalAnchors} anchors
+                  {' · '}{offsetState.result.totalSegments} STT segments
+                </div>
+              </div>
+              <p className="text-xs text-slate-600">
+                Apply will add this offset to every annotation interval (start &amp; end). Negative values pull
+                timestamps earlier — use this when the WAV is missing leading audio.
+              </p>
+              <div className="flex justify-end gap-2">
+                <button
+                  className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-50"
+                  onClick={() => setOffsetState({ phase: 'idle' })}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-700"
+                  onClick={() => { void applyDetectedOffset(); }}
+                  data-testid="offset-apply"
+                >
+                  Apply offset
+                </button>
+              </div>
+            </>
+          )}
+          {offsetState.phase === 'applying' && (
+            <div className="flex items-center gap-2 text-slate-600">
+              <Loader2 className="h-4 w-4 animate-spin"/> Applying offset…
+            </div>
+          )}
+          {offsetState.phase === 'applied' && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-emerald-700">
+                <CheckCircle2 className="h-4 w-4"/> Shifted {offsetState.shifted} intervals by {offsetState.result.offsetSec.toFixed(3)}s
+              </div>
+              <div className="flex justify-end">
+                <button
+                  className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-50"
+                  onClick={() => setOffsetState({ phase: 'idle' })}
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          )}
+          {offsetState.phase === 'error' && (
+            <div className="space-y-2">
+              <div className="flex items-start gap-2 text-rose-700">
+                <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0"/>
+                <span data-testid="offset-error">{offsetState.message}</span>
+              </div>
+              <div className="flex justify-end">
+                <button
+                  className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-50"
+                  onClick={() => setOffsetState({ phase: 'idle' })}
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       </Modal>
       <Modal open={commentsImportOpen} onClose={() => setCommentsImportOpen(false)} title="Import Audition Comments">
         <CommentsImport onImportComplete={() => setCommentsImportOpen(false)} />

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -260,6 +260,47 @@ export async function pollSTT(jobId: string): Promise<STTStatus> {
   });
 }
 
+// Timestamp offset — detect a constant CSV/STT misalignment and (optionally) apply it.
+export interface OffsetDetectResult {
+  speaker: string;
+  offsetSec: number;
+  confidence: number;
+  nAnchors: number;
+  totalAnchors: number;
+  totalSegments: number;
+  method: string;
+}
+
+export interface OffsetApplyResult {
+  speaker: string;
+  appliedOffsetSec: number;
+  shiftedIntervals: number;
+}
+
+export async function detectTimestampOffset(
+  speaker: string,
+  options?: { sttJobId?: string; sttSegments?: unknown[] }
+): Promise<OffsetDetectResult> {
+  return apiFetch<OffsetDetectResult>("/api/offset/detect", {
+    method: "POST",
+    body: JSON.stringify({
+      speaker,
+      sttJobId: options?.sttJobId,
+      sttSegments: options?.sttSegments,
+    }),
+  });
+}
+
+export async function applyTimestampOffset(
+  speaker: string,
+  offsetSec: number
+): Promise<OffsetApplyResult> {
+  return apiFetch<OffsetApplyResult>("/api/offset/apply", {
+    method: "POST",
+    body: JSON.stringify({ speaker, offsetSec }),
+  });
+}
+
 // IPA
 export async function requestIPA(text: string, language?: string): Promise<{ ipa: string }> {
   return apiFetch<{ ipa: string }>("/api/ipa", {


### PR DESCRIPTION
## Summary

- New **Detect Timestamp Offset** action in the Actions dropdown. Uses
  `python/compare/offset_detect.py` (already in the repo) to find a constant
  shift between a speaker's annotated lexeme timestamps and the STT
  segments for the same WAV. Confirms via a modal showing the detected
  offset + confidence, then applies it to every annotation interval.
- Designed for the case where an upstream working WAV had its leading
  audio trimmed off, so all CSV-sourced lexeme timestamps are uniformly
  later than the actual audio.
- Two new sync HTTP endpoints under `/api/offset/{detect,apply}`.
- Same capability exposed over MCP (`detect_timestamp_offset`,
  `apply_timestamp_offset`) so agents using the PARSE MCP server (Claude
  Code, Cursor, etc.) can run the alignment without going through the UI.

## How it works

1. `compare.anchors_from_intervals` builds anchor candidates from the
   speaker's `ortho`/`ipa`/`concept` tier intervals (no temp CSV needed).
2. `compare.segments_from_raw` builds STT segments from a completed
   in-memory STT job (no temp JSON needed).
3. `compare.detect_offset` runs the existing keyword-alignment +
   bucket-clustering pipeline and returns `(offsetSec, confidence,
   nMatched)`.
4. Apply adds `offsetSec` to every interval `start`/`end` (clamped at 0)
   and rewrites the annotation; the UI then reloads the speaker.

## Test plan

- [ ] Run STT on the affected speaker (the one with the trimmed WAV).
- [ ] Open Actions → **Detect Timestamp Offset**.
- [ ] Confirm the modal shows a sensible negative offset (≈ minutes
      missing from the WAV) with confidence ≥ ~0.5.
- [ ] Click **Apply offset**, confirm the count of shifted intervals
      matches the speaker's interval total, and that lexeme regions in
      Annotate now line up with the audio.
- [ ] Spot-check via MCP: `detect_timestamp_offset({speaker, sttJobId})`
      returns the same number; `apply_timestamp_offset({speaker,
      offsetSec, dryRun: true})` returns a sane preview.
- [ ] Run `pytest python/adapters/test_mcp_adapter.py` (the
      `test_every_mcp_tool_is_allowlisted_in_parse_chat_tools` cross-check
      will catch any phantom MCP-only tool names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)