### PR TITLE
fix(compare): natural-sort the Survey view + drop the "Q" prefix

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1827,20 +1827,43 @@ export function ParseUI() {
     if (sortMode === 'az') {
       list = [...list].sort((a, b) => a.name.localeCompare(b.name));
     } else if (sortMode === 'survey') {
+      // Natural sort: group first by source (KLQ / JBIL / …), then by every
+      // embedded number in order (section, item, variant). Without this
+      // "JBIL_10" lands before "JBIL_2" because the default string compare
+      // treats each segment as a whole literal.
+      const surveyKey = (raw: string): (string | number)[] => {
+        const tokens: (string | number)[] = [];
+        // Pull out runs of letters and runs of digits separately. Dots and
+        // underscores act as delimiters only — "KLQ_1.10.A" yields
+        // ["klq", 1, 10, "a"] so item 10 sorts after item 2 (not before,
+        // which would happen if "1.10" were parsed as a decimal 1.1).
+        for (const match of raw.matchAll(/([A-Za-z]+)|(\d+)/g)) {
+          if (match[1]) tokens.push(match[1].toLowerCase());
+          else if (match[2]) tokens.push(parseInt(match[2], 10));
+        }
+        return tokens;
+      };
       list = [...list].sort((a, b) => {
         const av = a.surveyItem ?? '';
         const bv = b.surveyItem ?? '';
         if (av && !bv) return -1;
         if (!av && bv) return 1;
-        // Try numeric (section.item) comparison, fall back to lex
-        const na = av.split('.').map(n => parseFloat(n));
-        const nb = bv.split('.').map(n => parseFloat(n));
-        for (let i = 0; i < Math.max(na.length, nb.length); i++) {
-          const xa = na[i] ?? 0;
-          const xb = nb[i] ?? 0;
-          if (Number.isFinite(xa) && Number.isFinite(xb) && xa !== xb) return xa - xb;
+        const ka = surveyKey(av);
+        const kb = surveyKey(bv);
+        for (let i = 0; i < Math.max(ka.length, kb.length); i++) {
+          const xa = ka[i];
+          const xb = kb[i];
+          if (xa === undefined) return -1;
+          if (xb === undefined) return 1;
+          if (typeof xa === 'number' && typeof xb === 'number') {
+            if (xa !== xb) return xa - xb;
+          } else {
+            const sa = String(xa);
+            const sb = String(xb);
+            if (sa !== sb) return sa < sb ? -1 : 1;
+          }
         }
-        return av.localeCompare(bv);
+        return 0;
       });
     } else {
       list = [...list].sort((a, b) => a.id - b.id);
@@ -2281,7 +2304,9 @@ export function ParseUI() {
             {filtered.map(c => {
               const active = c.id === conceptId;
               const badge = sortMode === 'survey' && c.surveyItem ? c.surveyItem : String(c.id);
-              const badgePrefix = sortMode === 'survey' ? 'Q' : '#';
+              // Survey items already carry their own source prefix
+              // (KLQ_1.1.A / JBIL_32.A); adding a second "Q" read noisy.
+              const badgePrefix = sortMode === 'survey' ? '' : '#';
               return (
                 <button key={c.id} onClick={() => setConceptId(c.id)}
                   className={`group mb-0.5 flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left transition ${active ? 'bg-indigo-50 text-indigo-900' : 'text-slate-600 hover:bg-slate-50'}`}>

--- a/src/__tests__/surveySort.test.ts
+++ b/src/__tests__/surveySort.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+
+// Mirror of the surveyKey helper in ParseUI.tsx. Kept here so the ordering
+// contract is testable without mounting the whole component tree.
+function surveyKey(raw: string): (string | number)[] {
+  const tokens: (string | number)[] = [];
+  for (const match of raw.matchAll(/([A-Za-z]+)|(\d+)/g)) {
+    if (match[1]) tokens.push(match[1].toLowerCase());
+    else if (match[2]) tokens.push(parseInt(match[2], 10));
+  }
+  return tokens;
+}
+
+function compare(a: string, b: string): number {
+  const ka = surveyKey(a);
+  const kb = surveyKey(b);
+  for (let i = 0; i < Math.max(ka.length, kb.length); i++) {
+    const xa = ka[i];
+    const xb = kb[i];
+    if (xa === undefined) return -1;
+    if (xb === undefined) return 1;
+    if (typeof xa === "number" && typeof xb === "number") {
+      if (xa !== xb) return xa - xb;
+    } else {
+      const sa = String(xa);
+      const sb = String(xb);
+      if (sa !== sb) return sa < sb ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+describe("survey-item natural sort", () => {
+  it("orders JBIL numerically: 1, 2, 10, 11, 100 (not 1, 10, 100, 11, 2)", () => {
+    const items = ["JBIL_10.A", "JBIL_100.A", "JBIL_11.A", "JBIL_1.A", "JBIL_2.A"];
+    const sorted = [...items].sort(compare);
+    expect(sorted).toEqual([
+      "JBIL_1.A", "JBIL_2.A", "JBIL_10.A", "JBIL_11.A", "JBIL_100.A",
+    ]);
+  });
+
+  it("treats KLQ section.item as two integers (not a decimal)", () => {
+    // The pre-fix regex captured 1.10 as a float (1.1), so KLQ_1.10.A would
+    // land *before* KLQ_1.2.A. Guard that explicitly.
+    const items = [
+      "KLQ_1.10.A", "KLQ_1.2.A", "KLQ_1.2.B", "KLQ_2.1.A", "KLQ_1.1.A",
+    ];
+    const sorted = [...items].sort(compare);
+    expect(sorted).toEqual([
+      "KLQ_1.1.A", "KLQ_1.2.A", "KLQ_1.2.B", "KLQ_1.10.A", "KLQ_2.1.A",
+    ]);
+  });
+
+  it("groups by source prefix before number (JBIL before KLQ alphabetically)", () => {
+    const items = ["KLQ_1.1.A", "JBIL_1.A", "KLQ_2.1.A", "JBIL_10.A"];
+    const sorted = [...items].sort(compare);
+    expect(sorted).toEqual([
+      "JBIL_1.A", "JBIL_10.A", "KLQ_1.1.A", "KLQ_2.1.A",
+    ]);
+  });
+
+  it("A/B variants on the same (section,item) stay adjacent in variant order", () => {
+    const items = ["KLQ_1.2.B", "KLQ_1.1.A", "KLQ_1.2.A"];
+    const sorted = [...items].sort(compare);
+    expect(sorted).toEqual(["KLQ_1.1.A", "KLQ_1.2.A", "KLQ_1.2.B"]);
+  });
+
+  it("unprefixed numeric survey ids sort numerically too", () => {
+    // Fallback for workspaces that store bare numeric ids.
+    const items = ["10", "100", "11", "1", "2"];
+    const sorted = [...items].sort(compare);
+    expect(sorted).toEqual(["1", "2", "10", "11", "100"]);
+  });
+});


### PR DESCRIPTION
## Summary
Two sidebar Survey-sort issues in one change:

1. **Lexicographic ordering.** `JBIL_1.A` sorted before `JBIL_10.A` but also before `JBIL_2.A`, and `KLQ_1.10.A` landed before `KLQ_1.2.A`. Root cause: the comparator split on `.` and `parseFloat`'d each segment, so `1.10` looked like the decimal `1.1`.
2. **Redundant "Q" badge.** The sidebar showed `QJBIL_1` even though the survey_item already carries its own source prefix (JBIL / KLQ / …).

## Fix
- New `surveyKey(raw)` tokenises a survey_item into alternating letter-runs and integer-runs — `"KLQ_1.10.A"` → `["klq", 1, 10, "a"]`. Comparator walks the token lists element-wise: numbers numerically, letters lexically. Produces natural order within each source, grouped by source prefix, with A/B variants adjacent.
- Drop the "Q" badge prefix in Survey mode; the survey_item string is self-descriptive.

## Test plan
`npx vitest run src/__tests__/surveySort.test.ts` — **5 passed**:
- [x] JBIL orders 1, 2, 10, 11, 100
- [x] KLQ treats section.item as two integers (1.10 after 1.2)
- [x] source prefix grouping (JBIL before KLQ)
- [x] A/B variant adjacency on the same (section, item)
- [x] bare numeric ids still sort naturally

Live verify on PC: after this lands, Survey sort should render `JBIL_1.A, JBIL_2.A, JBIL_3.A, …, JBIL_10.A, JBIL_11.A, JBIL_100.A, KLQ_1.1.A, KLQ_1.2.A, …, KLQ_1.10.A` with no "Q" before the survey badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)