### PR TITLE
fix: float STT status below topbar + rehydrate jobs on reload

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -2071,6 +2071,34 @@ def _job_response_payload(job: Dict[str, Any]) -> Dict[str, Any]:
     return payload
 
 
+def _list_active_jobs_snapshots() -> List[Dict[str, Any]]:
+    """Return public snapshots for all currently-running jobs.
+
+    Used by the frontend on page load to rehydrate in-flight progress bars
+    (STT, normalize, IPA, etc.) after a reload — backend threads outlive the
+    browser, so the job is still running; the UI just lost its ``job_id``.
+    """
+    results: List[Dict[str, Any]] = []
+    with _jobs_lock:
+        for job in _jobs.values():
+            if job.get("status") != "running":
+                continue
+            payload = _job_response_payload(job)
+            meta = job.get("meta") if isinstance(job.get("meta"), dict) else {}
+            if isinstance(meta, dict) and meta:
+                # Only surface safe metadata the UI already has access to:
+                # speaker identifies which hook should adopt this job.
+                speaker = meta.get("speaker")
+                if isinstance(speaker, str) and speaker.strip():
+                    payload["speaker"] = speaker.strip()
+                language = meta.get("language")
+                if isinstance(language, str) and language.strip():
+                    payload["language"] = language.strip()
+            results.append(payload)
+    return results
+
+
+
 def _load_cached_suggestions(speaker: str, concept_ids: List[str]) -> List[Dict[str, Any]]:
     suggestions_path = _project_root() / "ai_suggestions.json"
     if not suggestions_path.exists():
@@ -2943,6 +2971,10 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             self._api_get_chat_session(parts[3])
             return
 
+        if request_path == "/api/jobs/active":
+            self._api_get_jobs_active()
+            return
+
         if request_path == "/api/enrichments":
             self._api_get_enrichments()
             return
@@ -3682,6 +3714,11 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             raise ApiError(HTTPStatus.BAD_REQUEST, "job_id is not a normalize job")
 
         self._send_json(HTTPStatus.OK, _job_response_payload(job))
+
+    def _api_get_jobs_active(self) -> None:
+        """Return a list of currently-running jobs so the UI can rehydrate
+        progress after a page reload. See ``_list_active_jobs_snapshots``."""
+        self._send_json(HTTPStatus.OK, {"jobs": _list_active_jobs_snapshots()})
 
     def _api_post_stt_start(self) -> None:
         body = self._expect_object(self._read_json_body(), "Request body")

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -25,6 +25,7 @@ import { LaneColorPicker } from './components/annotate/LaneColorPicker';
 import { useAnnotationSync } from './hooks/useAnnotationSync';
 import { useComputeJob } from './hooks/useComputeJob';
 import { useActionJob, formatEta } from './hooks/useActionJob';
+import { listActiveJobs } from './api/client';
 import type { PollResult } from './hooks/useActionJob';
 import { useConfigStore } from './stores/configStore';
 import { useEnrichmentStore } from './stores/enrichmentStore';
@@ -1854,6 +1855,8 @@ export function ParseUI() {
     catch { /* storage unavailable */ }
   }, [sttLanguage]);
   const activeActionSpeaker = selectedSpeakers[0] ?? null;
+  const activeActionSpeakerRef = useRef(activeActionSpeaker);
+  useEffect(() => { activeActionSpeakerRef.current = activeActionSpeaker; }, [activeActionSpeaker]);
   const loadSpeaker = useAnnotationStore((s) => s.loadSpeaker);
   const loadEnrichments = useEnrichmentStore((s) => s.load);
 
@@ -1941,6 +1944,42 @@ export function ParseUI() {
 
   const allJobs = [normalizeJob, sttJob, ipaJob, pipelineJob, crossSpeakerJob];
   const activeJobs = allJobs.filter(j => j.state.status !== 'idle');
+
+  // On mount, adopt any in-flight backend jobs so progress bars survive
+  // a page reload. STT (and similar) run in a background thread that
+  // outlives the browser tab — before this, the UI had no way to
+  // reconnect, making the process look dead even though it was still
+  // burning GPU cycles on the PC.
+  const didRehydrateJobsRef = useRef(false);
+  useEffect(() => {
+    if (didRehydrateJobsRef.current) return;
+    didRehydrateJobsRef.current = true;
+    void (async () => {
+      let snapshots;
+      try {
+        snapshots = await listActiveJobs();
+      } catch {
+        return; // Endpoint may not exist on older servers; fail silent.
+      }
+      const speaker = activeActionSpeakerRef.current;
+      for (const snap of snapshots) {
+        if (snap.type === 'stt' && snap.speaker && snap.speaker === speaker) {
+          sttJob.adopt(snap.jobId);
+        } else if (snap.type === 'normalize' && snap.speaker && snap.speaker === speaker) {
+          normalizeJob.adopt(snap.jobId);
+        } else if (snap.type === 'compute:ipa_only' && snap.speaker && snap.speaker === speaker) {
+          ipaJob.adopt(snap.jobId);
+        } else if (snap.type === 'compute:full_pipeline') {
+          pipelineJob.adopt(snap.jobId);
+        } else if (snap.type === 'compute:contact-lexemes') {
+          crossSpeakerJob.adopt(snap.jobId);
+        }
+      }
+    })();
+    // Intentionally run once on mount — sttJob etc. are stable handles.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
 
   const [importModalOpen, setImportModalOpen] = useState(false);
 
@@ -2455,7 +2494,7 @@ export function ParseUI() {
     <div className="h-screen overflow-hidden bg-slate-50 text-slate-800 font-sans antialiased flex flex-col">
       {/* ============ MINIMAL TOP BAR ============ */}
       <header className="relative z-50 shrink-0 h-14 border-b border-slate-200/80 bg-white/90 backdrop-blur-xl">
-        <div className="flex h-full items-center justify-between px-5">
+        <div className="relative flex h-full items-center justify-between px-5">
           <div className="flex items-center gap-5">
             <div className="flex items-center gap-2">
               <div className="grid h-7 w-7 place-items-center rounded-md bg-gradient-to-br from-indigo-500 to-violet-600 text-white shadow-sm">
@@ -2655,7 +2694,7 @@ export function ParseUI() {
             </div>
 
             {activeJobs.length > 0 && (
-              <div className="ml-2 flex flex-col gap-1" data-testid="topbar-action-statuses">
+              <div className="pointer-events-auto absolute right-5 top-full z-40 mt-1 flex flex-col gap-1 rounded-md border border-slate-200 bg-white/95 px-3 py-1 shadow-sm backdrop-blur" data-testid="topbar-action-statuses">
                 {activeJobs.map((job, i) => (
                   <div key={i} className="flex items-center gap-2 text-[11px]">
                     {job.state.status === 'running' && (

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -265,6 +265,54 @@ export async function pollSTT(jobId: string): Promise<STTStatus> {
   });
 }
 
+export interface ActiveJobSnapshot {
+  jobId: string;
+  type: string;
+  status: string;
+  progress: number;
+  message?: string;
+  error?: string;
+  /** Only set for speaker-scoped jobs (STT, normalize, IPA). */
+  speaker?: string;
+  language?: string;
+}
+
+/** List currently-running backend jobs so the UI can rehydrate progress
+ * indicators after a page reload. Backend threads outlive the browser. */
+export async function listActiveJobs(): Promise<ActiveJobSnapshot[]> {
+  const payload = await apiFetch<{ jobs?: unknown }>("/api/jobs/active");
+  const raw = Array.isArray(payload?.jobs) ? payload!.jobs : [];
+  const out: ActiveJobSnapshot[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    const jobId = String(record.jobId ?? record.job_id ?? "").trim();
+    const type = String(record.type ?? "").trim();
+    if (!jobId || !type) continue;
+    const progressRaw = Number(record.progress ?? 0);
+    const snapshot: ActiveJobSnapshot = {
+      jobId,
+      type,
+      status: String(record.status ?? "running"),
+      progress: Number.isFinite(progressRaw) ? progressRaw : 0,
+    };
+    if (typeof record.message === "string" && record.message.trim()) {
+      snapshot.message = record.message;
+    }
+    if (typeof record.error === "string" && record.error.trim()) {
+      snapshot.error = record.error;
+    }
+    if (typeof record.speaker === "string" && record.speaker.trim()) {
+      snapshot.speaker = record.speaker.trim();
+    }
+    if (typeof record.language === "string" && record.language.trim()) {
+      snapshot.language = record.language.trim();
+    }
+    out.push(snapshot);
+  }
+  return out;
+}
+
 // Timestamp offset — detect a constant CSV/STT misalignment and (optionally) apply it.
 export interface OffsetMatch {
   anchor_index: number;

--- a/src/hooks/__tests__/useActionJob.test.ts
+++ b/src/hooks/__tests__/useActionJob.test.ts
@@ -31,6 +31,7 @@ describe("useActionJob", () => {
       error: null,
       label: null,
       etaMs: null,
+      message: null,
     });
   });
 
@@ -199,6 +200,7 @@ describe("useActionJob", () => {
       error: null,
       label: null,
       etaMs: null,
+      message: null,
     });
   });
 
@@ -279,6 +281,7 @@ describe("useActionJob", () => {
       error: "Start failed",
       label: "Running action…",
       etaMs: null,
+      message: null,
     });
     expect(poll).not.toHaveBeenCalled();
   });

--- a/src/hooks/useActionJob.ts
+++ b/src/hooks/useActionJob.ts
@@ -55,6 +55,9 @@ export interface ActionJobHandle {
   state: ActionJobState;
   run: () => Promise<void>;
   reset: () => void;
+  /** Attach to an already-running backend job (e.g. one launched before a
+   * page reload) and start polling its status. Skips config.start(). */
+  adopt: (jobId: string) => void;
 }
 
 const IDLE_STATE: ActionJobState = {
@@ -242,6 +245,35 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
     }
   }, [config, setStateIfMounted, stopPolling]);
 
+  const adopt = useCallback((jobId: string): void => {
+    const trimmed = String(jobId || "").trim();
+    if (!trimmed || stateRef.current.status === "running") {
+      return;
+    }
+
+    activeRunIdRef.current += 1;
+    const runId = activeRunIdRef.current;
+
+    stopPolling();
+    startedAtRef.current = Date.now();
+    jobIdRef.current = trimmed;
+    setStateIfMounted({
+      status: "running",
+      progress: 0,
+      error: null,
+      label: config.label,
+      etaMs: null,
+      message: null,
+    });
+
+    // Fire an immediate poll so the bar picks up real progress without
+    // waiting a full interval.
+    void pollOnce(runId);
+    intervalRef.current = setInterval(() => {
+      void pollOnce(runId);
+    }, config.pollIntervalMs ?? 1000);
+  }, [config.label, config.pollIntervalMs, pollOnce, setStateIfMounted, stopPolling]);
+
   const run = useCallback(async (): Promise<void> => {
     if (startInFlightRef.current || stateRef.current.status === "running") {
       return;
@@ -300,5 +332,5 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
     };
   }, [stopPolling]);
 
-  return { state, run, reset };
+  return { state, run, reset, adopt };
 }


### PR DESCRIPTION
## Summary

Follow-up fixes for #130 addressing two remaining issues the user hit:

1. **Progress indicator still displaced the Annotate/Actions menu** — the `activeJobs` row was a flex sibling of the topbar buttons, pushing them leftward when an STT job started.
2. **Reloading PARSE appeared to kill the in-flight STT job** — the backend thread outlives the browser just fine (`daemon=True`, no cancel-on-disconnect), but the UI lost the `jobId` on reload and had no way to reconnect.

## Changes

### Layout
`activeJobs` status row is now absolutely positioned below the topbar (anchored via `relative` on the header's inner row) so it no longer consumes flex space. Rendered as a floating chip with a light border and subtle shadow; multiple concurrent jobs stack vertically.

### Rehydration
- **Backend**: new `GET /api/jobs/active` returns snapshots of all non-completed jobs with `meta.speaker` / `language` surfaced. No behavior change — just exposes what already exists.
- **Frontend**: `useActionJob.adopt(jobId)` attaches an existing backend job id to the hook and starts polling without re-invoking `config.start()`. On mount, `ParseUI` queries `/api/jobs/active` and adopts matching running jobs (STT/normalize/IPA keyed on the current speaker; pipeline/cross-speaker are project-wide).
- **Tests**: `useActionJob` test expectations updated for the `message` field added in #130.

## Test plan
- [ ] Start STT, verify the status chip floats below the topbar and does NOT push Annotate/Actions
- [ ] While STT is running, hard-reload the browser — chip should reappear within ~1s with correct progress/message
- [ ] Kill the Python server mid-job, reload — chip should not appear (no running jobs)
- [ ] Run normalize and STT back-to-back — both should render in the floating chip, stacked
- [ ] Switch to a different speaker with its own running STT — UI adopts that speaker's job

🤖 Generated with [Claude Code](https://claude.com/claude-code)