### PR TITLE
fix: align STT/IPA/ORTHO lane timelines with the waveform

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -20,7 +20,7 @@ import { useSpectrogram } from './hooks/useSpectrogram';
 import { useWaveSurfer } from './hooks/useWaveSurfer';
 import { useAnnotationStore } from './stores/annotationStore';
 import { useTranscriptionLanesStore, type LaneKind } from './stores/transcriptionLanesStore';
-import { TranscriptionLanes } from './components/annotate/TranscriptionLanes';
+import { TranscriptionLanes, LABEL_COL_PX } from './components/annotate/TranscriptionLanes';
 import { LaneColorPicker } from './components/annotate/LaneColorPicker';
 import { useAnnotationSync } from './hooks/useAnnotationSync';
 import { useComputeJob } from './hooks/useComputeJob';
@@ -1473,19 +1473,28 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
 
         {/* Waveform container — WaveSurfer owns this div */}
         <div className="relative px-5 pt-4 pb-2">
-          <div className="relative">
+          <div className="flex items-stretch">
+            {/* Left gutter matches the lane label column so waveform t=0
+                lines up with segment t=0 in the STT/IPA/ORTHO strips. */}
             <div
-              ref={containerRef}
-              className="relative w-full overflow-hidden rounded-lg ring-1 ring-slate-100"
-              style={{ minHeight: 110 }}
+              className="shrink-0"
+              style={{ width: LABEL_COL_PX }}
+              aria-hidden="true"
             />
-            {spectroOn && (
-              <canvas
-                ref={spectroCanvasRef}
-                className="pointer-events-none absolute inset-0 rounded-lg"
-                style={{ width: '100%', height: '100%', opacity: 0.6, mixBlendMode: 'multiply' }}
+            <div className="relative flex-1">
+              <div
+                ref={containerRef}
+                className="relative w-full overflow-hidden rounded-lg ring-1 ring-slate-100"
+                style={{ minHeight: 110 }}
               />
-            )}
+              {spectroOn && (
+                <canvas
+                  ref={spectroCanvasRef}
+                  className="pointer-events-none absolute inset-0 rounded-lg"
+                  style={{ width: '100%', height: '100%', opacity: 0.6, mixBlendMode: 'multiply' }}
+                />
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/components/annotate/TranscriptionLanes.tsx
+++ b/src/components/annotate/TranscriptionLanes.tsx
@@ -28,7 +28,7 @@ const LANE_LABELS: Record<LaneKind, string> = {
 };
 
 const LANE_HEIGHT_PX = 28;
-const LABEL_COL_PX = 48;
+export const LABEL_COL_PX = 48;
 const MIN_LABEL_WIDTH_PX = 18;
 const VIRTUAL_BUFFER_PX = 400;
 


### PR DESCRIPTION
## Summary

The lane strips (STT / IPA / ORTHO) have a 48-pixel `LABEL_COL_PX` gutter on the left for the lane name. The waveform had no matching gutter, so segment t=0 rendered **48px to the right** of the waveform's t=0. At the user's zoom level in Fail02 (~20 px/s) that's ~2.4 seconds of apparent drift — easily enough to make segments look out of sync with the audio peaks they transcribe, or create the impression of missing text.

## Fix

- Export `LABEL_COL_PX` from `TranscriptionLanes.tsx` so ParseUI can reuse it.
- Wrap the waveform container in a flex row with a matching `LABEL_COL_PX` left spacer. Spectrogram canvas moves inside the `relative flex-1` wrapper so `inset-0` still targets just the waveform.

## Not in scope (follow-up)

While investigating I noticed the STT cache for **Qasr01** has **82 segments across 11 760 seconds (3.3 hours)** — roughly one segment every 2.4 minutes, which is extremely sparse. The culprit is almost certainly `vad_filter=True` with default parameters in `python/ai/provider.py:1107`; faster-whisper's default Silero VAD is conservative and drops low-volume / short utterances. Worth a separate PR to expose `vad_filter` / `vad_parameters` through `ai_config.json` so it can be loosened per speaker.

## Test plan
- [ ] Open Fail02 with STT visible — segment boxes should now sit directly under the audio peaks they describe
- [ ] Scroll the waveform — lane strips scroll with it and stay aligned
- [ ] Enable the spectrogram — canvas still sits over the waveform area only, not the gutter
- [ ] Zoom in/out — alignment holds at every zoom level

🤖 Generated with [Claude Code](https://claude.com/claude-code)