### PR TITLE
fix(stt): extend CUDA fallback to mid-transcription + PARSE_STT_FORCE_CPU

### DIFF
--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -683,6 +683,12 @@ def _looks_like_cuda_runtime_failure(message: str) -> bool:
     return any(marker in text for marker in _CUDA_RUNTIME_FAILURE_MARKERS)
 
 
+def _stt_force_cpu_env() -> bool:
+    """Respect PARSE_STT_FORCE_CPU as an emergency escape hatch."""
+    value = os.environ.get("PARSE_STT_FORCE_CPU", "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
 def _register_cuda_dll_directories() -> None:
     """Register cuBLAS / cuDNN DLL directories on Windows.
 
@@ -975,6 +981,15 @@ class LocalWhisperProvider(AIProvider):
             str(compute_type or stt_config.get("compute_type", "int8")).strip() or "int8"
         )
 
+        if _stt_force_cpu_env() and self.device.lower().startswith("cuda"):
+            print(
+                "[WARN] PARSE_STT_FORCE_CPU set; overriding stt.device "
+                "'{0}' → 'cpu' and compute_type → 'int8' before model load.".format(self.device),
+                file=sys.stderr,
+            )
+            self.device = "cpu"
+            self.compute_type = "int8"
+
         self._whisper_model: Optional[Any] = None
         self._model_source: Optional[str] = None
         self._effective_device: Optional[str] = None
@@ -1113,20 +1128,43 @@ class LocalWhisperProvider(AIProvider):
         try:
             segments_out = _run_transcription(model)
         except Exception as exc:
-            if self._effective_device == "cuda":
+            on_cuda = (
+                self._effective_device is not None
+                and self._effective_device.lower().startswith("cuda")
+            )
+            cuda_failure = on_cuda or _looks_like_cuda_runtime_failure(str(exc))
+            if not cuda_failure:
+                raise
+
+            print(
+                "[WARN] CUDA inference failed mid-transcription: {0}. "
+                "Rebuilding model on CPU/int8 and retrying. To use GPU, install "
+                "the matching cuDNN / cuBLAS runtime — typically "
+                "`pip install nvidia-cudnn-cu12 nvidia-cublas-cu12`.".format(exc),
+                file=sys.stderr,
+            )
+            os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+            from faster_whisper import WhisperModel as _WM
+            cpu_source = self._model_source or self.model_path or "base"
+            try:
+                cpu_model = _WM(cpu_source, device="cpu", compute_type="int8")
+            except Exception as cpu_exc:
                 print(
-                    "[WARN] CUDA inference failed mid-transcription: {0}. "
-                    "Rebuilding model on CPU/int8 and retrying.".format(exc),
+                    "[ERROR] CPU fallback rebuild failed for model '{0}': {1}".format(
+                        cpu_source, cpu_exc
+                    ),
                     file=sys.stderr,
                 )
-                from faster_whisper import WhisperModel as _WM
-                cpu_model = _WM(self._model_source, device="cpu", compute_type="int8")
-                self._whisper_model = cpu_model
-                self._effective_device = "cpu"
-                self._effective_compute_type = "int8"
-                segments_out = _run_transcription(cpu_model)
-            else:
-                raise
+                raise RuntimeError(
+                    "STT mid-transcription CUDA failure and CPU fallback both failed. "
+                    "Original GPU error: {0}. CPU fallback error: {1}".format(exc, cpu_exc)
+                ) from cpu_exc
+
+            self._whisper_model = cpu_model
+            self._effective_device = "cpu"
+            self._effective_compute_type = "int8"
+            segments_out = _run_transcription(cpu_model)
 
         if progress_callback is not None:
             progress_callback(100.0, len(segments_out))


### PR DESCRIPTION
## Summary

Follow-up to [#117](https://github.com/ArdeleanLucas/PARSE/pull/117) / [#118](https://github.com/ArdeleanLucas/PARSE/pull/118). Those covered CUDA fallback at model-load time, but STT still fails with `Library cublas64_12.dll is not found or cannot be loaded` because the DLL load happens **lazily during the first forward pass** — `WhisperModel(device='cuda')` returns successfully, then `model.transcribe()` blows up on first segment.

- `transcribe()` mid-inference fallback now fires on **any** CUDA-shaped error (cublas / cudnn / cuda / etc.), not only the literal `_effective_device == "cuda"` check — which missed `"cuda:0"`-style configs and the lazy-load path.
- Sets `CUDA_VISIBLE_DEVICES=""` before the CPU rebuild so CTranslate2 stops probing the GPU on retry.
- If the CPU rebuild itself fails, surfaces **both** errors in the raised `RuntimeError` instead of masking the GPU one.
- New env var `PARSE_STT_FORCE_CPU=1` — at `LocalWhisperProvider.__init__`, coerces `device`/`compute_type` to `cpu`/`int8` before any model construction. Emergency bypass for installs where probing CUDA at all is undesirable.

## Root cause

PR #118's fallback is in `_load_whisper_model`. But `faster_whisper.WhisperModel.transcribe()` is lazy — it returns a generator, and CTranslate2's `LoadLibraryEx` for `cublas64_12.dll` fires on first iteration. That exception escaped `_load_whisper_model` and hit `transcribe()`'s narrower fallback, which required exact `"cuda"` match.

## Test plan

- [ ] Deploy to `/home/lucas/parse-workspace`, restart API, re-run STT on a workspace WAV
- [ ] If CUDA init itself is suspected to be the block point, set `PARSE_STT_FORCE_CPU=1` in the systemd unit / launch script and restart
- [ ] Confirm normalize + IPA still pass (unchanged paths)
- [ ] Existing `test_stt_cuda_fallback.py` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)