### PR TITLE
Clip-bound Play button to selected region + Space hotkey

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import {
   Search, ChevronLeft, ChevronRight, Check, Flag, Split, GitMerge,
   RotateCw, Play, RefreshCw, Save, Upload,
@@ -1302,7 +1302,7 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
       : null;
   }, [conceptInterval]);
 
-  const { playPause, playClip, pause, seek, scrollToTimeAtFraction, skip, addRegion, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
+  const { playPause, playRange, pause, seek, scrollToTimeAtFraction, skip, addRegion, setZoom: wsSetZoom, setRate, wsRef } = useWaveSurfer({
     containerRef,
     audioUrl,
     peaksUrl,
@@ -1337,6 +1337,37 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
       }
     },
   });
+
+  // Press Play (or Space) on a selected region → clip-bounded playback that
+  // stops at the region end. No region selected → plain play/pause toggle.
+  const handlePlayToggle = useCallback(() => {
+    if (isPlaying) {
+      pause();
+      return;
+    }
+    if (selectedRegion) {
+      playRange(selectedRegion.start, selectedRegion.end);
+    } else {
+      playPause();
+    }
+  }, [isPlaying, selectedRegion, pause, playRange, playPause]);
+
+  // Global Space hotkey for play/pause. Skips when the user is typing so the
+  // IPA and orthographic fields keep accepting spaces.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== " " && e.code !== "Space") return;
+      const t = e.target as HTMLElement | null;
+      if (t) {
+        const tag = t.tagName?.toLowerCase();
+        if (tag === "input" || tag === "textarea" || tag === "select" || t.isContentEditable) return;
+      }
+      e.preventDefault();
+      handlePlayToggle();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handlePlayToggle]);
 
   // Speaker switches replace the underlying WaveSurfer instance. Reset the
   // ready gate and playback clock first so annotate-side seek/region effects
@@ -1658,22 +1689,8 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
           <button onClick={() => skip(-5)} title="-5s" className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><SkipBack className="h-4 w-4"/></button>
           <button onClick={() => skip(-1)} title="-1s" className="grid h-8 w-8 place-items-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800"><ChevronLeft className="h-4 w-4"/></button>
           <button
-            onClick={() => {
-              if (isPlaying) {
-                pause();
-                return;
-              }
-              // Default play: jump to the lexeme start and stop at its
-              // end (clip-bounded). Pressing Play again after the clip
-              // auto-stops, or after the user seeks elsewhere on the
-              // waveform, falls through to continuous playback inside
-              // playClip — which checks the hook's "primed" flag.
-              if (selectedRegion) {
-                playClip(selectedRegion.start, selectedRegion.end);
-              } else {
-                playPause();
-              }
-            }}
+            onClick={handlePlayToggle}
+            title={selectedRegion ? "Play selected region (Space)" : "Play (Space)"}
             data-testid="annotate-play"
             className="grid h-10 w-10 place-items-center rounded-full bg-slate-900 text-white shadow-sm hover:bg-slate-700"
           >

--- a/src/hooks/useWaveSurfer.ts
+++ b/src/hooks/useWaveSurfer.ts
@@ -152,6 +152,33 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     return true;
   }, []);
 
+  /**
+   * Play a fixed [startSec, endSec] window and always auto-pause at endSec.
+   * Unlike `playClip`, this ignores the region-primed flag and clip-bounds on
+   * every call — so the bottom Play button (and Space hotkey) on a selected
+   * region replays just that region even after waveform interaction cleared
+   * the primed state.
+   */
+  const playRange = useCallback((startSec: number, endSec: number) => {
+    const ws = wsRef.current;
+    if (!ws) return;
+    if (!Number.isFinite(endSec) || endSec <= 0 || endSec <= startSec) {
+      clipEndRef.current = null;
+      ws.play();
+      return;
+    }
+    const dur = ws.getDuration();
+    if (dur > 0 && Number.isFinite(startSec) && startSec >= 0) {
+      const cur = ws.getCurrentTime();
+      if (cur < startSec - 0.01 || cur >= endSec - 0.01) {
+        ws.seekTo(clamp(startSec / dur, 0, 1));
+      }
+    }
+    clipEndRef.current = endSec;
+    regionPrimedRef.current = false;
+    ws.play();
+  }, []);
+
   const seekToSec = useCallback((timeSec: number) => {
     const ws = wsRef.current;
     if (!ws) return;
@@ -459,6 +486,7 @@ export function useWaveSurfer(options: UseWaveSurferOptions) {
     pause,
     playPause,
     playClip,
+    playRange,
     seek,
     scrollToTimeAtFraction,
     skip,


### PR DESCRIPTION
## Summary
- Pressing Play (or the new Space hotkey) on a selected region seeks to the region start and auto-pauses at the region end instead of continuing past the word.
- Adds `playRange(start, end)` to `useWaveSurfer` — unconditional clip-bounding, unlike the existing `playClip` which only clip-bounds when the region-primed flag is still set. Waveform interactions (clicking, scrubbing) clear the primed flag in current `main`, making `playClip` degrade to plain `play`; this PR sidesteps that so the bottom Play button is reliable.
- A global Space keydown listener in `ParseUI` calls the same shared `handlePlayToggle`. It skips when focus is in an `input` / `textarea` / `select` / `contentEditable`, so the IPA and Kurdish orthography fields keep accepting spaces.

## Test plan
- [x] `vitest run src/hooks/__tests__/useWaveSurfer.test.ts` — 10/10 pass
- [x] `tsc --noEmit` — clean on the two touched files (preexisting unrelated `ChatMarkdown` errors remain)
- [ ] Manual: open a speaker, select a concept → region highlights → press Play → playhead jumps to region start and pauses at region end
- [ ] Manual: press Space anywhere outside a text field → same as Play button
- [ ] Manual: click inside IPA field, press Space → space is typed, playback unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)