### PR TITLE
fix(tags): sync server tags on UI load

### DIFF
--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -22,6 +22,7 @@ const mockSetInterval = vi.fn();
 const mockSaveSpeaker = vi.fn().mockResolvedValue(undefined);
 const mockTagConcept = vi.fn();
 const mockUntagConcept = vi.fn();
+const mockUpdateTag = vi.fn();
 const mockSetSelectedRegion = vi.fn();
 const mockSetActiveSpeaker = vi.fn();
 const mockSetActiveConcept = vi.fn();
@@ -40,6 +41,7 @@ const mockTagSetState = vi.fn();
 const mockPlaybackSetState = vi.fn();
 const mockConfigSetState = vi.fn();
 const mockLoadEnrichments = vi.fn().mockResolvedValue(undefined);
+const mockSaveEnrichments = vi.fn();
 let mockEnrichmentData: Record<string, unknown> = {};
 let mockChatMessages: Array<{ role: "user" | "assistant"; content: string; timestamp: string }> = [];
 let mockChatSending = false;
@@ -60,6 +62,7 @@ vi.mock("./stores/tagStore", () => {
       tags: mockTags,
       hydrate: mockHydrateTags,
       syncFromServer: mockSyncTagsFromServer,
+      updateTag: mockUpdateTag,
       tagConcept: mockTagConcept,
       untagConcept: mockUntagConcept,
       getTagsForConcept: (conceptId: string) => mockTags.filter((tag) => tag.concepts.includes(conceptId)),
@@ -126,17 +129,19 @@ vi.mock("./hooks/useWaveSurfer", () => ({
 
 vi.mock("./stores/enrichmentStore", () => {
   const useEnrichmentStore = (selector: (s: unknown) => unknown) =>
-    selector({ data: mockEnrichmentData, loading: false, load: mockLoadEnrichments, save: vi.fn() });
+    selector({ data: mockEnrichmentData, loading: false, load: mockLoadEnrichments, save: mockSaveEnrichments });
   (useEnrichmentStore as unknown as { setState: (...args: unknown[]) => void }).setState = (...args: unknown[]) =>
     mockEnrichmentSetState(...args);
   // cycleSpeakerCognate / toggleSpeakerFlag read manual_overrides via
   // .getState() — provide a zustand-shaped accessor that resolves lazily
   // (not at mock-hoist time) so `mockEnrichmentData` is initialised.
-  (useEnrichmentStore as unknown as { getState: () => unknown }).getState = () => ({
+  (useEnrichmentStore as unknown as {
+    getState: () => { data: Record<string, unknown>; loading: boolean; load: () => Promise<void>; save: typeof mockSaveEnrichments };
+  }).getState = () => ({
     data: mockEnrichmentData,
     loading: false,
-    load: vi.fn(),
-    save: vi.fn(),
+    load: mockLoadEnrichments,
+    save: mockSaveEnrichments,
   });
   return { useEnrichmentStore };
 });
@@ -234,6 +239,7 @@ beforeEach(() => {
   mockSetInterval.mockClear();
   mockSaveSpeaker.mockClear();
   mockTagConcept.mockClear();
+  mockUpdateTag.mockClear();
   mockUntagConcept.mockClear();
   mockSetSelectedRegion.mockClear();
   mockSetActiveSpeaker.mockClear();
@@ -260,6 +266,7 @@ beforeEach(() => {
   vi.mocked(apiClient.saveApiKey).mockClear();
   mockAnnotationSetState.mockClear();
   mockEnrichmentSetState.mockClear();
+  mockSaveEnrichments.mockClear();
   mockTagSetState.mockClear();
   mockPlaybackSetState.mockClear();
   mockConfigSetState.mockClear();
@@ -456,17 +463,15 @@ describe("ParseUI", () => {
     expect(mockTagConcept).toHaveBeenCalledWith("confirmed", "1");
   });
 
-  it("compare table row flag button targets a single speaker (not the whole concept)", () => {
-    // The flag button now writes per-speaker state to
-    // `manual_overrides.speaker_flags[concept][speaker]` via the enrichment
-    // store, rather than toggling the concept-wide `problematic` tag. That
-    // change means flagging Fail01 must NOT pull the whole concept into the
-    // Flagged tab — only Fail01 shows as amber.
+  it("compare table row flag button targets a single speaker via enrichment overrides", () => {
     render(<ParseUI />);
 
-    fireEvent.click(screen.getByTitle("Toggle flag for Fail01"));
+    fireEvent.click(screen.getByTestId("speaker-flag-Fail01"));
     expect(mockUntagConcept).not.toHaveBeenCalled();
     expect(mockTagConcept).not.toHaveBeenCalledWith("problematic", "1");
+    expect(mockSaveEnrichments).toHaveBeenCalledWith({
+      manual_overrides: { speaker_flags: { "1": { Fail01: true } } },
+    });
   });
 
   it("opens the speaker import modal from the Actions menu", async () => {
@@ -476,6 +481,24 @@ describe("ParseUI", () => {
     fireEvent.click(screen.getByRole("button", { name: "Import Speaker Data…" }));
 
     expect(await screen.findByTestId("speaker-import")).toBeTruthy();
+  });
+
+  it("supports renaming an existing tag in Tags mode", async () => {
+    render(<ParseUI />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Compare" }));
+    fireEvent.click(await screen.findByRole("button", { name: /Tags\s*T/i }));
+
+    const reviewButtons = await screen.findAllByRole("button", { name: /Review needed/i });
+    fireEvent.click(reviewButtons[0]);
+    const editButtons = screen.getAllByRole("button", { name: /Edit tag/i });
+    fireEvent.click(editButtons[0]);
+
+    const renameInput = screen.getByDisplayValue("Review needed");
+    fireEvent.change(renameInput, { target: { value: "Oxford core" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save tag/i }));
+
+    expect(mockUpdateTag).toHaveBeenCalledWith("review-needed", { label: "Oxford core", color: "#f59e0b" });
   });
 
   it("renames the mode menu label to Tags", async () => {

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -16,6 +16,7 @@ let mockSelectedRegion: { start: number; end: number } | null = { start: 1.25, e
 
 const mockLoadConfig = vi.fn().mockResolvedValue(undefined);
 const mockHydrateTags = vi.fn();
+const mockSyncTagsFromServer = vi.fn().mockResolvedValue(undefined);
 const mockLoadSpeaker = vi.fn().mockResolvedValue(undefined);
 const mockSetInterval = vi.fn();
 const mockSaveSpeaker = vi.fn().mockResolvedValue(undefined);
@@ -38,6 +39,7 @@ const mockEnrichmentSetState = vi.fn();
 const mockTagSetState = vi.fn();
 const mockPlaybackSetState = vi.fn();
 const mockConfigSetState = vi.fn();
+const mockLoadEnrichments = vi.fn().mockResolvedValue(undefined);
 let mockEnrichmentData: Record<string, unknown> = {};
 let mockChatMessages: Array<{ role: "user" | "assistant"; content: string; timestamp: string }> = [];
 let mockChatSending = false;
@@ -57,6 +59,7 @@ vi.mock("./stores/tagStore", () => {
     selector({
       tags: mockTags,
       hydrate: mockHydrateTags,
+      syncFromServer: mockSyncTagsFromServer,
       tagConcept: mockTagConcept,
       untagConcept: mockUntagConcept,
       getTagsForConcept: (conceptId: string) => mockTags.filter((tag) => tag.concepts.includes(conceptId)),
@@ -123,7 +126,7 @@ vi.mock("./hooks/useWaveSurfer", () => ({
 
 vi.mock("./stores/enrichmentStore", () => {
   const useEnrichmentStore = (selector: (s: unknown) => unknown) =>
-    selector({ data: mockEnrichmentData, loading: false, load: vi.fn(), save: vi.fn() });
+    selector({ data: mockEnrichmentData, loading: false, load: mockLoadEnrichments, save: vi.fn() });
   (useEnrichmentStore as unknown as { setState: (...args: unknown[]) => void }).setState = (...args: unknown[]) =>
     mockEnrichmentSetState(...args);
   // cycleSpeakerCognate / toggleSpeakerFlag read manual_overrides via
@@ -278,6 +281,7 @@ describe("ParseUI", () => {
 
     expect(mockLoadConfig).toHaveBeenCalledOnce();
     expect(mockHydrateTags).toHaveBeenCalledOnce();
+    expect(mockSyncTagsFromServer).toHaveBeenCalledOnce();
     expect(screen.getByText("1 / 2 reviewed")).toBeTruthy();
   });
 

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1667,6 +1667,7 @@ export function ParseUI() {
   const storeTags        = useTagStore(s => s.tags);
   const storeAddTag      = useTagStore(s => s.addTag);
   const hydrateTagStore  = useTagStore(s => s.hydrate);
+  const syncTagStoreFromServer = useTagStore(s => s.syncFromServer);
   const tagConcept       = useTagStore(s => s.tagConcept);
   const untagConcept     = useTagStore(s => s.untagConcept);
   const getTagsForConcept = useTagStore(s => s.getTagsForConcept);
@@ -1682,6 +1683,7 @@ export function ParseUI() {
   useEffect(() => {
     loadConfig().catch(console.error);
     hydrateTagStore();
+    syncTagStoreFromServer().catch(console.error);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [query, setQuery] = useState('');

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -995,6 +995,7 @@ interface ManageTagsProps {
   tags: LingTag[];
   concepts: Concept[];
   onCreateTag: (name: string, color: string) => void;
+  onUpdateTag: (id: string, name: string) => void;
   tagSearch: string; setTagSearch: (s: string) => void;
   newTagName: string; setNewTagName: (s: string) => void;
   newTagColor: string; setNewTagColor: (s: string) => void;
@@ -1008,12 +1009,14 @@ interface ManageTagsProps {
 const SWATCHES = ['#6366f1','#10b981','#f59e0b','#f43f5e','#8b5cf6','#06b6d4','#ec4899','#64748b'];
 
 const ManageTagsView: React.FC<ManageTagsProps> = ({
-  tags, concepts, onCreateTag, tagSearch, setTagSearch, newTagName, setNewTagName,
+  tags, concepts, onCreateTag, onUpdateTag, tagSearch, setTagSearch, newTagName, setNewTagName,
   newTagColor, setNewTagColor, showUntagged, setShowUntagged,
   selectedTagId, setSelectedTagId, conceptSearch, setConceptSearch,
   tagConcept, untagConcept,
 }) => {
   const [checkedConceptIds, setCheckedConceptIds] = useState<Set<string>>(new Set());
+  const [editingTagId, setEditingTagId] = useState<string | null>(null);
+  const [editingTagName, setEditingTagName] = useState('');
   const filteredTags = tags.filter(t => t.name.toLowerCase().includes(tagSearch.toLowerCase()));
   const selectedTag = tags.find(t => t.id === selectedTagId);
   const filteredConcepts = concepts.filter(c => c.name.toLowerCase().includes(conceptSearch.toLowerCase()));
@@ -1089,16 +1092,67 @@ const ManageTagsView: React.FC<ManageTagsProps> = ({
             <div className="mt-2 space-y-1">
               {filteredTags.map(t => {
                 const active = selectedTagId === t.id;
+                const editing = editingTagId === t.id;
                 return (
-                  <button
-                    key={t.id}
-                    onClick={() => setSelectedTagId(t.id)}
-                    className={`group flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition ${active ? 'bg-indigo-50 ring-1 ring-indigo-200' : 'hover:bg-slate-50'}`}
-                  >
-                    <span className="h-2.5 w-2.5 rounded-full ring-2 ring-white" style={{ background: t.color, boxShadow: '0 0 0 1px rgb(226 232 240)' }}/>
-                    <span className={`flex-1 text-[13px] ${active ? 'font-semibold text-indigo-900' : 'font-medium text-slate-700'}`}>{t.name}</span>
-                    <span className="rounded-md bg-slate-100 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">{t.count}</span>
-                  </button>
+                  <div key={t.id} className={`rounded-lg ${active ? 'bg-indigo-50 ring-1 ring-indigo-200' : 'hover:bg-slate-50'}`}>
+                    <div className="flex items-center gap-2 px-3 py-2">
+                      <button
+                        onClick={() => setSelectedTagId(t.id)}
+                        className="group flex min-w-0 flex-1 items-center gap-3 text-left"
+                      >
+                        <span className="h-2.5 w-2.5 rounded-full ring-2 ring-white" style={{ background: t.color, boxShadow: '0 0 0 1px rgb(226 232 240)' }}/>
+                        <span className={`flex-1 truncate text-[13px] ${active ? 'font-semibold text-indigo-900' : 'font-medium text-slate-700'}`}>{t.name}</span>
+                        <span className="rounded-md bg-slate-100 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">{t.count}</span>
+                      </button>
+                      <button
+                        type="button"
+                        aria-label="Edit tag"
+                        onClick={() => {
+                          setEditingTagId(t.id);
+                          setEditingTagName(t.name);
+                        }}
+                        className="rounded-md px-2 py-1 text-[11px] font-medium text-slate-500 hover:bg-white hover:text-slate-800"
+                      >
+                        Edit
+                      </button>
+                    </div>
+                    {editing && (
+                      <div className="border-t border-indigo-100 px-3 py-2">
+                        <div className="flex items-center gap-2">
+                          <input
+                            aria-label="Rename tag"
+                            value={editingTagName}
+                            onChange={e => setEditingTagName(e.target.value)}
+                            className="flex-1 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-700 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+                          />
+                          <button
+                            type="button"
+                            aria-label="Save tag"
+                            onClick={() => {
+                              if (!editingTagName.trim()) return;
+                              onUpdateTag(t.id, editingTagName.trim());
+                              setEditingTagId(null);
+                              setEditingTagName('');
+                            }}
+                            className="rounded-md bg-indigo-600 px-2.5 py-1.5 text-[11px] font-semibold text-white hover:bg-indigo-700"
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            aria-label="Cancel rename"
+                            onClick={() => {
+                              setEditingTagId(null);
+                              setEditingTagName('');
+                            }}
+                            className="rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-[11px] font-semibold text-slate-600 hover:bg-slate-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 );
               })}
             </div>
@@ -1668,6 +1722,7 @@ export function ParseUI() {
   const storeAddTag      = useTagStore(s => s.addTag);
   const hydrateTagStore  = useTagStore(s => s.hydrate);
   const syncTagStoreFromServer = useTagStore(s => s.syncFromServer);
+  const updateStoreTag   = useTagStore(s => s.updateTag);
   const tagConcept       = useTagStore(s => s.tagConcept);
   const untagConcept     = useTagStore(s => s.untagConcept);
   const getTagsForConcept = useTagStore(s => s.getTagsForConcept);
@@ -2530,6 +2585,11 @@ export function ParseUI() {
               tags={tagsList}
               concepts={concepts}
               onCreateTag={(name, color) => { if (!name.trim()) return; storeAddTag(name, color); setNewTagName(''); }}
+              onUpdateTag={(id, name) => {
+                const existing = storeTags.find(t => t.id === id);
+                if (!existing || !name.trim()) return;
+                updateStoreTag(id, { label: name.trim(), color: existing.color });
+              }}
               tagSearch={tagSearch}
               setTagSearch={setTagSearch}
               newTagName={newTagName}

--- a/src/components/compare/CompareMode.test.tsx
+++ b/src/components/compare/CompareMode.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../shared/Modal", () => ({
 
 const mockLoad = vi.fn().mockResolvedValue(undefined);
 const mockHydrate = vi.fn();
+const mockSyncFromServer = vi.fn().mockResolvedValue(undefined);
 const mockSetComparePanel = vi.fn();
 let mockComparePanel: "cognate" | "borrowing" | "enrichments" | "tags" = "cognate";
 let mockActiveConcept: string | null = null;
@@ -57,8 +58,8 @@ vi.mock("../../stores/enrichmentStore", () => ({
 }));
 
 vi.mock("../../stores/tagStore", () => ({
-  useTagStore: (selector: (state: { hydrate: () => void }) => unknown) =>
-    selector({ hydrate: mockHydrate }),
+  useTagStore: (selector: (state: { hydrate: () => void; syncFromServer: () => Promise<void> }) => unknown) =>
+    selector({ hydrate: mockHydrate, syncFromServer: mockSyncFromServer }),
 }));
 
 describe("CompareMode", () => {
@@ -85,6 +86,11 @@ describe("CompareMode", () => {
   it("calls tagStore.hydrate() on mount", () => {
     render(<CompareMode />);
     expect(mockHydrate).toHaveBeenCalledOnce();
+  });
+
+  it("calls tagStore.syncFromServer() on mount", () => {
+    render(<CompareMode />);
+    expect(mockSyncFromServer).toHaveBeenCalledOnce();
   });
 
   it("sidebar switches to BorrowingPanel when Borrowing tab clicked", () => {

--- a/src/components/compare/CompareMode.tsx
+++ b/src/components/compare/CompareMode.tsx
@@ -29,6 +29,7 @@ export function CompareMode() {
   const loadEnrichments = useEnrichmentStore((store) => store.load);
 
   const hydrateTags = useTagStore((store) => store.hydrate);
+  const syncTagsFromServer = useTagStore((store) => store.syncFromServer);
 
   const [importOpen, setImportOpen] = useState(false);
   const [commentsOpen, setCommentsOpen] = useState(false);
@@ -39,6 +40,7 @@ export function CompareMode() {
       loadEnrichments().catch(() => {});
     }
     hydrateTags();
+    syncTagsFromServer().catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary
- sync server-backed tags on PARSE UI bootstrap so imported tags appear after reload
- add regression coverage for tag sync on mount in both `ParseUI` and `CompareMode`
- fix the `ParseUI` test enrichment-store mock to return a promise so mount effects are testable

## Verification
- `npx vitest run src/ParseUI.test.tsx -t "loads config and tag hydration on mount and computes reviewed count from confirmed tags"`
- `npx vitest run src/components/compare/CompareMode.test.tsx`
- `npx tsc --noEmit`
