### PR TITLE
fix: drop flex wrapper around WaveSurfer container (PR #133 regression)

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1471,30 +1471,26 @@ const AnnotateView: React.FC<AnnotateViewProps> = ({ concept, speaker, totalConc
           </div>
         </div>
 
-        {/* Waveform container — WaveSurfer owns this div */}
+        {/* Waveform container — WaveSurfer owns this div. The left padding on
+            the inner wrapper matches the lane label gutter so waveform t=0
+            lines up with segment t=0 in the STT/IPA/ORTHO strips, without
+            wrapping WaveSurfer's container in a flex row (which caused the
+            container width to be unstable on first render and made the
+            Timeline plugin flicker). */}
         <div className="relative px-5 pt-4 pb-2">
-          <div className="flex items-stretch">
-            {/* Left gutter matches the lane label column so waveform t=0
-                lines up with segment t=0 in the STT/IPA/ORTHO strips. */}
+          <div className="relative" style={{ paddingLeft: LABEL_COL_PX }}>
             <div
-              className="shrink-0"
-              style={{ width: LABEL_COL_PX }}
-              aria-hidden="true"
+              ref={containerRef}
+              className="relative w-full overflow-hidden rounded-lg ring-1 ring-slate-100"
+              style={{ minHeight: 110 }}
             />
-            <div className="relative flex-1">
-              <div
-                ref={containerRef}
-                className="relative w-full overflow-hidden rounded-lg ring-1 ring-slate-100"
-                style={{ minHeight: 110 }}
+            {spectroOn && (
+              <canvas
+                ref={spectroCanvasRef}
+                className="pointer-events-none absolute inset-y-0 right-0 rounded-lg"
+                style={{ left: LABEL_COL_PX, opacity: 0.6, mixBlendMode: 'multiply' }}
               />
-              {spectroOn && (
-                <canvas
-                  ref={spectroCanvasRef}
-                  className="pointer-events-none absolute inset-0 rounded-lg"
-                  style={{ width: '100%', height: '100%', opacity: 0.6, mixBlendMode: 'multiply' }}
-                />
-              )}
-            </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Reported regression after PR #133 landed: timeline timestamps flicker / mostly don't render, selecting a lexeme no longer seeks the waveform, and the waveform rendering is generally unstable.

## Root cause

PR #133 wrapped the WaveSurfer container in a \`flex items-stretch\` row with a 48 px spacer to align t=0 with the transcription-lane label gutter:

\`\`\`jsx
<div className=\"flex items-stretch\">
  <div className=\"shrink-0\" style={{ width: LABEL_COL_PX }} />
  <div className=\"relative flex-1\">
    <div ref={containerRef} className=\"relative w-full overflow-hidden ...\" />
    …
  </div>
</div>
\`\`\`

With this structure, \`containerRef.clientWidth\` depends on flex layout resolution, which happens after the initial block-layout pass. \`useWaveSurfer\` reads that width synchronously when it creates WaveSurfer + the Timeline plugin, so the plugin's internal measurements end up out of sync with the waveform once flex sizing settles. Subsequent resize events (and the \`ResizeObserver\` in \`TranscriptionLanes\`) then keep re-reading from a wrapper whose layout is still churning — hence the flicker and the broken seeks.

## Fix

Achieve the same visual offset with \`paddingLeft: LABEL_COL_PX\` on the existing wrapper, preserving the original single-parent DOM tree around WaveSurfer's container:

\`\`\`jsx
<div className=\"relative\" style={{ paddingLeft: LABEL_COL_PX }}>
  <div ref={containerRef} className=\"relative w-full overflow-hidden ...\" />
  {spectroOn && <canvas className=\"absolute inset-y-0 right-0 ...\" style={{ left: LABEL_COL_PX }} />}
</div>
\`\`\`

- \`container.clientWidth\` is stable on first paint (parent width minus the 48 px of padding).
- Spectrogram canvas switches from \`inset-0\` to \`inset-y-0 right-0\` + \`left: LABEL_COL_PX\` so it still overlays only the waveform area, not the gutter.
- Lane alignment is preserved because the waveform still starts 48 px from the outer edge.

## Not verified locally

Python backend isn't running in my environment, so I couldn't exercise the real waveform with a speaker loaded. The code change is targeted at the regression's likely cause; please verify the glitch is gone on your end after pulling.

## Test plan

- [ ] Open Fail02 — waveform + timeline render on first load, no flicker
- [ ] Select a lexeme — waveform scrolls/zooms to the lexeme's time
- [ ] STT / IPA / ORTHO lanes stay aligned with the waveform at every zoom level
- [ ] Enable the spectrogram — canvas overlays only the waveform (not the 48 px gutter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)