### PR TITLE
fix(jobs): normalize inplace src==dst + surface real errors

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -2187,6 +2187,21 @@ def _run_normalize_job(job_id: str, speaker: str, source_wav: str) -> None:
         working_dir.mkdir(parents=True, exist_ok=True)
         output_path = build_normalized_output_path(audio_path, working_dir)
 
+        # If the source WAV is already living at the destination (e.g. a
+        # processed-speaker import landed the file directly under
+        # audio/working/<speaker>/), we can't ask ffmpeg to read-and-write the
+        # same file — it will truncate the input mid-read. Route the output
+        # through a sibling temp path and atomically replace after ffmpeg
+        # reports success.
+        try:
+            inplace = output_path.resolve() == audio_path.resolve()
+        except OSError:
+            inplace = str(output_path) == str(audio_path)
+        if inplace:
+            write_path = output_path.with_name(output_path.stem + ".normalized.tmp.wav")
+        else:
+            write_path = output_path
+
         # Pass 2: apply loudnorm with measured stats for precise normalization
         normalize_filter = "loudnorm=I={target}".format(target=NORMALIZE_LUFS_TARGET)
         if measured_i and measured_tp and measured_lra and measured_thresh:
@@ -2213,7 +2228,7 @@ def _run_normalize_job(job_id: str, speaker: str, source_wav: str) -> None:
             "-ac", NORMALIZE_CHANNELS,
             "-c:a", NORMALIZE_AUDIO_CODEC,
             "-sample_fmt", NORMALIZE_SAMPLE_FORMAT,
-            str(output_path),
+            str(write_path),
         ]
         proc = subprocess.run(
             normalize_cmd,
@@ -2223,11 +2238,21 @@ def _run_normalize_job(job_id: str, speaker: str, source_wav: str) -> None:
         )
 
         if proc.returncode != 0:
-            error_tail = (proc.stderr or "")[-500:]
-            raise RuntimeError("ffmpeg normalize failed: {0}".format(error_tail))
+            error_tail = (proc.stderr or "")[-800:]
+            if inplace and write_path.exists():
+                try:
+                    write_path.unlink()
+                except OSError:
+                    pass
+            raise RuntimeError("ffmpeg normalize failed (exit {0}): {1}".format(proc.returncode, error_tail))
 
-        if not output_path.exists():
+        if not write_path.exists():
             raise RuntimeError("ffmpeg produced no output file")
+
+        if inplace:
+            # Atomic same-filesystem swap keeps the workspace consistent —
+            # there's never a window where output_path is missing.
+            os.replace(str(write_path), str(output_path))
 
         _set_job_progress(job_id, 95.0, message="Finalizing")
 

--- a/python/test_run_normalize_inplace.py
+++ b/python/test_run_normalize_inplace.py
@@ -1,0 +1,134 @@
+"""Tests for _run_normalize_job inplace (src==dst) handling."""
+import pathlib
+import struct
+import subprocess
+import sys
+import wave
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+def _stub_ffmpeg_output(dest_path: pathlib.Path, *, bytes_: bytes = b"RIFF0000WAVEfmt \x01\x00\x01\x00\x40\x1f\x00\x00") -> None:
+    """Write a small file where ffmpeg would have written its output."""
+    dest_path.write_bytes(bytes_)
+
+
+def _fake_run(results_by_cmd):
+    """Build a subprocess.run stub keyed by whether the command ends with
+    measure (`-f null -`) or normalize (ends in a WAV path)."""
+    calls = []
+
+    def runner(cmd, *args, **kwargs):
+        calls.append(cmd)
+        # First measure pass — return empty stderr so loudnorm_stats stays None
+        if "null" in cmd:
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+        # Second pass: write an output file at the last arg and return success
+        dest = pathlib.Path(cmd[-1])
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if results_by_cmd.get("succeed", True):
+            _stub_ffmpeg_output(dest)
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(
+            cmd, returncode=1, stdout="",
+            stderr="x" * 2000 + "[Errno 21] Is a directory",  # important text in the tail
+        )
+
+    return runner, calls
+
+
+def _seed_workspace_wav(project_root: pathlib.Path, speaker: str, name: str = "source.wav") -> pathlib.Path:
+    working_dir = project_root / "audio" / "working" / speaker
+    working_dir.mkdir(parents=True, exist_ok=True)
+    wav_path = working_dir / name
+    # Generate a minimal valid WAV so audio_path.resolve() doesn't complain.
+    with wave.open(str(wav_path), "wb") as w:
+        w.setnchannels(1); w.setsampwidth(2); w.setframerate(16000)
+        w.writeframes(struct.pack("<8000h", *[0] * 8000))
+    return wav_path
+
+
+def test_inplace_source_is_not_truncated_mid_ffmpeg(tmp_path, monkeypatch):
+    """Regression for the 'source file inside workspace' bug: when the
+    resolved source path equals the computed output path, the worker must
+    route ffmpeg's output to a sibling temp file and atomically swap — never
+    letting ffmpeg read-and-write the same path, which would truncate input
+    mid-read."""
+    server._jobs.clear()
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    wav_path = _seed_workspace_wav(tmp_path, "Fail01", "Faili_M_1984.wav")
+    original_bytes = wav_path.read_bytes()
+
+    runner, calls = _fake_run({"succeed": True})
+    monkeypatch.setattr(server.subprocess, "run", runner)
+
+    job_id = server._create_job("normalize", {"speaker": "Fail01"})
+    server._run_normalize_job(job_id, "Fail01", "audio/working/Fail01/Faili_M_1984.wav")
+
+    job = server._jobs[job_id]
+    assert job["status"] == "complete", job.get("error")
+
+    # The ffmpeg normalize command should have targeted a *temp* path, not
+    # the input path. Find the normalize call (second subprocess.run).
+    normalize_cmd = [c for c in calls if isinstance(c, list) and "-af" in c and c[-1].endswith(".wav")][-1]
+    dest_arg = normalize_cmd[-1]
+    assert dest_arg != str(wav_path), "ffmpeg must not read-and-write the same path"
+    assert dest_arg.endswith(".normalized.tmp.wav"), dest_arg
+
+    # After the atomic swap, the canonical output path exists, and no temp
+    # file is left behind.
+    assert wav_path.exists()
+    assert not (tmp_path / "audio/working/Fail01" / "Faili_M_1984.normalized.tmp.wav").exists()
+    # The canonical output path carries the *new* (stubbed) bytes.
+    assert wav_path.read_bytes() != original_bytes
+
+
+def test_non_inplace_writes_directly_to_output_path(tmp_path, monkeypatch):
+    """When the source is not already at the working-copy path (normal
+    onboard flow, source under audio/original/), ffmpeg writes directly."""
+    server._jobs.clear()
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    # Source lives under audio/original/, not audio/working/
+    original_dir = tmp_path / "audio" / "original" / "Fail01"
+    original_dir.mkdir(parents=True)
+    src = original_dir / "raw.wav"
+    with wave.open(str(src), "wb") as w:
+        w.setnchannels(1); w.setsampwidth(2); w.setframerate(16000)
+        w.writeframes(struct.pack("<8000h", *[0] * 8000))
+
+    runner, calls = _fake_run({"succeed": True})
+    monkeypatch.setattr(server.subprocess, "run", runner)
+
+    job_id = server._create_job("normalize", {"speaker": "Fail01"})
+    server._run_normalize_job(job_id, "Fail01", "audio/original/Fail01/raw.wav")
+
+    assert server._jobs[job_id]["status"] == "complete"
+    normalize_cmd = [c for c in calls if isinstance(c, list) and "-af" in c and c[-1].endswith(".wav")][-1]
+    dest_arg = normalize_cmd[-1]
+    assert dest_arg.endswith("audio/working/Fail01/raw.wav") or dest_arg.endswith("audio\\working\\Fail01\\raw.wav"), dest_arg
+    assert ".normalized.tmp.wav" not in dest_arg  # no temp indirection needed
+
+
+def test_inplace_ffmpeg_failure_cleans_up_temp_and_reports_exit_code(tmp_path, monkeypatch):
+    """If ffmpeg fails during the inplace flow, the temp file must be
+    removed so a retry doesn't stumble over it, and the RuntimeError must
+    carry the exit code + stderr tail."""
+    server._jobs.clear()
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    wav_path = _seed_workspace_wav(tmp_path, "Fail01", "Faili_M_1984.wav")
+
+    runner, _ = _fake_run({"succeed": False})
+    monkeypatch.setattr(server.subprocess, "run", runner)
+
+    job_id = server._create_job("normalize", {"speaker": "Fail01"})
+    server._run_normalize_job(job_id, "Fail01", "audio/working/Fail01/Faili_M_1984.wav")
+
+    job = server._jobs[job_id]
+    assert job["status"] == "error"
+    assert "exit 1" in job["error"]
+    assert "Is a directory" in job["error"]
+    # Temp file must be removed so retries don't see stale artifacts
+    assert not (tmp_path / "audio/working/Fail01" / "Faili_M_1984.normalized.tmp.wav").exists()
+    # Original source should remain untouched
+    assert wav_path.exists()

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2060,7 +2060,26 @@ export function ParseUI() {
                     {job.state.status === 'error' && (
                       <>
                         <XCircle className="h-3 w-3 text-rose-500" />
-                        <span className="max-w-[200px] truncate text-rose-600">{job.state.error}</span>
+                        <span
+                          className="max-w-[560px] truncate text-rose-600"
+                          title={job.state.error ?? ''}
+                          data-testid="job-error-text"
+                        >
+                          {job.state.error}
+                        </span>
+                        <button
+                          onClick={() => {
+                            if (job.state.error) {
+                              console.error('[PARSE action job]', job.state.label, job.state.error);
+                              alert(`${job.state.label}\n\n${job.state.error}`);
+                            }
+                          }}
+                          className="text-[10px] text-rose-600 underline hover:text-rose-700"
+                          title="Show full error"
+                          data-testid="job-error-details"
+                        >
+                          Details
+                        </button>
                         <button
                           onClick={() => { void job.run(); }}
                           className="text-[10px] text-rose-600 underline hover:text-rose-700"

--- a/src/hooks/useActionJob.ts
+++ b/src/hooks/useActionJob.ts
@@ -198,7 +198,10 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
         setStateIfMounted({
           status: "error",
           progress,
-          error: poll.message ?? poll.error ?? "Job failed",
+          // Surface the actual exception (`poll.error`) first — `poll.message`
+          // is the last in-progress status line ("Loading model", "Initializing
+          // STT provider") and was masking the real failures.
+          error: poll.error ?? poll.message ?? "Job failed",
           label: config.label,
           etaMs: null,
         });


### PR DESCRIPTION
## Summary
Three fixes so Actions-menu failures are actually diagnosable, and so normalize works for processed-speaker imports.

### 1. `_run_normalize_job`: **inplace src==dst** (the bug the other agent flagged)
When `source_wav` resolves to the same path ffmpeg would write — e.g. processed-speaker imports land WAVs directly under `audio/working/<speaker>/` — ffmpeg was being asked to read-and-write the same file, which truncates the input mid-read. Fixed: detect `source.resolve() == output.resolve()`, route output to a sibling `<name>.normalized.tmp.wav`, then `os.replace()` over the source after ffmpeg reports success. Temp file is cleaned on failure. Error now includes the exit code and an 800-byte stderr tail (was 500, often truncating the real cause).

### 2. **Real errors were masked by the splash**
`useActionJob` populated `state.error` from `poll.message ?? poll.error ?? …` — but `message` is the *last progress status line* ("Loading model", "Initializing STT provider"). Failed jobs showed that stale label with a Retry button and no hint of the real cause. Swap the priority: prefer `poll.error`, fall back to `message`, then a generic "Job failed".

### 3. **Error text truncated to 200px in the UI**
The rose banner clipped anything past ~30 chars. Widen to 560px, add a `title` tooltip with the full text, and a new **Details** button that `console.error`s the full error and shows it in an `alert()` so users can select-copy the traceback for triage.

## Depends on
Stacks on top of [#109](https://github.com/ArdeleanLucas/PARSE/pull/109) (merged).

## Test plan
- [x] `python3.12 -m pytest python/test_run_normalize_inplace.py python/test_run_stt_job.py` — 7 passed (3 new + 4 from #109).
- [x] `npx tsc --noEmit` — clean.
- Manual on PC once merged:
  - Click Run Audio Normalization on Fail01 (source at `audio/working/Fail01/Faili_M_1984.wav`) — should no longer truncate the WAV; output ends up at the same path via an atomic swap.
  - Trigger an STT failure (expected — CUDA/model config issue per earlier diagnosis) and click **Details** on the error banner to see the full Python traceback in the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)