### PR TITLE
fix: animated indeterminate bar during STT warm-up

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2663,12 +2663,20 @@ export function ParseUI() {
                         <Loader2 className="h-3 w-3 animate-spin text-indigo-500" />
                         <span className="text-slate-600">{job.state.label}</span>
                         <div className="h-1.5 w-20 overflow-hidden rounded-full bg-slate-200">
-                          <div
-                            className="h-full rounded-full bg-indigo-500 transition-all duration-300"
-                            style={{ width: `${Math.round(job.state.progress * 100)}%` }}
-                          />
+                          {job.state.progress < 0.05 ? (
+                            <div className="h-full w-2/5 animate-pulse rounded-full bg-indigo-400" />
+                          ) : (
+                            <div
+                              className="h-full rounded-full bg-indigo-500 transition-all duration-300"
+                              style={{ width: `${Math.round(job.state.progress * 100)}%` }}
+                            />
+                          )}
                         </div>
-                        <span className="tabular-nums text-slate-400">{Math.round(job.state.progress * 100)}%</span>
+                        {job.state.progress < 0.05 ? (
+                          <span className="text-slate-400">{job.state.message ?? 'Starting…'}</span>
+                        ) : (
+                          <span className="tabular-nums text-slate-400">{Math.round(job.state.progress * 100)}%</span>
+                        )}
                         {job.state.etaMs !== null && job.state.etaMs > 0 && (
                           <span className="tabular-nums text-slate-400" title="Estimated time remaining">
                             · ~{formatEta(job.state.etaMs)} left

--- a/src/hooks/useActionJob.ts
+++ b/src/hooks/useActionJob.ts
@@ -14,6 +14,8 @@ export interface ActionJobState {
   label: string | null;
   /** ms remaining, projected from elapsed time and current progress. null until the projection is stable. */
   etaMs: number | null;
+  /** Latest status message from the backend (e.g. "Loading model", "Transcribing"). null when idle or unknown. */
+  message: string | null;
 }
 
 const MIN_PROGRESS_FOR_ETA = 0.05
@@ -61,6 +63,7 @@ const IDLE_STATE: ActionJobState = {
   error: null,
   label: null,
   etaMs: null,
+  message: null,
 };
 
 function toErrorMessage(error: unknown, fallback: string): string {
@@ -167,6 +170,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
             error: toErrorMessage(error, `${config.label} follow-up failed`),
             label: config.label,
             etaMs: null,
+            message: null,
           });
           return;
         }
@@ -181,6 +185,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
           error: null,
           label: config.label,
           etaMs: 0,
+          message: null,
         });
 
         if (config.autoDismissMs !== 0) {
@@ -198,6 +203,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
         setStateIfMounted({
           status: "error",
           progress,
+          message: null,
           // Surface the actual exception (`poll.error`) first — `poll.message`
           // is the last in-progress status line ("Loading model", "Initializing
           // STT provider") and was masking the real failures.
@@ -210,11 +216,13 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
 
       const elapsed = startedAtRef.current === null ? 0 : Date.now() - startedAtRef.current;
       const etaMs = projectEtaMs(progress, elapsed);
+      const message = poll.message != null ? String(poll.message) : null;
       setStateIfMounted((prev) => ({
         ...prev,
         status: "running",
         progress,
         etaMs,
+        message,
       }));
     } catch (error) {
       if (activeRunIdRef.current !== runId) {
@@ -227,6 +235,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
         error: toErrorMessage(error, "Job polling failed"),
         label: config.label,
         etaMs: null,
+        message: null,
       });
     } finally {
       pollInFlightRef.current = false;
@@ -244,7 +253,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
     startInFlightRef.current = true;
     stopPolling();
     startedAtRef.current = Date.now();
-    setStateIfMounted({ status: "running", progress: 0, error: null, label: config.label, etaMs: null });
+    setStateIfMounted({ status: "running", progress: 0, error: null, label: config.label, etaMs: null, message: null });
 
     try {
       const job = await config.start();
@@ -272,6 +281,7 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
         error: toErrorMessage(error, "Job start failed"),
         label: config.label,
         etaMs: null,
+        message: null,
       });
     } finally {
       if (activeRunIdRef.current === runId) {


### PR DESCRIPTION
## Summary

- STT progress bar stuck at 2% while faster-whisper loads VAD — users thought the job was frozen
- Root cause: `poll.message` was never stored in `ActionJobState`, and the bar rendered a static 2% fill with no animation
- Fix: below 5% progress, render a pulsing indeterminate bar and show the backend status message (e.g. "Loading model", "Transcribing (0 segments)") instead of the numeric percentage

## Changes
- `src/hooks/useActionJob.ts` — adds `message: string | null` to `ActionJobState`; propagates `poll.message` on each poll tick
- `src/ParseUI.tsx` — progress bar switches to `animate-pulse` indeterminate mode below 5%, then transitions to the normal determinate bar once segments start flowing

## Test plan
- [ ] Start STT on a speaker — bar should pulse and show "Loading model" instead of frozen "2%"
- [ ] Once segments flow (>5%), bar switches to normal fill + percentage + ETA
- [ ] Error state still shows correct error message (not masked by message field)
- [ ] Other jobs (normalize, IPA, pipeline) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)