### PR TITLE
fix(compare): wire Borrowing detection to CLEF contact-lexemes compute type

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2747,8 +2747,7 @@ export function ParseUI() {
                     className="w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-[11px] text-slate-700 focus:border-indigo-300 focus:outline-none">
                     <option value="cognates">Cognates</option>
                     <option value="similarity">Phonetic similarity</option>
-                    <option value="alignment">Alignment</option>
-                    <option value="borrowings">Borrowing detection</option>
+                    <option value="contact-lexemes">Borrowing detection (CLEF)</option>
                   </select>
                   <div className="mt-2 grid grid-cols-2 gap-1.5">
                     <button


### PR DESCRIPTION
## Summary

- `Borrowing detection` in the Compare right-drawer Compute dropdown was mapped to `borrowings`, which the server doesn't support → threw *"Unsupported compute type: borrowings"* on every Run
- `Alignment` option had the same problem (`alignment` is also unhandled server-side) — removed it
- Both are replaced with a single correct entry: `contact-lexemes` (the CLEF provider pipeline), now labelled **Borrowing detection (CLEF)**

## Test plan

- [ ] Open Compare mode → right drawer → COMPUTE section
- [ ] Select **Borrowing detection (CLEF)** and click Run — job should start without an "Unsupported compute type" error
- [ ] Cognates and Phonetic similarity still run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)