### PR TITLE
fix: auto-detect STT language, make VAD/task/beam_size tunable

### DIFF
--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -33,9 +33,25 @@ _DEFAULT_AI_CONFIG: Dict[str, Any] = {
     "stt": {
         "provider": "faster-whisper",
         "model_path": "",
-        "language": "sd",
+        # Empty string = let Whisper auto-detect the language. We used to
+        # default to "sd" (Sindhi), but the project's Southern Kurdish audio
+        # isn't in Whisper's supported language list and forcing Sindhi made
+        # the decoder hallucinate (produced 'ايقIt is not legal'-style
+        # garbage). Auto-detect lands on Persian (fa) — a close relative —
+        # and produces coherent Kurdish-script output.
+        "language": "",
         "device": "cuda",
         "compute_type": "float16",
+        "beam_size": 5,
+        # "transcribe" preserves the detected language. Set to "translate"
+        # if you want an English gloss of the speech.
+        "task": "transcribe",
+        # VAD gates silence out of the audio before decoding. Keep it on —
+        # vad_filter=False produces hallucination loops in long silences
+        # (e.g. repeating 'شوال' 5x during a 10s pause). Parameters below
+        # are tunable; leave as {} to use faster-whisper's Silero defaults.
+        "vad_filter": True,
+        "vad_parameters": {},
     },
     "ipa": {
         "provider": "local",
@@ -981,6 +997,20 @@ class LocalWhisperProvider(AIProvider):
             str(compute_type or stt_config.get("compute_type", "int8")).strip() or "int8"
         )
 
+        try:
+            self.beam_size = max(1, int(stt_config.get("beam_size", 5) or 5))
+        except (TypeError, ValueError):
+            self.beam_size = 5
+        task_raw = str(stt_config.get("task", "transcribe") or "transcribe").strip().lower()
+        self.task = task_raw if task_raw in {"transcribe", "translate"} else "transcribe"
+        self.vad_filter = bool(stt_config.get("vad_filter", True))
+        vad_params_raw = stt_config.get("vad_parameters")
+        # Only forward a dict when the user has set explicit parameters;
+        # an empty {} falls through to faster-whisper's Silero defaults.
+        self.vad_parameters: Optional[Dict[str, Any]] = (
+            dict(vad_params_raw) if isinstance(vad_params_raw, dict) and vad_params_raw else None
+        )
+
         if _stt_force_cpu_env() and self.device.lower().startswith("cuda"):
             print(
                 "[WARN] PARSE_STT_FORCE_CPU set; overriding stt.device "
@@ -1096,16 +1126,22 @@ class LocalWhisperProvider(AIProvider):
             raise FileNotFoundError("Audio file not found: {0}".format(path))
 
         model = self._load_whisper_model()
-        selected_language = language or self.language
+        # Auto-detect when the user hasn't forced a language (empty/None).
+        # faster-whisper treats language=None as auto-detect; language=""
+        # would error.
+        selected_language = (language or self.language) or None
 
         def _run_transcription(m: Any) -> List[Segment]:
             segs_out: List[Segment] = []
-            segs_iter, info = m.transcribe(
-                str(path),
-                language=selected_language,
-                beam_size=5,
-                vad_filter=True,
-            )
+            transcribe_kwargs: Dict[str, Any] = {
+                "language": selected_language,
+                "beam_size": self.beam_size,
+                "task": self.task,
+                "vad_filter": self.vad_filter,
+            }
+            if self.vad_filter and self.vad_parameters is not None:
+                transcribe_kwargs["vad_parameters"] = self.vad_parameters
+            segs_iter, info = m.transcribe(str(path), **transcribe_kwargs)
             total_duration = float(getattr(info, "duration", 0.0) or 0.0)
             for segment in segs_iter:
                 start = float(_dict_or_attr(segment, "start", 0.0) or 0.0)

--- a/python/test_stt_configurable_transcribe.py
+++ b/python/test_stt_configurable_transcribe.py
@@ -1,0 +1,174 @@
+"""Tests for LocalWhisperProvider's configurable transcribe() path.
+
+Ensures:
+  - empty ``stt.language`` maps to ``language=None`` (auto-detect), not "".
+  - ``stt.vad_filter`` / ``stt.vad_parameters`` / ``stt.task`` / ``stt.beam_size``
+    flow through to ``WhisperModel.transcribe()``.
+  - Omitting ``stt.vad_parameters`` (or passing {}) does NOT send
+    ``vad_parameters`` to faster-whisper (so its Silero defaults apply).
+
+Context: default was ``language="sd"`` (Sindhi) + hard-coded
+``vad_filter=True`` with no way to tune. Probing real Southern Kurdish
+audio showed "sd" forces whisper to hallucinate garbage; auto-detect
+lands on "fa" and produces coherent text. This test guards the new
+config surface so we don't regress back to the hard-coded behavior.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Any, Dict, List, Tuple
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from ai import provider as provider_module
+from ai.provider import LocalWhisperProvider
+
+
+class _StubSegment:
+    def __init__(self, start: float, end: float, text: str) -> None:
+        self.start = start
+        self.end = end
+        self.text = text
+        self.avg_logprob = -0.3
+
+
+class _StubInfo:
+    def __init__(self, duration: float = 10.0) -> None:
+        self.duration = duration
+
+
+class _StubWhisperModel:
+    """Records every transcribe() call so tests can assert on kwargs."""
+
+    last_call: Dict[str, Any] = {}
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def transcribe(self, audio: str, **kwargs: Any) -> Tuple[List[_StubSegment], _StubInfo]:
+        type(self).last_call = {"audio": audio, **kwargs}
+        return iter([_StubSegment(0.0, 1.0, "ok")]), _StubInfo()
+
+
+def _make_provider(tmp_path: pathlib.Path, stt_config: Dict[str, Any],
+                   monkeypatch: Any) -> LocalWhisperProvider:
+    """Instantiate LocalWhisperProvider with the given stt config,
+    bypassing real WhisperModel loading."""
+    _StubWhisperModel.last_call = {}
+    # Stub the WhisperModel import inside _load_whisper_model.
+    monkeypatch.setattr(
+        provider_module, "_register_cuda_dll_directories", lambda: None, raising=False
+    )
+
+    # Skip the real CUDA DLL dance by monkeypatching the import path.
+    import faster_whisper  # type: ignore
+    monkeypatch.setattr(faster_whisper, "WhisperModel", _StubWhisperModel, raising=True)
+
+    provider = LocalWhisperProvider(
+        config={"stt": stt_config},
+        config_path=tmp_path / "ai_config.json",
+    )
+    return provider
+
+
+def _make_audio(tmp_path: pathlib.Path) -> pathlib.Path:
+    p = tmp_path / "clip.wav"
+    p.write_bytes(b"RIFF    WAVEfmt ")  # faux header; provider only stats existence
+    return p
+
+
+def test_empty_language_becomes_none_for_auto_detect(tmp_path, monkeypatch):
+    """language="" in config must translate to language=None when calling
+    faster-whisper, otherwise the decoder would error. This is the
+    regression guard for the old default of "sd" (Sindhi) producing
+    garbage on Kurdish audio — auto-detect is now the default."""
+    provider = _make_provider(tmp_path, {"language": ""}, monkeypatch)
+    provider.transcribe(_make_audio(tmp_path))
+    assert _StubWhisperModel.last_call["language"] is None
+
+
+def test_explicit_language_is_passed_through(tmp_path, monkeypatch):
+    """When the user explicitly sets a language code (in config or per-call),
+    we forward it to whisper unchanged."""
+    provider = _make_provider(tmp_path, {"language": "fa"}, monkeypatch)
+    provider.transcribe(_make_audio(tmp_path))
+    assert _StubWhisperModel.last_call["language"] == "fa"
+
+    # Per-call override wins over config.
+    provider.transcribe(_make_audio(tmp_path), language="ar")
+    assert _StubWhisperModel.last_call["language"] == "ar"
+
+
+def test_vad_parameters_forwarded_when_populated(tmp_path, monkeypatch):
+    """Non-empty vad_parameters dict reaches faster-whisper verbatim."""
+    stt = {
+        "language": "fa",
+        "vad_filter": True,
+        "vad_parameters": {
+            "min_silence_duration_ms": 500,
+            "threshold": 0.35,
+        },
+    }
+    provider = _make_provider(tmp_path, stt, monkeypatch)
+    provider.transcribe(_make_audio(tmp_path))
+    call = _StubWhisperModel.last_call
+    assert call["vad_filter"] is True
+    assert call["vad_parameters"] == {
+        "min_silence_duration_ms": 500,
+        "threshold": 0.35,
+    }
+
+
+def test_empty_vad_parameters_omitted_so_silero_defaults_apply(tmp_path, monkeypatch):
+    """The config's default is `vad_parameters: {}` meaning "use faster-
+    whisper's built-in Silero defaults". We verify that an empty dict is
+    NOT forwarded — otherwise it would override Silero with a broken
+    empty config."""
+    provider = _make_provider(tmp_path, {"vad_filter": True, "vad_parameters": {}}, monkeypatch)
+    provider.transcribe(_make_audio(tmp_path))
+    call = _StubWhisperModel.last_call
+    assert call["vad_filter"] is True
+    assert "vad_parameters" not in call, call
+
+
+def test_vad_disabled_does_not_forward_parameters(tmp_path, monkeypatch):
+    """If vad_filter=False, vad_parameters is meaningless — we should not
+    pass it even when the user configured values."""
+    stt = {
+        "vad_filter": False,
+        "vad_parameters": {"threshold": 0.35},
+    }
+    provider = _make_provider(tmp_path, stt, monkeypatch)
+    provider.transcribe(_make_audio(tmp_path))
+    call = _StubWhisperModel.last_call
+    assert call["vad_filter"] is False
+    assert "vad_parameters" not in call, call
+
+
+def test_task_and_beam_size_forwarded(tmp_path, monkeypatch):
+    provider = _make_provider(
+        tmp_path,
+        {"task": "translate", "beam_size": 3},
+        monkeypatch,
+    )
+    provider.transcribe(_make_audio(tmp_path))
+    call = _StubWhisperModel.last_call
+    assert call["task"] == "translate"
+    assert call["beam_size"] == 3
+
+
+def test_invalid_task_falls_back_to_transcribe(tmp_path, monkeypatch):
+    provider = _make_provider(
+        tmp_path, {"task": "garbage-value"}, monkeypatch
+    )
+    provider.transcribe(_make_audio(tmp_path))
+    assert _StubWhisperModel.last_call["task"] == "transcribe"
+
+
+def test_invalid_beam_size_falls_back_to_five(tmp_path, monkeypatch):
+    provider = _make_provider(
+        tmp_path, {"beam_size": "not-a-number"}, monkeypatch
+    )
+    provider.transcribe(_make_audio(tmp_path))
+    assert _StubWhisperModel.last_call["beam_size"] == 5


### PR DESCRIPTION
## Summary

Follow-up to #133. Investigating whether the STT lane was actually "sparse" uncovered a bigger issue: the default `stt.language = "sd"` (Sindhi) in `ai_config.json` was forcing faster-whisper to decode Southern Kurdish audio as Sindhi — which produced **pure garbage** (`'ايقIt is not legal'`, `'اجا دل ہبي لبلي أم�'`). Whisper doesn't support Kurdish, but forcing a wrong language code is worse than auto-detect.

## What this changes

1. **Default `stt.language` → `""` (auto-detect).** Empty / None is now mapped to `language=None` before the faster-whisper call. Auto-detect reliably picks `fa` (Persian, a close relative of Kurdish) on this corpus and produces coherent Kurdish-script output.
2. **`vad_filter`, `vad_parameters`, `task`, `beam_size`** are now read from `ai_config.json`. An empty `vad_parameters: {}` uses faster-whisper's built-in Silero defaults.
3. **8 new unit tests** in `test_stt_configurable_transcribe.py` lock in the behaviour.

## Evidence

Empirical probe — faster-whisper `base` on 180s of Qasr01 audio:

| config                                   | lang detected | segments | quality |
|------------------------------------------|---------------|----------|---------|
| old default (`sd`, vad_filter=True)      | sd (forced)   | 53       | garbage ('ايقIt is not legal') |
| **auto-detect (new default)**            | **fa** (p=0.72) | **69** | **coherent** ('یک؟ یک؟' = "one? one?", 'دو دو دو' = "two two two") |
| auto-detect, vad=False                   | fa            | 39       | hallucination loops in silence ('شوال' × 6) |
| `fa` forced, vad=False                   | fa            | 55       | OK |
| `ar` forced, vad=False                   | ar            | 47       | different script |
| translate→en, vad=False                  | fa            | 46       | English gloss |
| `sd` + looser VAD (500/100/0.35/200)     | sd (forced)   | 47       | garbage + fewer |

Key insight from the last row: **looser VAD on the wrong language doesn't help.** The language default is the real bug. This is also why the existing on-disk `coarse_transcripts/*.json` caches (82 segs for Qasr01 over 197 minutes) look so sparse — they were produced by `python/coarse_transcripts.py`, which ingests existing pipeline data (Audition CSV + transcription CSV), **not by faster-whisper at all**. A fresh STT run with the new defaults will replace them with ~10 segments/minute of real Kurdish-script transcription.

## Test plan

- [x] `pytest test_stt_configurable_transcribe.py` — 8/8 new tests pass
- [x] `pytest test_run_stt_job.py test_stt_cuda_fallback.py` — 9/9 existing pass (no regression)
- [ ] Re-run STT on a speaker through the PARSE UI — cache should now contain dense Kurdish-script segments rather than the imported Swadesh labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)