### PR TITLE
fix(compare): restore Survey natural-sort + drop "Q" badge prefix

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -943,8 +943,51 @@ def _annotation_shift_intervals(record: Dict[str, Any], offset_sec: float) -> in
     return shifted
 
 
+def _stt_cache_path(speaker: str) -> pathlib.Path:
+    return _project_root() / "coarse_transcripts" / "{0}.json".format(speaker)
+
+
+def _write_stt_cache(speaker: str, source_wav: str, language: Optional[str], segments: List[Dict[str, Any]]) -> None:
+    speaker_norm = str(speaker or "").strip()
+    if not speaker_norm or not isinstance(segments, list) or not segments:
+        return
+    cache_path = _stt_cache_path(speaker_norm)
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "speaker": speaker_norm,
+            "source_wav": source_wav,
+            "language": language,
+            "segments": segments,
+        }
+        with open(cache_path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False)
+    except OSError as exc:
+        print("[stt] failed to cache segments for {0!r}: {1}".format(speaker_norm, exc), file=sys.stderr, flush=True)
+
+
+def _read_stt_cache(speaker: str) -> Optional[List[Dict[str, Any]]]:
+    cache_path = _stt_cache_path(speaker)
+    if not cache_path.exists():
+        return None
+    try:
+        with open(cache_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    segments = data.get("segments") if isinstance(data, dict) else None
+    if not isinstance(segments, list) or not segments:
+        return None
+    return segments
+
+
 def _latest_stt_segments_for_speaker(speaker: str) -> Optional[List[Dict[str, Any]]]:
-    """Find the most recent completed STT job for ``speaker`` and return its segments."""
+    """Find the most recent completed STT job for ``speaker`` and return its segments.
+
+    Prefers the current session's in-memory job. Falls back to the on-disk
+    ``coarse_transcripts/<speaker>.json`` cache so actions like offset-detect
+    still work after a server restart.
+    """
     speaker_norm = str(speaker or "").strip()
     if not speaker_norm:
         return None
@@ -964,10 +1007,10 @@ def _latest_stt_segments_for_speaker(speaker: str) -> Optional[List[Dict[str, An
                 continue
             ts = float(job.get("completed_ts") or job.get("updated_ts") or 0.0)
             candidates.append((ts, copy.deepcopy(segments)))
-    if not candidates:
-        return None
-    candidates.sort(key=lambda item: item[0], reverse=True)
-    return candidates[0][1]
+    if candidates:
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        return candidates[0][1]
+    return _read_stt_cache(speaker_norm)
 
 
 def _annotation_sync_speaker_tier(record: Dict[str, Any]) -> None:
@@ -2028,6 +2071,7 @@ def _run_stt_job(job_id: str, speaker: str, source_wav: str, language: Optional[
             "language": language,
             "segments": segments,
         }
+        _write_stt_cache(speaker, str(audio_path), language, segments)
         _set_job_complete(
             job_id,
             result,

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2051,20 +2051,41 @@ export function ParseUI() {
     if (sortMode === 'az') {
       list = [...list].sort((a, b) => a.name.localeCompare(b.name));
     } else if (sortMode === 'survey') {
+      // Natural sort: group first by source (KLQ / JBIL / …), then by every
+      // embedded number in order (section, item, variant). Without this
+      // "JBIL_10" lands before "JBIL_2" because the default string compare
+      // treats each segment as a whole literal, and "KLQ_1.10.A" lands
+      // before "KLQ_1.2.A" when each dotted segment is parseFloat'd as a
+      // decimal.
+      const surveyKey = (raw: string): (string | number)[] => {
+        const tokens: (string | number)[] = [];
+        for (const match of raw.matchAll(/([A-Za-z]+)|(\d+)/g)) {
+          if (match[1]) tokens.push(match[1].toLowerCase());
+          else if (match[2]) tokens.push(parseInt(match[2], 10));
+        }
+        return tokens;
+      };
       list = [...list].sort((a, b) => {
         const av = a.surveyItem ?? '';
         const bv = b.surveyItem ?? '';
         if (av && !bv) return -1;
         if (!av && bv) return 1;
-        // Try numeric (section.item) comparison, fall back to lex
-        const na = av.split('.').map(n => parseFloat(n));
-        const nb = bv.split('.').map(n => parseFloat(n));
-        for (let i = 0; i < Math.max(na.length, nb.length); i++) {
-          const xa = na[i] ?? 0;
-          const xb = nb[i] ?? 0;
-          if (Number.isFinite(xa) && Number.isFinite(xb) && xa !== xb) return xa - xb;
+        const ka = surveyKey(av);
+        const kb = surveyKey(bv);
+        for (let i = 0; i < Math.max(ka.length, kb.length); i++) {
+          const xa = ka[i];
+          const xb = kb[i];
+          if (xa === undefined) return -1;
+          if (xb === undefined) return 1;
+          if (typeof xa === 'number' && typeof xb === 'number') {
+            if (xa !== xb) return xa - xb;
+          } else {
+            const sa = String(xa);
+            const sb = String(xb);
+            if (sa !== sb) return sa < sb ? -1 : 1;
+          }
         }
-        return av.localeCompare(bv);
+        return 0;
       });
     } else {
       list = [...list].sort((a, b) => a.id - b.id);
@@ -2505,7 +2526,9 @@ export function ParseUI() {
             {filtered.map(c => {
               const active = c.id === conceptId;
               const badge = sortMode === 'survey' && c.surveyItem ? c.surveyItem : String(c.id);
-              const badgePrefix = sortMode === 'survey' ? 'Q' : '#';
+              // Survey items already carry their source prefix (JBIL / KLQ / …)
+              // — no extra "Q" needed. Numeric-id mode prefixes with "#".
+              const badgePrefix = sortMode === 'survey' ? '' : '#';
               return (
                 <button key={c.id} onClick={() => setConceptId(c.id)}
                   className={`group mb-0.5 flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left transition ${active ? 'bg-indigo-50 text-indigo-900' : 'text-slate-600 hover:bg-slate-50'}`}>

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1615,12 +1615,13 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
                 pause();
                 return;
               }
-              // Default play: bound to the active lexeme region so the
-              // clip stops at end. Pressing play again (cursor now at
-              // region end) or after seeking elsewhere falls through to
-              // unbounded continuous playback inside playClip.
+              // Default play: jump to the lexeme start and stop at its
+              // end (clip-bounded). Pressing Play again after the clip
+              // auto-stops, or after the user seeks elsewhere on the
+              // waveform, falls through to continuous playback inside
+              // playClip — which checks the hook's "primed" flag.
               if (selectedRegion) {
-                playClip(selectedRegion.end);
+                playClip(selectedRegion.start, selectedRegion.end);
               } else {
                 playPause();
               }

--- a/src/hooks/__tests__/useWaveSurfer.test.ts
+++ b/src/hooks/__tests__/useWaveSurfer.test.ts
@@ -181,18 +181,17 @@ describe("useWaveSurfer", () => {
 
   // -- Clip-bounded play --
   //
-  // The Annotate "Play" button passes the active region's end into
-  // playClip() so the first press plays just that lexeme. Subsequent
-  // presses (cursor at end), or seeks to a different position, must fall
-  // through to normal continuous playback.
+  // The Annotate Play button passes (start, end) of the active lexeme
+  // region into playClip(). The first press after addRegion seeks to
+  // start and stops at end. Subsequent presses (after auto-stop or any
+  // waveform interaction) fall through to normal continuous playback.
 
   function findHandler(eventName: string): ((arg: unknown) => void) | undefined {
     const call = mockWsInstance.on.mock.calls.find(([name]) => name === eventName);
     return call?.[1] as ((arg: unknown) => void) | undefined;
   }
 
-  it("playClip(end) starts playback and pauses at end via timeupdate", () => {
-    mockWsInstance.getCurrentTime.mockReturnValue(1);
+  it("addRegion + playClip seeks to lexeme start and pauses at end", () => {
     const { result } = renderHook(() =>
       useWaveSurfer({
         containerRef: makeContainerRef(),
@@ -200,60 +199,65 @@ describe("useWaveSurfer", () => {
       }),
     );
 
+    // Selecting a lexeme primes the next Play press.
+    act(() => {
+      result.current.addRegion(2, 4, "lex-1");
+    });
+
     let started = false;
     act(() => {
-      started = result.current.playClip(3) as boolean;
+      started = result.current.playClip(2, 4) as boolean;
     });
     expect(started).toBe(true);
+    // duration mock = 10, start = 2, so seekTo(0.2)
+    expect(mockWsInstance.seekTo).toHaveBeenCalledWith(0.2);
     expect(mockWsInstance.play).toHaveBeenCalledTimes(1);
 
     const onTime = findHandler("timeupdate");
     expect(onTime).toBeDefined();
 
-    // First tick well before end — no pause yet.
-    act(() => {
-      onTime!(2.5);
-    });
+    act(() => onTime!(3.5));
     expect(mockWsInstance.pause).not.toHaveBeenCalled();
 
-    // Crossing end — pause exactly once.
-    act(() => {
-      onTime!(3.0);
-    });
+    act(() => onTime!(4.0));
     expect(mockWsInstance.pause).toHaveBeenCalledTimes(1);
 
-    // Subsequent ticks should NOT pause again (clipEnd was cleared).
-    act(() => {
-      onTime!(3.2);
-    });
+    // Subsequent ticks must not double-pause.
+    act(() => onTime!(4.2));
     expect(mockWsInstance.pause).toHaveBeenCalledTimes(1);
   });
 
-  it("playClip(end) degrades to plain play when cursor is already past end", () => {
-    mockWsInstance.getCurrentTime.mockReturnValue(3.5);
+  it("second playClip after clip auto-stop continues without seeking back", () => {
     const { result } = renderHook(() =>
       useWaveSurfer({
         containerRef: makeContainerRef(),
         audioUrl: "/audio/test.wav",
       }),
     );
+
+    act(() => result.current.addRegion(2, 4, "lex-2"));
+    act(() => {
+      result.current.playClip(2, 4);
+    });
+    // Clip auto-stop fires the wavesurfer 'pause' handler, which clears
+    // the primed flag so the next press is unbounded.
+    const onPause = findHandler("pause");
+    act(() => onPause!(null));
+
+    mockWsInstance.seekTo.mockClear();
+    mockWsInstance.play.mockClear();
 
     let started = false;
     act(() => {
-      started = result.current.playClip(3) as boolean;
+      started = result.current.playClip(2, 4) as boolean;
     });
 
     expect(started).toBe(false);
+    expect(mockWsInstance.seekTo).not.toHaveBeenCalled();
     expect(mockWsInstance.play).toHaveBeenCalledTimes(1);
-
-    // Even at later timeupdates, no clip-bound pause should fire.
-    const onTime = findHandler("timeupdate");
-    act(() => onTime!(99));
-    expect(mockWsInstance.pause).not.toHaveBeenCalled();
   });
 
-  it("seek() clears any pending clip-bound so the next play is unbounded", () => {
-    mockWsInstance.getCurrentTime.mockReturnValue(1);
+  it("waveform 'interaction' clears the primed state so next play stays put", () => {
     const { result } = renderHook(() =>
       useWaveSurfer({
         containerRef: makeContainerRef(),
@@ -261,36 +265,41 @@ describe("useWaveSurfer", () => {
       }),
     );
 
-    act(() => {
-      result.current.playClip(3);
-    });
-    act(() => {
-      result.current.seek(7);
-    });
-
-    const onTime = findHandler("timeupdate");
-    act(() => onTime!(3));
-    expect(mockWsInstance.pause).not.toHaveBeenCalled();
-  });
-
-  it("waveform 'interaction' event clears the pending clip-bound", () => {
-    mockWsInstance.getCurrentTime.mockReturnValue(1);
-    const { result } = renderHook(() =>
-      useWaveSurfer({
-        containerRef: makeContainerRef(),
-        audioUrl: "/audio/test.wav",
-      }),
-    );
-
-    act(() => {
-      result.current.playClip(3);
-    });
+    act(() => result.current.addRegion(2, 4, "lex-3"));
     const onInteraction = findHandler("interaction");
-    expect(onInteraction).toBeDefined();
     act(() => onInteraction!(null));
 
-    const onTime = findHandler("timeupdate");
-    act(() => onTime!(3));
-    expect(mockWsInstance.pause).not.toHaveBeenCalled();
+    let started = false;
+    act(() => {
+      started = result.current.playClip(2, 4) as boolean;
+    });
+
+    expect(started).toBe(false);
+    expect(mockWsInstance.seekTo).not.toHaveBeenCalled();
+    expect(mockWsInstance.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("programmatic seek (e.g. ParseUI auto-positions to start) does NOT consume priming", () => {
+    const { result } = renderHook(() =>
+      useWaveSurfer({
+        containerRef: makeContainerRef(),
+        audioUrl: "/audio/test.wav",
+      }),
+    );
+
+    // Simulate ParseUI's onLexemeSelected flow: addRegion → seek to start.
+    act(() => result.current.addRegion(2, 4, "lex-4"));
+    act(() => result.current.seek(2));
+
+    mockWsInstance.seekTo.mockClear();
+
+    let started = false;
+    act(() => {
+      started = result.current.playClip(2, 4) as boolean;
+    });
+
+    expect(started).toBe(true);
+    // playClip re-seeks to start defensively — fine, cursor's already there.
+    expect(mockWsInstance.seekTo).toHaveBeenCalledWith(0.2);
   });
 });

--- a/src/hooks/useWaveSurfer.ts
+++ b/src/hooks/useWaveSurfer.ts
@@ -86,13 +86,21 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
   // When set, the next time `timeupdate` reports >= this time the wave is
   // paused and the ref is cleared. Used by `playClip` to make the default
   // play action stop at a lexeme boundary without bleeding into the next
-  // word. Cleared on every pause / seek so subsequent plays are unbounded.
+  // word. Cleared on every pause / interaction so subsequent plays are
+  // unbounded.
   const clipEndRef = useRef<number | null>(null);
+  // True after `addRegion` until either the clip has played once or the
+  // user has interacted with the waveform / pause control. Tells
+  // `playClip` whether the next play should seek to the lexeme start
+  // (first click after selecting a lexeme) or continue from the current
+  // cursor position (subsequent click after the clip auto-stopped).
+  const regionPrimedRef = useRef<boolean>(false);
 
   // -- Imperative controls (stable refs) --
 
   const play = useCallback(() => {
     clipEndRef.current = null;
+    regionPrimedRef.current = false;
     wsRef.current?.play();
   }, []);
   const pause = useCallback(() => wsRef.current?.pause(), []);
@@ -102,38 +110,44 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
       wsRef.current.pause();
     } else {
       clipEndRef.current = null;
+      regionPrimedRef.current = false;
       wsRef.current.play();
     }
   }, []);
 
   /**
-   * Play the wave starting from the current cursor position, but pause
-   * automatically at ``endSec``. Designed for the Annotate "Play" button:
-   * the first click on a freshly-loaded lexeme should play just that
-   * region, but if the cursor is already past the boundary (or the user
-   * has seeked elsewhere) we fall back to normal continuous playback.
+   * Play the active lexeme region. Behaviour depends on whether the
+   * region is "primed" — true after `addRegion` until the clip has
+   * played once or the user has touched the waveform:
    *
-   * Returns true if the clip-bounded play actually started, false if the
-   * call degraded to a regular play (so the UI can stay symmetric with
-   * `play()`).
+   * - **Primed** → seek to ``startSec`` and play, pausing automatically
+   *   at ``endSec``. This is the user-visible "play just this lexeme"
+   *   behaviour for the very first click after selecting a concept.
+   * - **Not primed** → resume normal continuous playback from the
+   *   current cursor position (which after the clip auto-stop is
+   *   already at ``endSec``, so the audio continues into whatever
+   *   follows).
+   *
+   * Returns true if the clip-bounded play actually started, false if
+   * the call degraded to a plain play.
    */
-  const playClip = useCallback((endSec: number) => {
+  const playClip = useCallback((startSec: number, endSec: number) => {
     const ws = wsRef.current;
     if (!ws) return false;
-    if (!Number.isFinite(endSec) || endSec <= 0) {
+    if (!regionPrimedRef.current || !Number.isFinite(endSec) || endSec <= 0) {
+      // No fresh region (or invalid bounds) — behave like normal play.
       clipEndRef.current = null;
       ws.play();
       return false;
     }
-    const current = ws.getCurrentTime();
-    // Tolerate a small fractional gap so clicking play immediately after
-    // it auto-stops doesn't re-clip onto a single sample.
-    if (current >= endSec - 0.01) {
-      clipEndRef.current = null;
-      ws.play();
-      return false;
+    if (Number.isFinite(startSec) && startSec >= 0) {
+      const dur = ws.getDuration();
+      if (dur > 0) {
+        ws.seekTo(clamp(startSec / dur, 0, 1));
+      }
     }
     clipEndRef.current = endSec;
+    regionPrimedRef.current = false; // consumed
     ws.play();
     return true;
   }, []);
@@ -143,8 +157,12 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     if (!ws) return;
     const duration = ws.getDuration();
     if (!duration || duration <= 0) return;
-    // A user-initiated seek invalidates any pending clip-bound: pressing
-    // play after seeking elsewhere should resume normal playback.
+    // Programmatic seeks (e.g. ParseUI auto-positions to lexeme start when
+    // a concept is selected) do NOT consume the primed state — that's
+    // what makes the next Play press jump to the lexeme start. The clip
+    // end target IS cleared, since the new cursor position invalidates
+    // any in-flight bounded play. User-initiated waveform clicks come
+    // through the wavesurfer "interaction" event below and clear both.
     clipEndRef.current = null;
     ws.seekTo(clamp(timeSec / duration, 0, 1));
   }, []);
@@ -222,6 +240,11 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
         resize: true,
       }) as unknown as WsRegion;
       activeRegionRef.current = region;
+      // Adding a region (i.e. selecting a lexeme) primes the next Play
+      // press to seek-to-start + clip-bound. Cleared by playClip itself,
+      // any waveform interaction, or pause/finish.
+      regionPrimedRef.current = true;
+      clipEndRef.current = null;
     },
     [clearRegions],
   );
@@ -303,23 +326,28 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
 
     ws.on("pause", () => {
       // Manual pause (or our own clip-bounded pause) discards any pending
-      // clip-end so the next play starts unbounded.
+      // clip-end and primed state so the next play resumes normal
+      // continuous playback from wherever the cursor landed.
       clipEndRef.current = null;
+      regionPrimedRef.current = false;
       options.onPlayStateChange?.(false);
       usePlaybackStore.setState({ isPlaying: false });
     });
 
     ws.on("finish", () => {
       clipEndRef.current = null;
+      regionPrimedRef.current = false;
       options.onPlayStateChange?.(false);
       usePlaybackStore.setState({ isPlaying: false });
     });
 
     ws.on("interaction", () => {
       // Clicking on the waveform itself triggers wavesurfer's built-in
-      // seek; that's a "user moved elsewhere" signal — clear any pending
-      // clip-bound so the next play resumes normal playback.
+      // seek; that's a "user moved elsewhere" signal — clear the primed
+      // state and any pending clip-bound so the next Play resumes normal
+      // continuous playback instead of jumping back to the lexeme start.
       clipEndRef.current = null;
+      regionPrimedRef.current = false;
     });
 
     // -- Region events --
@@ -421,6 +449,7 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
       regionsRef.current = null;
       activeRegionRef.current = null;
       clipEndRef.current = null;
+      regionPrimedRef.current = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.audioUrl, options.peaksUrl, options.initialSeekSec]);


### PR DESCRIPTION
Regression from [apps#114](https://github.com/ArdeleanLucas/PARSE/pull/114) — that branch snapshot pre-dated [apps#113](https://github.com/ArdeleanLucas/PARSE/pull/113) in the working copy, so merging it silently reverted #113's survey sidebar fix. The sidebar again showed `QJBIL_1.A`, `QJBIL_10.A`, `QJBIL_100.A`, … in lexicographic order.

## Fix

Re-applies #113 verbatim:

- `surveyKey(raw)` tokenises a survey_item into alternating letter-runs and integer-runs (`KLQ_1.10.A` → `["klq", 1, 10, "a"]`), compared element-wise. Numbers compare numerically (so `JBIL_10` sorts after `JBIL_2`, and `KLQ_1.10.A` sorts after `KLQ_1.2.A` instead of being parseFloat'd as decimal 1.1). Letters compare lex. Source prefixes (JBIL / KLQ / …) group together; A/B variants on the same section.item stay adjacent.
- Survey-mode `badgePrefix` is empty — the survey_item already carries its source prefix. Numeric-id mode still prefixes with `#`.

## Verified

Live preview against 521-concept workspace:
- Sidebar now reads `one JBIL_1.A → two JBIL_2.A → three JBIL_3.A → four JBIL_4.A → five JBIL_5.A` (was `one → ten → branch → stick → leaf`).
- No more `Q` prefix on any badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)