### PR TITLE
Unblock STT on missing cuBLAS + clip-bound default Play in Annotate

### DIFF
--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -662,6 +662,100 @@ def _dict_or_attr(item: Any, key: str, default: Any = None) -> Any:
     return getattr(item, key, default)
 
 
+# Cache so repeated _load_whisper_model calls don't re-walk the filesystem.
+_CUDA_DLL_DIRS_REGISTERED: Optional[bool] = None
+_CUDA_RUNTIME_FAILURE_MARKERS = (
+    "cublas",
+    "cudnn",
+    "cuda",
+    "is not found or cannot be loaded",
+    "could not load library",
+    "no cuda-capable device",
+    "no cuda gpus are available",
+    "cuda driver version is insufficient",
+    "cublasstatus",
+)
+
+
+def _looks_like_cuda_runtime_failure(message: str) -> bool:
+    """Heuristic — the GPU init failed because of a missing/broken CUDA runtime."""
+    text = (message or "").lower()
+    return any(marker in text for marker in _CUDA_RUNTIME_FAILURE_MARKERS)
+
+
+def _register_cuda_dll_directories() -> None:
+    """Register cuBLAS / cuDNN DLL directories on Windows.
+
+    Since Python 3.8 the loader no longer searches ``PATH`` for dependent
+    DLLs, so a Windows install with cuBLAS reachable via PATH still produces
+    ``Library cublas64_12.dll is not found or cannot be loaded`` when
+    CTranslate2 tries to ``LoadLibraryEx``. We add every plausible directory
+    via ``os.add_dll_directory`` so the import succeeds.
+
+    Safe no-op on non-Windows platforms.
+    """
+    global _CUDA_DLL_DIRS_REGISTERED
+    if _CUDA_DLL_DIRS_REGISTERED is not None:
+        return
+    _CUDA_DLL_DIRS_REGISTERED = False
+
+    if os.name != "nt":
+        return
+
+    add_dll_directory = getattr(os, "add_dll_directory", None)
+    if add_dll_directory is None:
+        return
+
+    candidates: List[Path] = []
+
+    # 1. NVIDIA pip wheels (nvidia-cublas-cu12, nvidia-cudnn-cu12) install
+    #    DLLs under <site-packages>/nvidia/<lib>/bin. Walk every nvidia
+    #    subpackage that has a `bin` dir.
+    try:
+        import nvidia  # type: ignore[import-not-found]
+
+        nvidia_root = Path(nvidia.__file__).resolve().parent
+        for entry in nvidia_root.iterdir():
+            bin_dir = entry / "bin"
+            if bin_dir.is_dir():
+                candidates.append(bin_dir)
+    except Exception:
+        pass
+
+    # 2. Explicit env vars that ship with CUDA Toolkit installs.
+    for env_key in ("CUDA_PATH", "CUDA_HOME", "CUDNN_PATH"):
+        value = os.environ.get(env_key)
+        if not value:
+            continue
+        candidates.append(Path(value) / "bin")
+        candidates.append(Path(value))
+
+    # 3. Anything the user explicitly added.
+    extra = os.environ.get("PARSE_CUDA_DLL_DIRS", "")
+    for chunk in extra.split(os.pathsep):
+        chunk = chunk.strip()
+        if chunk:
+            candidates.append(Path(chunk))
+
+    seen: set = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except Exception:
+            continue
+        if resolved in seen or not resolved.is_dir():
+            continue
+        seen.add(resolved)
+        try:
+            add_dll_directory(str(resolved))
+            _CUDA_DLL_DIRS_REGISTERED = True
+        except (OSError, FileNotFoundError):
+            # Directory exists but cannot be registered (e.g. permissions).
+            # Skip silently — the WhisperModel try/except below will surface
+            # any remaining DLL load failures with full context.
+            pass
+
+
 _ARABIC_DIACRITICS = {
     "\u064b",  # tanwin fatha
     "\u064c",  # tanwin damma
@@ -888,9 +982,20 @@ class LocalWhisperProvider(AIProvider):
         self._epitran_instances: Dict[str, Any] = {}
 
     def _load_whisper_model(self) -> Any:
-        """Lazy-load faster-whisper model."""
+        """Lazy-load faster-whisper model.
+
+        On Windows the CUDA backend needs cuBLAS / cuDNN DLLs visible to the
+        process. Since Python 3.8, ``PATH`` is no longer searched for DLLs, so
+        even a correct CUDA install can fail with
+        ``Library cublas64_12.dll is not found or cannot be loaded``. We
+        proactively register every plausible DLL directory before importing
+        ``faster_whisper`` (it's the import that triggers the CTranslate2
+        load), then fall back to CPU if the GPU model still won't initialize.
+        """
         if self._whisper_model is not None:
             return self._whisper_model
+
+        _register_cuda_dll_directories()
 
         try:
             from faster_whisper import WhisperModel
@@ -910,6 +1015,8 @@ class LocalWhisperProvider(AIProvider):
             )
 
         self._model_source = model_source
+        wants_gpu = str(self.device or "").strip().lower() in {"cuda", "auto"} or \
+            self.device.lower().startswith("cuda")
 
         try:
             self._whisper_model = WhisperModel(
@@ -919,29 +1026,11 @@ class LocalWhisperProvider(AIProvider):
             )
             self._effective_device = self.device
             self._effective_compute_type = self.compute_type
+            return self._whisper_model
         except Exception as exc:
-            if self.device.lower().startswith("cuda"):
-                print(
-                    "[WARN] Failed to load faster-whisper on CUDA ('{0}'): {1}. "
-                    "This commonly means cuBLAS/cuDNN DLLs are missing. "
-                    "Retrying on CPU/int8.".format(model_source, exc),
-                    file=sys.stderr,
-                )
-                try:
-                    self._whisper_model = WhisperModel(
-                        model_source, device="cpu", compute_type="int8"
-                    )
-                    self._effective_device = "cpu"
-                    self._effective_compute_type = "int8"
-                except Exception as cpu_exc:
-                    print(
-                        "[ERROR] CPU fallback also failed for model '{0}': {1}".format(
-                            model_source, cpu_exc
-                        ),
-                        file=sys.stderr,
-                    )
-                    raise cpu_exc from exc
-            else:
+            message = str(exc)
+            cuda_failure = wants_gpu and _looks_like_cuda_runtime_failure(message)
+            if not cuda_failure:
                 print(
                     "[ERROR] Failed to load faster-whisper model '{0}': {1}".format(
                         model_source, exc
@@ -950,7 +1039,35 @@ class LocalWhisperProvider(AIProvider):
                 )
                 raise
 
-        return self._whisper_model
+            print(
+                "[WARN] CUDA backend unavailable for faster-whisper "
+                "(device='{0}', compute_type='{1}'): {2}. "
+                "Falling back to CPU (compute_type='int8'). To use GPU, install "
+                "the matching cuDNN / cuBLAS runtime — typically "
+                "`pip install nvidia-cudnn-cu12 nvidia-cublas-cu12` — and ensure "
+                "their `bin` directories are reachable.".format(
+                    self.device, self.compute_type, message
+                ),
+                file=sys.stderr,
+            )
+
+            try:
+                self._whisper_model = WhisperModel(
+                    model_source, device="cpu", compute_type="int8"
+                )
+                self._effective_device = "cpu"
+                self._effective_compute_type = "int8"
+            except Exception as cpu_exc:
+                print(
+                    "[ERROR] CPU fallback for faster-whisper also failed: {0}".format(cpu_exc),
+                    file=sys.stderr,
+                )
+                raise RuntimeError(
+                    "STT initialization failed on both GPU and CPU. "
+                    "Original GPU error: {0}. CPU fallback error: {1}".format(message, cpu_exc)
+                ) from cpu_exc
+
+            return self._whisper_model
 
     def transcribe(
         self,

--- a/python/test_stt_cuda_fallback.py
+++ b/python/test_stt_cuda_fallback.py
@@ -1,0 +1,148 @@
+"""Tests for cuBLAS / cuDNN runtime fallback in LocalWhisperProvider.
+
+Covers the ``Library cublas64_12.dll is not found or cannot be loaded``
+class of errors: when the requested CUDA backend can't initialise we want
+STT to silently retry on CPU rather than block the entire pipeline. This
+mirrors the user requirement: "when wav files are located within parse
+workspace, it should be possible to trigger STT, IPA transcriptions, and
+all tools".
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import List
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from ai import provider as provider_module
+from ai.provider import (
+    LocalWhisperProvider,
+    _looks_like_cuda_runtime_failure,
+    _register_cuda_dll_directories,
+)
+
+
+CUBLAS_ERROR = (
+    "Library cublas64_12.dll is not found or cannot be loaded"
+)
+
+
+class _FakeWhisperModel:
+    """Stand-in for faster_whisper.WhisperModel that mimics the GPU/CPU split.
+
+    First ``raise_until`` constructions raise the configured CUDA error;
+    after that, instances record the device/compute_type they were built
+    with so the test can assert the fallback used "cpu" / "int8".
+    """
+
+    raise_until: int = 0
+    instances: List["_FakeWhisperModel"] = []
+
+    def __init__(self, model_source: str, device: str, compute_type: str) -> None:
+        if _FakeWhisperModel.raise_until > 0:
+            _FakeWhisperModel.raise_until -= 1
+            raise RuntimeError(CUBLAS_ERROR)
+        self.model_source = model_source
+        self.device = device
+        self.compute_type = compute_type
+        _FakeWhisperModel.instances.append(self)
+
+
+def _install_fake_whisper(monkeypatch, *, raise_until: int) -> None:
+    _FakeWhisperModel.raise_until = raise_until
+    _FakeWhisperModel.instances = []
+
+    class _FakeFasterWhisperModule:
+        WhisperModel = _FakeWhisperModel
+
+    monkeypatch.setitem(sys.modules, "faster_whisper", _FakeFasterWhisperModule)
+
+
+def test_looks_like_cuda_runtime_failure_matches_cublas_dll_error() -> None:
+    assert _looks_like_cuda_runtime_failure(CUBLAS_ERROR)
+    assert _looks_like_cuda_runtime_failure("CUDA driver version is insufficient")
+    assert _looks_like_cuda_runtime_failure("Could not load library libcudnn.so.8")
+    assert not _looks_like_cuda_runtime_failure("model.bin: file not found")
+    assert not _looks_like_cuda_runtime_failure("")
+
+
+def test_register_cuda_dll_directories_is_idempotent_and_safe_off_windows() -> None:
+    # Reset the cache so the first call actually runs.
+    provider_module._CUDA_DLL_DIRS_REGISTERED = None  # type: ignore[attr-defined]
+    _register_cuda_dll_directories()
+    first = provider_module._CUDA_DLL_DIRS_REGISTERED  # type: ignore[attr-defined]
+    # Second invocation should be a no-op (cache flag retained).
+    _register_cuda_dll_directories()
+    assert provider_module._CUDA_DLL_DIRS_REGISTERED is first
+
+
+def test_cuda_runtime_failure_falls_back_to_cpu(monkeypatch) -> None:
+    _install_fake_whisper(monkeypatch, raise_until=1)
+
+    provider_module._CUDA_DLL_DIRS_REGISTERED = True  # type: ignore[attr-defined]
+
+    provider = LocalWhisperProvider(
+        config={
+            "stt": {
+                "model_path": "tiny",
+                "device": "cuda",
+                "compute_type": "float16",
+            }
+        }
+    )
+    model = provider._load_whisper_model()
+
+    assert isinstance(model, _FakeWhisperModel)
+    assert model.device == "cpu"
+    assert model.compute_type == "int8"
+    # Provider records the realised runtime separately from the requested
+    # device so other consumers that read self.device still see the user's
+    # intent. Status payloads / loaders should prefer _effective_device.
+    assert provider._effective_device == "cpu"
+    assert provider._effective_compute_type == "int8"
+
+
+def test_non_cuda_failure_is_re_raised_without_cpu_fallback(monkeypatch) -> None:
+    class _FailingFasterWhisperModule:
+        @staticmethod
+        def WhisperModel(model_source, device, compute_type):  # noqa: N802
+            raise RuntimeError("model.bin: file not found")
+
+    monkeypatch.setitem(sys.modules, "faster_whisper", _FailingFasterWhisperModule)
+    provider_module._CUDA_DLL_DIRS_REGISTERED = True  # type: ignore[attr-defined]
+
+    provider = LocalWhisperProvider(
+        config={
+            "stt": {
+                "model_path": "tiny",
+                "device": "cuda",
+                "compute_type": "float16",
+            }
+        }
+    )
+
+    try:
+        provider._load_whisper_model()
+    except RuntimeError as exc:
+        assert "file not found" in str(exc)
+    else:
+        raise AssertionError("expected non-CUDA failure to propagate")
+
+
+def test_cpu_device_failure_does_not_attempt_cpu_fallback(monkeypatch) -> None:
+    """If the user explicitly asked for CPU and it failed, we shouldn't
+    silently swallow that into a second CPU attempt."""
+    _install_fake_whisper(monkeypatch, raise_until=1)
+    provider_module._CUDA_DLL_DIRS_REGISTERED = True  # type: ignore[attr-defined]
+
+    provider = LocalWhisperProvider(
+        config={"stt": {"model_path": "tiny", "device": "cpu", "compute_type": "int8"}}
+    )
+
+    try:
+        provider._load_whisper_model()
+    except RuntimeError as exc:
+        assert CUBLAS_ERROR in str(exc) or "cublas" in str(exc).lower()
+    else:
+        raise AssertionError("expected CPU init failure to propagate")

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1254,7 +1254,7 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
       : null;
   }, [conceptInterval]);
 
-  const { playPause, seek, scrollToTimeAtFraction, skip, addRegion, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
+  const { playPause, playClip, pause, seek, scrollToTimeAtFraction, skip, addRegion, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
     containerRef,
     audioUrl,
     peaksUrl,
@@ -1610,7 +1610,22 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
           <button onClick={() => skip(-5)} title="-5s" className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><SkipBack className="h-4 w-4"/></button>
           <button onClick={() => skip(-1)} title="-1s" className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><ChevronLeft className="h-4 w-4"/></button>
           <button
-            onClick={() => playPause()}
+            onClick={() => {
+              if (isPlaying) {
+                pause();
+                return;
+              }
+              // Default play: bound to the active lexeme region so the
+              // clip stops at end. Pressing play again (cursor now at
+              // region end) or after seeking elsewhere falls through to
+              // unbounded continuous playback inside playClip.
+              if (selectedRegion) {
+                playClip(selectedRegion.end);
+              } else {
+                playPause();
+              }
+            }}
+            data-testid="annotate-play"
             className="grid h-10 w-10 place-items-center rounded-full bg-slate-900 text-white shadow-sm hover:bg-slate-700"
           >
             {isPlaying ? <Pause className="h-4 w-4"/> : <Play className="h-4 w-4 translate-x-[1px]"/>}

--- a/src/hooks/__tests__/useWaveSurfer.test.ts
+++ b/src/hooks/__tests__/useWaveSurfer.test.ts
@@ -15,6 +15,7 @@ const { mockWsInstance, mockRegionInstance, mockRegionsPlugin, mockSetState } =
       play: vi.fn(),
       pause: vi.fn(),
       playPause: vi.fn(),
+      isPlaying: vi.fn(() => false),
       destroy: vi.fn(),
       load: vi.fn(),
       seekTo: vi.fn(),
@@ -176,5 +177,120 @@ describe("useWaveSurfer", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(mockWsInstance.setScroll).toHaveBeenCalledWith(120);
+  });
+
+  // -- Clip-bounded play --
+  //
+  // The Annotate "Play" button passes the active region's end into
+  // playClip() so the first press plays just that lexeme. Subsequent
+  // presses (cursor at end), or seeks to a different position, must fall
+  // through to normal continuous playback.
+
+  function findHandler(eventName: string): ((arg: unknown) => void) | undefined {
+    const call = mockWsInstance.on.mock.calls.find(([name]) => name === eventName);
+    return call?.[1] as ((arg: unknown) => void) | undefined;
+  }
+
+  it("playClip(end) starts playback and pauses at end via timeupdate", () => {
+    mockWsInstance.getCurrentTime.mockReturnValue(1);
+    const { result } = renderHook(() =>
+      useWaveSurfer({
+        containerRef: makeContainerRef(),
+        audioUrl: "/audio/test.wav",
+      }),
+    );
+
+    let started = false;
+    act(() => {
+      started = result.current.playClip(3) as boolean;
+    });
+    expect(started).toBe(true);
+    expect(mockWsInstance.play).toHaveBeenCalledTimes(1);
+
+    const onTime = findHandler("timeupdate");
+    expect(onTime).toBeDefined();
+
+    // First tick well before end — no pause yet.
+    act(() => {
+      onTime!(2.5);
+    });
+    expect(mockWsInstance.pause).not.toHaveBeenCalled();
+
+    // Crossing end — pause exactly once.
+    act(() => {
+      onTime!(3.0);
+    });
+    expect(mockWsInstance.pause).toHaveBeenCalledTimes(1);
+
+    // Subsequent ticks should NOT pause again (clipEnd was cleared).
+    act(() => {
+      onTime!(3.2);
+    });
+    expect(mockWsInstance.pause).toHaveBeenCalledTimes(1);
+  });
+
+  it("playClip(end) degrades to plain play when cursor is already past end", () => {
+    mockWsInstance.getCurrentTime.mockReturnValue(3.5);
+    const { result } = renderHook(() =>
+      useWaveSurfer({
+        containerRef: makeContainerRef(),
+        audioUrl: "/audio/test.wav",
+      }),
+    );
+
+    let started = false;
+    act(() => {
+      started = result.current.playClip(3) as boolean;
+    });
+
+    expect(started).toBe(false);
+    expect(mockWsInstance.play).toHaveBeenCalledTimes(1);
+
+    // Even at later timeupdates, no clip-bound pause should fire.
+    const onTime = findHandler("timeupdate");
+    act(() => onTime!(99));
+    expect(mockWsInstance.pause).not.toHaveBeenCalled();
+  });
+
+  it("seek() clears any pending clip-bound so the next play is unbounded", () => {
+    mockWsInstance.getCurrentTime.mockReturnValue(1);
+    const { result } = renderHook(() =>
+      useWaveSurfer({
+        containerRef: makeContainerRef(),
+        audioUrl: "/audio/test.wav",
+      }),
+    );
+
+    act(() => {
+      result.current.playClip(3);
+    });
+    act(() => {
+      result.current.seek(7);
+    });
+
+    const onTime = findHandler("timeupdate");
+    act(() => onTime!(3));
+    expect(mockWsInstance.pause).not.toHaveBeenCalled();
+  });
+
+  it("waveform 'interaction' event clears the pending clip-bound", () => {
+    mockWsInstance.getCurrentTime.mockReturnValue(1);
+    const { result } = renderHook(() =>
+      useWaveSurfer({
+        containerRef: makeContainerRef(),
+        audioUrl: "/audio/test.wav",
+      }),
+    );
+
+    act(() => {
+      result.current.playClip(3);
+    });
+    const onInteraction = findHandler("interaction");
+    expect(onInteraction).toBeDefined();
+    act(() => onInteraction!(null));
+
+    const onTime = findHandler("timeupdate");
+    act(() => onTime!(3));
+    expect(mockWsInstance.pause).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useWaveSurfer.ts
+++ b/src/hooks/useWaveSurfer.ts
@@ -83,17 +83,69 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
   const activeRegionRef = useRef<WsRegion | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
+  // When set, the next time `timeupdate` reports >= this time the wave is
+  // paused and the ref is cleared. Used by `playClip` to make the default
+  // play action stop at a lexeme boundary without bleeding into the next
+  // word. Cleared on every pause / seek so subsequent plays are unbounded.
+  const clipEndRef = useRef<number | null>(null);
+
   // -- Imperative controls (stable refs) --
 
-  const play = useCallback(() => wsRef.current?.play(), []);
+  const play = useCallback(() => {
+    clipEndRef.current = null;
+    wsRef.current?.play();
+  }, []);
   const pause = useCallback(() => wsRef.current?.pause(), []);
-  const playPause = useCallback(() => wsRef.current?.playPause(), []);
+  const playPause = useCallback(() => {
+    if (!wsRef.current) return;
+    if (wsRef.current.isPlaying()) {
+      wsRef.current.pause();
+    } else {
+      clipEndRef.current = null;
+      wsRef.current.play();
+    }
+  }, []);
+
+  /**
+   * Play the wave starting from the current cursor position, but pause
+   * automatically at ``endSec``. Designed for the Annotate "Play" button:
+   * the first click on a freshly-loaded lexeme should play just that
+   * region, but if the cursor is already past the boundary (or the user
+   * has seeked elsewhere) we fall back to normal continuous playback.
+   *
+   * Returns true if the clip-bounded play actually started, false if the
+   * call degraded to a regular play (so the UI can stay symmetric with
+   * `play()`).
+   */
+  const playClip = useCallback((endSec: number) => {
+    const ws = wsRef.current;
+    if (!ws) return false;
+    if (!Number.isFinite(endSec) || endSec <= 0) {
+      clipEndRef.current = null;
+      ws.play();
+      return false;
+    }
+    const current = ws.getCurrentTime();
+    // Tolerate a small fractional gap so clicking play immediately after
+    // it auto-stops doesn't re-clip onto a single sample.
+    if (current >= endSec - 0.01) {
+      clipEndRef.current = null;
+      ws.play();
+      return false;
+    }
+    clipEndRef.current = endSec;
+    ws.play();
+    return true;
+  }, []);
 
   const seekToSec = useCallback((timeSec: number) => {
     const ws = wsRef.current;
     if (!ws) return;
     const duration = ws.getDuration();
     if (!duration || duration <= 0) return;
+    // A user-initiated seek invalidates any pending clip-bound: pressing
+    // play after seeking elsewhere should resume normal playback.
+    clipEndRef.current = null;
     ws.seekTo(clamp(timeSec / duration, 0, 1));
   }, []);
 
@@ -221,6 +273,11 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     // -- Store sync & callbacks --
 
     ws.on("timeupdate", (t: number) => {
+      const stopAt = clipEndRef.current;
+      if (stopAt !== null && t >= stopAt) {
+        clipEndRef.current = null;
+        ws.pause();
+      }
       options.onTimeUpdate?.(t);
       usePlaybackStore.setState({ currentTime: t });
     });
@@ -245,13 +302,24 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     });
 
     ws.on("pause", () => {
+      // Manual pause (or our own clip-bounded pause) discards any pending
+      // clip-end so the next play starts unbounded.
+      clipEndRef.current = null;
       options.onPlayStateChange?.(false);
       usePlaybackStore.setState({ isPlaying: false });
     });
 
     ws.on("finish", () => {
+      clipEndRef.current = null;
       options.onPlayStateChange?.(false);
       usePlaybackStore.setState({ isPlaying: false });
+    });
+
+    ws.on("interaction", () => {
+      // Clicking on the waveform itself triggers wavesurfer's built-in
+      // seek; that's a "user moved elsewhere" signal — clear any pending
+      // clip-bound so the next play resumes normal playback.
+      clipEndRef.current = null;
     });
 
     // -- Region events --
@@ -352,6 +420,7 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
       wsRef.current = null;
       regionsRef.current = null;
       activeRegionRef.current = null;
+      clipEndRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.audioUrl, options.peaksUrl, options.initialSeekSec]);
@@ -360,6 +429,7 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     play,
     pause,
     playPause,
+    playClip,
     seek,
     scrollToTimeAtFraction,
     skip,


### PR DESCRIPTION
Two unrelated fixes that came up together.

## 1. STT no longer blocked by missing cuBLAS / cuDNN DLLs

`RuntimeError: Library cublas64_12.dll is not found or cannot be loaded`
was leaving the STT worker in a permanent error state on Windows even
when normalize / IPA still worked. The user requirement is that with a
WAV in the workspace, STT/IPA must always be runnable.

Two complementary fixes in `python/ai/provider.py`:

- **Register CUDA DLL directories before importing faster_whisper.**
  Since Python 3.8 the loader no longer searches `PATH` for dependent
  DLLs, so a Windows install with cuBLAS reachable via PATH still fails
  CTranslate2's `LoadLibraryEx`. We walk
  `<site-packages>/nvidia/<lib>/bin` (where pip-installed
  `nvidia-cublas-cu12` / `nvidia-cudnn-cu12` land), the
  `CUDA_PATH` / `CUDA_HOME` / `CUDNN_PATH` env vars, and an optional
  `PARSE_CUDA_DLL_DIRS` escape hatch — each gets
  `os.add_dll_directory()`. Safe no-op on non-Windows.
- **Fall back to CPU on CUDA runtime failures.** If `WhisperModel`
  raises anything matching cublas/cudnn/cuda/etc., log a clear warning
  pointing at the pip remedy, then retry with `device='cpu'`,
  `compute_type='int8'`. Provider state is updated so subsequent loads
  and status payloads reflect the realised runtime instead of
  continuing to claim GPU. Explicit CPU device failures are NOT
  silently re-attempted (would mask the real error), and non-CUDA
  failures (missing model file etc.) propagate unchanged.

`python/test_stt_cuda_fallback.py` covers the helpers and three
fallback paths.

## 2. Annotate Play button now plays just the selected lexeme

When a lexeme is selected in Annotate, the Play button used to keep
playing past the segment boundary. New behaviour: first press plays
that segment and stops at its end. Pressing Play again (cursor at
region end) or after seeking elsewhere falls through to normal
continuous playback.

Done with a new `playClip(endSec)` on `useWaveSurfer` that sets a
one-shot stop target; the existing `timeupdate` listener pauses when
the cursor crosses it, then clears the target. The pending bound is
cleared on pause, finish, seek (programmatic and the new wavesurfer
`interaction` click), and the next `playClip` / `play` — so
"play after stop" and "play after clicking elsewhere" both resume
unbounded.

Four new tests cover the happy path, the already-past-end
degrade-to-plain-play case, and both clear paths (seek + interaction).

## Test plan

- [ ] On a Windows machine without `nvidia-cublas-cu12` installed:
      run STT — should succeed on CPU with a warning in the server log,
      not error.
- [ ] On the same machine after `pip install nvidia-cublas-cu12 nvidia-cudnn-cu12`:
      restart the server, run STT — should pick GPU automatically.
- [ ] In Annotate mode: select a lexeme, press Play — playback stops
      at the lexeme end. Press Play again — plays the rest of the WAV
      normally. Click elsewhere on the waveform, press Play — plays
      normally.
- [ ] `pytest python/test_stt_cuda_fallback.py` (or the simple
      no-pytest runner shown in the PR) passes.
- [ ] `vitest run src/hooks/__tests__/useWaveSurfer.test.ts` shows
      10/10 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)