### PR TITLE
fix: IPA/Ortho lanes never scroll into view (WaveSurfer scroll event arg mismatch)

### DIFF
--- a/src/components/annotate/TranscriptionLanes.tsx
+++ b/src/components/annotate/TranscriptionLanes.tsx
@@ -96,7 +96,9 @@ export function TranscriptionLanes({
       setDuration(ws.getDuration() ?? 0);
       if (wrapper) {
         setScrollLeft(wrapper.scrollLeft ?? 0);
-        setViewportWidth(wrapper.clientWidth ?? 0);
+        // Use the wrapper's parent (the visible viewport) for the rendered width,
+        // not the wrapper itself which expands to the full timeline pixel width.
+        setViewportWidth(wrapper.parentElement?.clientWidth ?? wrapper.clientWidth ?? 0);
       }
     };
 
@@ -107,8 +109,10 @@ export function TranscriptionLanes({
     }
     readState();
 
-    const onScroll = (left: number) => {
-      setScrollLeft(left);
+    // WaveSurfer 7 emits scroll as (visibleStartSec, visibleEndSec, scrollLeftPx, scrollRightPx).
+    // Read argument index 2 (pixel offset) — not index 0 which is start time in seconds.
+    const onScroll = (_startSec: number, _endSec: number, leftPx: number) => {
+      setScrollLeft(leftPx);
     };
     const onZoom = () => readState();
     const onReady = () => readState();


### PR DESCRIPTION
## Summary

- **Root cause**: `TranscriptionLanes` was reading argument 0 of the WaveSurfer `scroll` event (visible start time in seconds) as the lane scroll offset in pixels. WaveSurfer 7 actually emits `(visibleStartSec, visibleEndSec, scrollLeftPx, scrollRightPx)`, so argument 2 is the correct pixel offset.
- For a concept at 365 s with 10 px/s zoom this produced `scrollLeft ≈ 336 px` instead of `3 651 px`, keeping IPA and Ortho lanes pinned near position 0 regardless of where the waveform scrolled.
- Secondary fix: `viewportWidth` now reads from `wrapper.parentElement.clientWidth` (the clipped visible container) instead of `wrapper.clientWidth` (the full scrollable inner div), which was inflating the virtual render window and causing all 1 000+ STT segments to render at once.

## Changes

`src/components/annotate/TranscriptionLanes.tsx`
- `onScroll` handler: read `leftPx` (arg index 2) instead of `_startSec` (arg index 0)
- `readState`: use `wrapper.parentElement?.clientWidth` for `viewportWidth`

## Test plan

- [ ] Open any speaker with IPA annotations (e.g. Fail02)
- [ ] Select concept #1 ("hair") — waveform seeks to ~365 s
- [ ] Confirm IPA and Ortho tier lanes scroll to the same position and show intervals
- [ ] Confirm STT lane still shows correctly
- [ ] Zoom out to 10 px/s and manually scroll — verify all three lanes stay in sync
- [ ] Zoom in to 400 px/s — verify lanes still track correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)