### PR TITLE
Razhan-backed ORTHO compute + pre-flight checklist for full pipeline

### DIFF
--- a/config/ai_config.example.json
+++ b/config/ai_config.example.json
@@ -12,6 +12,15 @@
     "provider": "local",
     "model": "epitran"
   },
+  "ortho": {
+    "_comment": "Orthographic transcription (e.g. Kurdish Arabic script). Razhan is the canonical SDH model. model_path may be a HuggingFace repo id (razhan/whisper-base-sdh) or a local CTranslate2 path.",
+    "provider": "faster-whisper",
+    "model_path": "razhan/whisper-base-sdh",
+    "language": "sd",
+    "device": "cuda",
+    "compute_type": "float16",
+    "beam_size": 5
+  },
   "llm": {
     "provider": "openai",
     "model": "gpt-5.4",

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -41,6 +41,13 @@ _DEFAULT_AI_CONFIG: Dict[str, Any] = {
         "provider": "local",
         "model": "epitran",
     },
+    "ortho": {
+        "provider": "faster-whisper",
+        "model_path": "razhan/whisper-base-sdh",
+        "language": "sd",
+        "device": "cuda",
+        "compute_type": "float16",
+    },
     "llm": {
         "provider": "openai",
         "model": "gpt-5.4",
@@ -961,7 +968,12 @@ class AIProvider(abc.ABC):
 
 
 class LocalWhisperProvider(AIProvider):
-    """Local provider backed by faster-whisper for STT."""
+    """Local provider backed by faster-whisper.
+
+    Used by both STT (``config_section="stt"``) and ORTHO
+    (``config_section="ortho"``, razhan/whisper-base-sdh). The section
+    selects which ai_config block supplies model_path/device/compute_type.
+    """
 
     def __init__(
         self,
@@ -970,15 +982,17 @@ class LocalWhisperProvider(AIProvider):
         language: Optional[str] = None,
         device: Optional[str] = None,
         compute_type: Optional[str] = None,
+        config_section: str = "stt",
     ) -> None:
         super().__init__(config=config, config_path=config_path)
 
-        stt_config = self.config.get("stt", {})
-        self.model_path = str(stt_config.get("model_path", "")).strip()
-        self.language = str(language or stt_config.get("language", "")).strip() or None
-        self.device = str(device or stt_config.get("device", "cpu")).strip() or "cpu"
+        self.config_section = str(config_section or "stt").strip() or "stt"
+        section_config = self.config.get(self.config_section, {})
+        self.model_path = str(section_config.get("model_path", "")).strip()
+        self.language = str(language or section_config.get("language", "")).strip() or None
+        self.device = str(device or section_config.get("device", "cpu")).strip() or "cpu"
         self.compute_type = (
-            str(compute_type or stt_config.get("compute_type", "int8")).strip() or "int8"
+            str(compute_type or section_config.get("compute_type", "int8")).strip() or "int8"
         )
 
         if _stt_force_cpu_env() and self.device.lower().startswith("cuda"):
@@ -1608,6 +1622,19 @@ def get_stt_provider(config: Optional[Dict[str, Any]] = None) -> AIProvider:
     return _build_provider(provider_name, merged)
 
 
+def get_ortho_provider(config: Optional[Dict[str, Any]] = None) -> AIProvider:
+    """Factory for the orthographic transcription provider (razhan/whisper-base-sdh).
+
+    ORTHO is always a faster-whisper model configured in the `ortho` block,
+    distinct from whatever general-purpose model STT uses. This goes straight
+    to ``LocalWhisperProvider`` with ``config_section="ortho"`` so
+    model_path / device / language come from the ortho block rather than stt.
+    """
+    override = config or {}
+    merged = _deep_merge_dicts(load_ai_config(), override)
+    return LocalWhisperProvider(config=merged, config_section="ortho")
+
+
 def get_ipa_provider(config: Optional[Dict[str, Any]] = None) -> AIProvider:
     """Factory for IPA providers resolved from `ipa.provider` fallback chain."""
     override = config or {}
@@ -1660,6 +1687,7 @@ __all__ = [
     "OllamaProvider",
     "OpenAIChatRuntime",
     "get_stt_provider",
+    "get_ortho_provider",
     "get_ipa_provider",
     "get_llm_provider",
     "get_chat_config",

--- a/python/server.py
+++ b/python/server.py
@@ -23,7 +23,7 @@ from urllib.parse import unquote, urlparse
 
 from ai.chat_orchestrator import ChatOrchestrator, ChatOrchestratorError, READ_ONLY_NOTICE
 from ai.chat_tools import ParseChatTools
-from ai.provider import get_chat_config, get_ipa_provider, get_llm_provider, get_stt_provider, load_ai_config, resolve_context_window
+from ai.provider import get_chat_config, get_ipa_provider, get_llm_provider, get_ortho_provider, get_stt_provider, load_ai_config, resolve_context_window
 from audio_pipeline_paths import build_normalized_output_path
 
 try:
@@ -2801,6 +2801,403 @@ def _compute_speaker_ipa(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]
     return {"speaker": speaker, "filled": filled, "skipped": skipped, "total": total}
 
 
+def _pipeline_audio_path_for_speaker(speaker: str) -> pathlib.Path:
+    """Resolve the best audio file to feed a Whisper-family model for a speaker.
+
+    Prefers the normalized working copy under ``audio/working/<speaker>/`` if it
+    exists; otherwise falls back to the raw source recording recorded in the
+    annotation's ``source_audio`` field. Raises ``FileNotFoundError`` if neither
+    is reachable.
+    """
+    annotation_path = _annotation_read_path_for_speaker(speaker)
+    if not annotation_path.is_file():
+        raise RuntimeError("No annotation found for speaker {0!r}".format(speaker))
+
+    record = _read_json_file(annotation_path, {})
+    source_rel = ""
+    if isinstance(record, dict):
+        source_rel = str(
+            record.get("source_audio") or record.get("source_wav") or ""
+        ).strip()
+    if not source_rel:
+        source_rel = _annotation_primary_source_wav(speaker)
+    if not source_rel:
+        raise RuntimeError(
+            "No source_audio on annotation for {0!r}; import or onboard the speaker first".format(
+                speaker
+            )
+        )
+
+    source_path = _resolve_project_path(source_rel)
+    working_dir = _project_root() / "audio" / "working" / speaker
+    normalized_path = build_normalized_output_path(source_path, working_dir)
+    if normalized_path.exists():
+        return normalized_path
+    if source_path.exists():
+        return source_path
+    raise FileNotFoundError(
+        "Neither normalized ({0}) nor source audio ({1}) exists for {2!r}".format(
+            normalized_path, source_path, speaker
+        )
+    )
+
+
+def _pipeline_state_for_speaker(speaker: str) -> Dict[str, Any]:
+    """Return what's already been done for a speaker, per pipeline step.
+
+    Shape::
+
+        {
+          "speaker": "Fail02",
+          "normalize": {"done": true, "path": "audio/working/Fail02/Fail02.wav"},
+          "stt":       {"done": true, "segments": 142, "source_wav": "..."},
+          "ortho":     {"done": true, "intervals": 84},
+          "ipa":       {"done": false, "intervals": 0}
+        }
+
+    "done" means a tier has at least one non-empty text interval. The UI uses
+    this to drive the pre-flight checklist: unchecked steps are skipped;
+    steps with ``done=True`` surface an overwrite confirmation.
+    """
+    speaker_norm = _normalize_speaker_id(speaker)
+    result: Dict[str, Any] = {"speaker": speaker_norm}
+
+    # Normalize: working WAV exists?
+    try:
+        annotation_path = _annotation_read_path_for_speaker(speaker_norm)
+        record = _read_json_file(annotation_path, {}) if annotation_path.is_file() else {}
+    except Exception:
+        record = {}
+
+    source_rel = ""
+    if isinstance(record, dict):
+        source_rel = str(
+            record.get("source_audio") or record.get("source_wav") or ""
+        ).strip()
+    normalized_info: Dict[str, Any] = {"done": False, "path": None}
+    if source_rel:
+        try:
+            source_path = _resolve_project_path(source_rel)
+            working_dir = _project_root() / "audio" / "working" / speaker_norm
+            normalized_path = build_normalized_output_path(source_path, working_dir)
+            if normalized_path.exists():
+                normalized_info = {
+                    "done": True,
+                    "path": str(normalized_path.relative_to(_project_root())),
+                }
+        except Exception:
+            pass
+    result["normalize"] = normalized_info
+
+    # STT: cache populated?
+    cached_stt = _latest_stt_segments_for_speaker(speaker_norm)
+    stt_info: Dict[str, Any] = {"done": False, "segments": 0}
+    if cached_stt:
+        stt_info = {"done": True, "segments": len(cached_stt)}
+    result["stt"] = stt_info
+
+    # ORTHO + IPA: count non-empty intervals on the annotation tiers.
+    tiers = {}
+    if isinstance(record, dict):
+        tiers = record.get("tiers") if isinstance(record.get("tiers"), dict) else {}
+
+    def _non_empty_count(tier_name: str) -> int:
+        tier = tiers.get(tier_name) if isinstance(tiers, dict) else None
+        if not isinstance(tier, dict):
+            return 0
+        intervals = tier.get("intervals") or []
+        if not isinstance(intervals, list):
+            return 0
+        return sum(
+            1 for iv in intervals
+            if isinstance(iv, dict) and str(iv.get("text") or "").strip()
+        )
+
+    ortho_count = _non_empty_count("ortho")
+    ipa_count = _non_empty_count("ipa")
+    result["ortho"] = {"done": ortho_count > 0, "intervals": ortho_count}
+    result["ipa"] = {"done": ipa_count > 0, "intervals": ipa_count}
+
+    return result
+
+
+def _compute_speaker_ortho(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Generate an orthographic transcript for a speaker using the razhan model.
+
+    Runs the ORTHO provider (faster-whisper with razhan/whisper-base-sdh)
+    full-file against the speaker's working WAV (normalized copy preferred,
+    raw source as fallback) and writes razhan's own segments to the
+    ``ortho`` tier of the annotation.
+
+    Payload: ``{"speaker": "Fail02", "overwrite": false}``.
+
+    Overwrite semantics differ from IPA: razhan's segmentation isn't stable
+    across runs, so we can't pair segments by ``(start, end)`` the way IPA
+    does. Rule: if the ortho tier already has any non-empty text intervals,
+    the caller must set ``overwrite=True`` to replace the whole tier;
+    otherwise the run is a no-op and returns ``skipped=True``. Empty tiers
+    are always populated.
+    """
+    speaker = _normalize_speaker_id(payload.get("speaker"))
+    overwrite = bool(payload.get("overwrite", False))
+    language = payload.get("language")
+    language_str = str(language).strip() if isinstance(language, str) and language.strip() else None
+
+    canonical_path = _project_root() / _annotation_record_relative_path(speaker)
+    legacy_path = _project_root() / _annotation_legacy_record_relative_path(speaker)
+
+    if canonical_path.is_file():
+        annotation_path = canonical_path
+    elif legacy_path.is_file():
+        annotation_path = legacy_path
+    else:
+        raise RuntimeError("No annotation found for speaker {0!r}".format(speaker))
+
+    annotation = _read_json_file(annotation_path, {})
+    if not isinstance(annotation, dict):
+        raise RuntimeError("Annotation is not a JSON object")
+
+    tiers = annotation.get("tiers") or {}
+    ortho_tier = tiers.get("ortho") if isinstance(tiers.get("ortho"), dict) else None
+    existing_intervals: List[Dict[str, Any]] = []
+    if isinstance(ortho_tier, dict):
+        existing_intervals = [iv for iv in (ortho_tier.get("intervals") or []) if isinstance(iv, dict)]
+    has_existing_text = any(str(iv.get("text") or "").strip() for iv in existing_intervals)
+
+    if has_existing_text and not overwrite:
+        return {
+            "speaker": speaker,
+            "filled": 0,
+            "skipped": True,
+            "reason": "ortho tier already populated; pass overwrite=True to replace",
+            "existing_intervals": len(existing_intervals),
+        }
+
+    audio_path = _pipeline_audio_path_for_speaker(speaker)
+    _set_job_progress(job_id, 2.0, message="Loading ortho model (razhan)")
+
+    provider = get_ortho_provider()
+
+    def _progress_callback(progress: float, segments_processed: int) -> None:
+        clamped = min(float(progress) if progress is not None else 0.0, 98.0)
+        _set_job_progress(
+            job_id,
+            max(2.0, clamped),
+            message="ORTHO transcribing ({0} segments)".format(segments_processed),
+            segments_processed=segments_processed,
+        )
+
+    segments = provider.transcribe(
+        audio_path=audio_path,
+        language=language_str,
+        progress_callback=_progress_callback,
+    )
+
+    new_intervals: List[Dict[str, Any]] = []
+    for seg in segments:
+        start = float(seg.get("start", 0.0) or 0.0)
+        end = float(seg.get("end", start) or start)
+        text = str(seg.get("text", "") or "").strip()
+        if not text:
+            continue
+        new_intervals.append({"start": start, "end": end, "text": text})
+
+    new_intervals.sort(key=lambda iv: (float(iv["start"]), float(iv["end"])))
+
+    if ortho_tier is None:
+        ortho_tier = {"type": "interval", "display_order": 2, "intervals": []}
+    ortho_tier["intervals"] = new_intervals
+    tiers["ortho"] = ortho_tier
+    annotation["tiers"] = tiers
+    _annotation_touch_metadata(annotation, preserve_created=True)
+
+    _write_json_file(annotation_path, annotation)
+    if canonical_path != annotation_path:
+        _write_json_file(canonical_path, annotation)
+    if legacy_path != annotation_path:
+        _write_json_file(legacy_path, annotation)
+
+    _set_job_progress(job_id, 99.0, message="ORTHO written ({0} intervals)".format(len(new_intervals)))
+
+    return {
+        "speaker": speaker,
+        "filled": len(new_intervals),
+        "skipped": False,
+        "replaced_existing": has_existing_text,
+        "audio_path": str(audio_path),
+        "total": len(new_intervals),
+    }
+
+
+# Canonical step identifiers recognised by the full-pipeline sequencer.
+PIPELINE_STEPS: Tuple[str, ...] = ("normalize", "stt", "ortho", "ipa")
+
+
+def _compute_full_pipeline(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Run a user-selected subset of the speaker pipeline sequentially.
+
+    Payload::
+
+        {
+          "speaker": "Fail02",
+          "steps": ["normalize", "stt", "ortho", "ipa"],
+          "overwrites": {"normalize": false, "stt": false, "ortho": true, "ipa": false},
+          "language": "sd"       // optional, forwarded to STT + ORTHO
+        }
+
+    Steps run in canonical order (normalize → stt → ortho → ipa). Unselected
+    steps are skipped silently. Overwrite flags only matter for steps whose
+    prior state already has data — an unchecked "overwrite" on a populated
+    tier causes that step to skip with ``skipped=True`` in its sub-result.
+    Failure of any step aborts the pipeline and propagates the error.
+    """
+    speaker = _normalize_speaker_id(payload.get("speaker"))
+
+    raw_steps = payload.get("steps")
+    if raw_steps is None:
+        selected = list(PIPELINE_STEPS)
+    elif isinstance(raw_steps, (list, tuple)):
+        selected_set = {str(s).strip().lower() for s in raw_steps if str(s).strip()}
+        selected = [s for s in PIPELINE_STEPS if s in selected_set]
+    else:
+        raise RuntimeError("steps must be a list, got {0}".format(type(raw_steps).__name__))
+
+    if not selected:
+        return {"speaker": speaker, "steps_run": [], "results": {}, "message": "No steps selected"}
+
+    overwrites_raw = payload.get("overwrites") or {}
+    if not isinstance(overwrites_raw, dict):
+        overwrites_raw = {}
+    overwrites = {str(k).strip().lower(): bool(v) for k, v in overwrites_raw.items()}
+
+    language = payload.get("language")
+    language_str = (
+        str(language).strip() if isinstance(language, str) and language.strip() else None
+    )
+
+    results: Dict[str, Any] = {}
+    steps_run: List[str] = []
+    total = len(selected)
+
+    for idx, step in enumerate(selected):
+        step_base_pct = 5.0 + (idx / total) * 90.0
+        _set_job_progress(
+            job_id,
+            step_base_pct,
+            message="Pipeline step {0}/{1}: {2}".format(idx + 1, total, step),
+        )
+
+        if step == "normalize":
+            source_rel = _annotation_primary_source_wav(speaker)
+            if not source_rel:
+                raise RuntimeError(
+                    "Cannot normalize {0!r}: no source_audio on annotation".format(speaker)
+                )
+            audio_path = _resolve_project_path(source_rel)
+            working_dir = _project_root() / "audio" / "working" / speaker
+            normalized_path = build_normalized_output_path(audio_path, working_dir)
+            if normalized_path.exists() and not overwrites.get("normalize", False):
+                results["normalize"] = {
+                    "skipped": True,
+                    "reason": "normalized output already exists; overwrite=False",
+                    "path": str(normalized_path.relative_to(_project_root())),
+                }
+                steps_run.append(step)
+                continue
+            # Delegate to the background normalize runner, but execute inline
+            # (no new thread) so the pipeline job owns the job_id.
+            _run_normalize_job(job_id, speaker, source_rel)
+            # The runner swallows its own exceptions into _set_job_error —
+            # re-raise here so the pipeline aborts visibly.
+            snapshot = _get_job_snapshot(job_id) or {}
+            if str(snapshot.get("status") or "") == "error":
+                raise RuntimeError(
+                    "normalize step failed: {0}".format(snapshot.get("error") or "unknown error")
+                )
+            sub_result = snapshot.get("result") if isinstance(snapshot.get("result"), dict) else {}
+            results["normalize"] = dict(sub_result) if sub_result else {"done": True}
+            _reset_job_to_running(job_id)
+            steps_run.append(step)
+
+        elif step == "stt":
+            source_rel = _annotation_primary_source_wav(speaker)
+            if not source_rel:
+                raise RuntimeError(
+                    "Cannot run STT for {0!r}: no source_audio on annotation".format(speaker)
+                )
+            cached = _latest_stt_segments_for_speaker(speaker)
+            if cached and not overwrites.get("stt", False):
+                results["stt"] = {
+                    "skipped": True,
+                    "reason": "STT cache already exists; overwrite=False",
+                    "segments": len(cached),
+                }
+                steps_run.append(step)
+                continue
+            _run_stt_job(job_id, speaker, source_rel, language_str)
+            snapshot = _get_job_snapshot(job_id) or {}
+            if str(snapshot.get("status") or "") == "error":
+                raise RuntimeError(
+                    "stt step failed: {0}".format(snapshot.get("error") or "unknown error")
+                )
+            sub_result = snapshot.get("result") if isinstance(snapshot.get("result"), dict) else {}
+            results["stt"] = {
+                "segments": len(sub_result.get("segments") or []) if isinstance(sub_result, dict) else 0,
+                "done": True,
+            }
+            _reset_job_to_running(job_id)
+            steps_run.append(step)
+
+        elif step == "ortho":
+            sub_result = _compute_speaker_ortho(
+                job_id,
+                {
+                    "speaker": speaker,
+                    "overwrite": overwrites.get("ortho", False),
+                    "language": language_str,
+                },
+            )
+            results["ortho"] = sub_result
+            steps_run.append(step)
+
+        elif step == "ipa":
+            sub_result = _compute_speaker_ipa(
+                job_id,
+                {"speaker": speaker, "overwrite": overwrites.get("ipa", False)},
+            )
+            results["ipa"] = sub_result
+            steps_run.append(step)
+
+        else:
+            raise RuntimeError("Unknown pipeline step: {0}".format(step))
+
+    _set_job_progress(job_id, 99.0, message="Pipeline complete")
+    return {
+        "speaker": speaker,
+        "steps_run": steps_run,
+        "results": results,
+    }
+
+
+def _reset_job_to_running(job_id: str) -> None:
+    """Clear terminal-state flags on a job so later pipeline steps can report progress.
+
+    ``_run_normalize_job`` and ``_run_stt_job`` are designed as one-shot background
+    workers that call ``_set_job_complete`` on success. When we call them inline
+    from the full-pipeline sequencer we need to undo that so the outer job stays
+    in a ``running`` state for the next step.
+    """
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+        if not isinstance(job, dict):
+            return
+        job["status"] = "running"
+        job["result"] = None
+        job["error"] = None
+        job["completed_at"] = None
+        job["completed_ts"] = None
+
+
 def _run_compute_job(job_id: str, compute_type: str, payload: Dict[str, Any]) -> None:
     try:
         normalized_type = str(compute_type or "").strip().lower()
@@ -2812,6 +3209,10 @@ def _run_compute_job(job_id: str, compute_type: str, payload: Dict[str, Any]) ->
             result = _compute_contact_lexemes(job_id, payload)
         elif normalized_type in {"ipa_only", "ipa-only", "ipa"}:
             result = _compute_speaker_ipa(job_id, payload)
+        elif normalized_type in {"ortho", "ortho_only", "ortho-only"}:
+            result = _compute_speaker_ortho(job_id, payload)
+        elif normalized_type in {"full_pipeline", "full-pipeline", "pipeline"}:
+            result = _compute_full_pipeline(job_id, payload)
         else:
             raise RuntimeError("Unsupported compute type: {0}".format(normalized_type))
 
@@ -2965,6 +3366,10 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         if len(parts) == 3 and parts[0] == "api" and parts[1] == "stt-segments":
             self._api_get_stt_segments(parts[2])
+            return
+
+        if len(parts) == 4 and parts[0] == "api" and parts[1] == "pipeline" and parts[2] == "state":
+            self._api_get_pipeline_state(parts[3])
             return
 
         if len(parts) == 4 and parts[0] == "api" and parts[1] == "chat" and parts[2] == "session":
@@ -3188,6 +3593,22 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         segments = data.get("segments") if isinstance(data.get("segments"), list) else []
         data["segments"] = segments
         self._send_json(HTTPStatus.OK, data)
+
+    def _api_get_pipeline_state(self, speaker_part: str) -> None:
+        """Return per-step pipeline state for a speaker.
+
+        Drives the pre-flight checklist modal shown before ``Run Full Pipeline``.
+        Shape is documented on ``_pipeline_state_for_speaker``.
+        """
+        try:
+            speaker = _normalize_speaker_id(speaker_part)
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc))
+        try:
+            payload = _pipeline_state_for_speaker(speaker)
+        except Exception as exc:
+            raise ApiError(HTTPStatus.INTERNAL_SERVER_ERROR, str(exc))
+        self._send_json(HTTPStatus.OK, payload)
 
     def _api_post_annotation(self, speaker_part: str) -> None:
         try:

--- a/python/test_compute_speaker_ortho.py
+++ b/python/test_compute_speaker_ortho.py
@@ -1,0 +1,313 @@
+"""Unit tests for _compute_speaker_ortho and the full-pipeline sequencer."""
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server  # noqa: E402
+
+
+class _StubOrthoProvider:
+    """Returns a fixed set of razhan-style segments so tests can assert exact output."""
+
+    def __init__(self, segments=None):
+        # Default segmentation: three intervals, mid-file, Kurdish-ish placeholders.
+        self._segments = segments or [
+            {"start": 0.5, "end": 1.2, "text": "بەش", "confidence": 0.9},
+            {"start": 1.3, "end": 2.0, "text": "سەرە", "confidence": 0.85},
+            {"start": 2.1, "end": 2.8, "text": "", "confidence": 0.1},  # empty → dropped
+        ]
+        self.calls: list[dict] = []
+
+    def transcribe(self, audio_path, language=None, progress_callback=None):
+        self.calls.append({"audio_path": str(audio_path), "language": language})
+        # Exercise progress callback to mirror the real provider contract.
+        if progress_callback is not None:
+            progress_callback(50.0, 1)
+            progress_callback(100.0, len(self._segments))
+        return list(self._segments)
+
+
+def _seed_annotation(tmp_path, speaker, ortho=None, source_audio="x.wav"):
+    annotations_dir = tmp_path / "annotations"
+    annotations_dir.mkdir(exist_ok=True)
+    annotation = {
+        "version": 1,
+        "project_id": "t",
+        "speaker": speaker,
+        "source_audio": source_audio,
+        "source_audio_duration_sec": 10.0,
+        "tiers": {
+            "ipa":     {"type": "interval", "display_order": 1, "intervals": []},
+            "ortho":   {"type": "interval", "display_order": 2, "intervals": ortho or []},
+            "concept": {"type": "interval", "display_order": 3, "intervals": []},
+            "speaker": {"type": "interval", "display_order": 4, "intervals": []},
+        },
+        "metadata": {
+            "language_code": "sdh",
+            "created": "2026-01-01T00:00:00Z",
+            "modified": "2026-01-01T00:00:00Z",
+        },
+    }
+    (annotations_dir / f"{speaker}.parse.json").write_text(
+        json.dumps(annotation), encoding="utf-8",
+    )
+    return annotation
+
+
+def _write_fake_source_wav(tmp_path, rel_path):
+    path = tmp_path / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfake")  # not real audio — we stub the provider
+    return path
+
+
+def _load_canonical(tmp_path, speaker):
+    return json.loads((tmp_path / "annotations" / f"{speaker}.parse.json").read_text("utf-8"))
+
+
+def test_ortho_writes_razhan_segments_to_empty_tier(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    stub = _StubOrthoProvider()
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho("j1", {"speaker": "Fail02"})
+
+    assert result["filled"] == 2  # empty segment dropped
+    assert result["skipped"] is False
+    assert result["replaced_existing"] is False
+    assert len(stub.calls) == 1
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    intervals = ann["tiers"]["ortho"]["intervals"]
+    assert [iv["text"] for iv in intervals] == ["بەش", "سەرە"]
+    assert intervals[0]["start"] == pytest.approx(0.5)
+    assert intervals[1]["end"] == pytest.approx(2.0)
+
+
+def test_ortho_skips_if_tier_populated_without_overwrite(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    stub = _StubOrthoProvider()
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+
+    existing = [{"start": 5.0, "end": 5.5, "text": "manual-edit"}]
+    _seed_annotation(tmp_path, "Fail02", ortho=existing, source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho("j1", {"speaker": "Fail02"})
+
+    assert result["skipped"] is True
+    assert result["existing_intervals"] == 1
+    # Provider was never invoked — skip happens before model load.
+    assert stub.calls == []
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    assert ann["tiers"]["ortho"]["intervals"] == existing
+
+
+def test_ortho_overwrite_true_replaces_tier(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    stub = _StubOrthoProvider()
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+
+    existing = [{"start": 5.0, "end": 5.5, "text": "manual-edit"}]
+    _seed_annotation(tmp_path, "Fail02", ortho=existing, source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho(
+        "j1", {"speaker": "Fail02", "overwrite": True},
+    )
+
+    assert result["skipped"] is False
+    assert result["replaced_existing"] is True
+    assert result["filled"] == 2
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    texts = [iv["text"] for iv in ann["tiers"]["ortho"]["intervals"]]
+    assert "manual-edit" not in texts
+    assert texts == ["بەش", "سەرە"]
+
+
+def test_ortho_prefers_normalized_working_wav(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    stub = _StubOrthoProvider()
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+    normalized = _write_fake_source_wav(tmp_path, "audio/working/Fail02/Fail02.wav")
+
+    server._compute_speaker_ortho("j1", {"speaker": "Fail02"})
+
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["audio_path"] == str(normalized)
+
+
+def test_ortho_missing_annotation_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: _StubOrthoProvider())
+
+    with pytest.raises(RuntimeError, match="No annotation"):
+        server._compute_speaker_ortho("j1", {"speaker": "GhostSpeaker"})
+
+
+def test_run_compute_job_dispatches_ortho(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: _StubOrthoProvider())
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    captured = {}
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        server, "_set_job_complete",
+        lambda jid, result, **kw: captured.setdefault("result", result),
+    )
+    monkeypatch.setattr(
+        server, "_set_job_error",
+        lambda jid, err: captured.setdefault("error", err),
+    )
+
+    server._run_compute_job("j1", "ortho", {"speaker": "Fail02"})
+    assert "error" not in captured
+    assert captured["result"]["filled"] == 2
+
+
+# --------------------------------------------------------------------------
+# Pipeline state probe
+# --------------------------------------------------------------------------
+
+
+def test_pipeline_state_reports_all_steps_empty_for_fresh_speaker(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    state = server._pipeline_state_for_speaker("Fail02")
+
+    assert state["speaker"] == "Fail02"
+    assert state["normalize"]["done"] is False
+    assert state["stt"]["done"] is False
+    assert state["ortho"]["done"] is False
+    assert state["ipa"]["done"] is False
+
+
+def test_pipeline_state_detects_existing_ortho_and_normalized(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    ortho = [{"start": 1.0, "end": 1.5, "text": "hair"}]
+    _seed_annotation(tmp_path, "Fail02", ortho=ortho, source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "audio/working/Fail02/Fail02.wav")
+
+    state = server._pipeline_state_for_speaker("Fail02")
+
+    assert state["normalize"]["done"] is True
+    assert state["normalize"]["path"].endswith("Fail02.wav")
+    assert state["ortho"]["done"] is True
+    assert state["ortho"]["intervals"] == 1
+    assert state["ipa"]["done"] is False
+
+
+# --------------------------------------------------------------------------
+# full_pipeline sequencer
+# --------------------------------------------------------------------------
+
+
+def test_full_pipeline_runs_only_selected_steps(tmp_path, monkeypatch):
+    """Unchecked steps must not invoke their compute functions."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    called: list[str] = []
+
+    def fake_ortho(job_id, payload):
+        called.append("ortho")
+        return {"speaker": payload["speaker"], "filled": 3, "skipped": False}
+
+    def fake_ipa(job_id, payload):
+        called.append("ipa")
+        return {"speaker": payload["speaker"], "filled": 2, "skipped": 0, "total": 2}
+
+    def fake_normalize(*a, **kw):
+        called.append("normalize")
+        raise AssertionError("normalize should not run when unchecked")
+
+    def fake_stt(*a, **kw):
+        called.append("stt")
+        raise AssertionError("stt should not run when unchecked")
+
+    monkeypatch.setattr(server, "_compute_speaker_ortho", fake_ortho)
+    monkeypatch.setattr(server, "_compute_speaker_ipa", fake_ipa)
+    monkeypatch.setattr(server, "_run_normalize_job", fake_normalize)
+    monkeypatch.setattr(server, "_run_stt_job", fake_stt)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+
+    result = server._compute_full_pipeline(
+        "j1",
+        {
+            "speaker": "Fail02",
+            "steps": ["ortho", "ipa"],
+            "overwrites": {"ortho": True},
+        },
+    )
+
+    assert called == ["ortho", "ipa"]
+    assert result["steps_run"] == ["ortho", "ipa"]
+    assert result["results"]["ortho"]["filled"] == 3
+    assert result["results"]["ipa"]["filled"] == 2
+
+
+def test_full_pipeline_enforces_canonical_order(tmp_path, monkeypatch):
+    """Even if steps are submitted in the wrong order, run normalize → stt → ortho → ipa."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    called: list[str] = []
+    monkeypatch.setattr(server, "_compute_speaker_ortho", lambda *a, **kw: called.append("ortho") or {"filled": 0})
+    monkeypatch.setattr(server, "_compute_speaker_ipa", lambda *a, **kw: called.append("ipa") or {"filled": 0})
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+
+    server._compute_full_pipeline(
+        "j1",
+        {
+            "speaker": "Fail02",
+            "steps": ["ipa", "ortho"],   # deliberately reversed
+        },
+    )
+
+    assert called == ["ortho", "ipa"]
+
+
+def test_full_pipeline_propagates_step_failure(tmp_path, monkeypatch):
+    """A step raising should abort the pipeline and propagate the error."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    def broken_ortho(*a, **kw):
+        raise RuntimeError("razhan exploded")
+
+    ipa_called = {"count": 0}
+
+    def fake_ipa(*a, **kw):
+        ipa_called["count"] += 1
+        return {"filled": 0}
+
+    monkeypatch.setattr(server, "_compute_speaker_ortho", broken_ortho)
+    monkeypatch.setattr(server, "_compute_speaker_ipa", fake_ipa)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+
+    with pytest.raises(RuntimeError, match="razhan exploded"):
+        server._compute_full_pipeline(
+            "j1",
+            {"speaker": "Fail02", "steps": ["ortho", "ipa"]},
+        )
+    # IPA must not run after ORTHO fails.
+    assert ipa_called["count"] == 0

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -641,15 +641,16 @@ describe("ParseUI", () => {
 
 
 describe("Actions menu job lifecycle", () => {
-  it("Actions menu renders all 5 processing action buttons", () => {
+  it("Actions menu renders all processing action buttons (incl. Generate ORTHO + Run Full Pipeline…)", () => {
     render(<ParseUI />);
 
     fireEvent.click(screen.getByRole("button", { name: "Actions" }));
 
     expect(screen.getByText("Run Audio Normalization")).toBeTruthy();
-    expect(screen.getByText("Run Orthographic STT")).toBeTruthy();
+    expect(screen.getByText("Run STT")).toBeTruthy();
+    expect(screen.getByText("Generate ORTHO (razhan)")).toBeTruthy();
     expect(screen.getByText("Run IPA Transcription")).toBeTruthy();
-    expect(screen.getByText("Run Full Pipeline")).toBeTruthy();
+    expect(screen.getByText("Run Full Pipeline…")).toBeTruthy();
     expect(screen.getByText("Run Cross-Speaker Match")).toBeTruthy();
   });
 

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -33,6 +33,7 @@ import { usePlaybackStore } from './stores/playbackStore';
 import { useTagStore } from './stores/tagStore';
 import { useUIStore } from './stores/uiStore';
 import { Modal } from './components/shared/Modal';
+import { PipelineChecklistModal, type PipelineChecklistResult } from './components/shared/PipelineChecklistModal';
 import { ChatMarkdown } from './components/shared/ChatMarkdown';
 import { LexemeDetail } from './components/compare/LexemeDetail';
 import { CommentsImport } from './components/compare/CommentsImport';
@@ -1954,12 +1955,54 @@ export function ParseUI() {
     onComplete: () => reloadSpeakerAnnotation(activeActionSpeaker),
   });
 
+  const orthoJob = useActionJob({
+    start: () => {
+      if (!activeActionSpeaker) return Promise.reject(new Error('No speaker selected'));
+      // Default user-initiated run is "replace" — the Actions menu click
+      // means the user explicitly asked to regenerate ORTHO.
+      return startCompute('ortho', { speaker: activeActionSpeaker, overwrite: true });
+    },
+    poll: (id) => pollCompute('ortho', id),
+    label: 'Generating orthographic transcript…',
+    onComplete: () => reloadSpeakerAnnotation(activeActionSpeaker),
+  });
+
+  // Launched by the pre-flight checklist modal. The actual start payload is
+  // supplied when the user confirms the checklist, so we stash it in a ref.
+  const pipelinePayloadRef = useRef<Record<string, unknown> | null>(null);
   const pipelineJob = useActionJob({
-    start: () => startCompute('full_pipeline'),
+    start: () => {
+      if (!activeActionSpeaker) return Promise.reject(new Error('No speaker selected'));
+      const payload = pipelinePayloadRef.current ?? { speaker: activeActionSpeaker };
+      return startCompute('full_pipeline', payload);
+    },
     poll: (id) => pollCompute('full_pipeline', id),
     label: 'Running full pipeline…',
-    onComplete: loadEnrichments,
+    onComplete: async () => {
+      if (activeActionSpeaker) {
+        void useTranscriptionLanesStore.getState().reloadStt(activeActionSpeaker);
+        await reloadSpeakerAnnotation(activeActionSpeaker);
+      }
+      await loadEnrichments();
+    },
   });
+
+  const [pipelineChecklistOpen, setPipelineChecklistOpen] = useState(false);
+  const openPipelineChecklist = () => {
+    if (!activeActionSpeaker) return;
+    setPipelineChecklistOpen(true);
+  };
+  const handlePipelineConfirm = (result: PipelineChecklistResult) => {
+    setPipelineChecklistOpen(false);
+    if (!activeActionSpeaker || result.steps.length === 0) return;
+    pipelinePayloadRef.current = {
+      speaker: activeActionSpeaker,
+      steps: result.steps,
+      overwrites: result.overwrites,
+      language: sttLanguageRef.current || undefined,
+    };
+    void pipelineJob.run();
+  };
 
   const crossSpeakerJob = useActionJob({
     start: () => startCompute('contact-lexemes'),
@@ -1968,7 +2011,7 @@ export function ParseUI() {
     onComplete: loadEnrichments,
   });
 
-  const allJobs = [normalizeJob, sttJob, ipaJob, pipelineJob, crossSpeakerJob];
+  const allJobs = [normalizeJob, sttJob, ipaJob, orthoJob, pipelineJob, crossSpeakerJob];
   const activeJobs = allJobs.filter(j => j.state.status !== 'idle');
 
   // On mount, adopt any in-flight backend jobs so progress bars survive
@@ -2632,6 +2675,15 @@ export function ParseUI() {
                       </button>
                     </div>
                     <button
+                      onClick={() => { setActionsMenuOpen(false); void orthoJob.run(); }}
+                      disabled={!activeActionSpeaker || orthoJob.state.status === 'running'}
+                      data-testid="actions-generate-ortho"
+                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Type className="h-3.5 w-3.5 text-slate-400"/>
+                      {orthoJob.state.status === 'running' ? 'Generating ORTHO…' : 'Generate ORTHO (razhan)'}
+                    </button>
+                    <button
                       onClick={() => { setActionsMenuOpen(false); void ipaJob.run(); }}
                       disabled={!activeActionSpeaker || ipaJob.state.status === 'running'}
                       className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
@@ -2640,12 +2692,13 @@ export function ParseUI() {
                       {ipaJob.state.status === 'running' ? 'Transcribing…' : 'Run IPA Transcription'}
                     </button>
                     <button
-                      onClick={() => { setActionsMenuOpen(false); void pipelineJob.run(); }}
-                      disabled={pipelineJob.state.status === 'running'}
+                      onClick={() => { setActionsMenuOpen(false); openPipelineChecklist(); }}
+                      disabled={!activeActionSpeaker || pipelineJob.state.status === 'running'}
+                      data-testid="actions-run-full-pipeline"
                       className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Workflow className="h-3.5 w-3.5 text-slate-400"/>
-                      {pipelineJob.state.status === 'running' ? 'Running pipeline…' : 'Run Full Pipeline'}
+                      {pipelineJob.state.status === 'running' ? 'Running pipeline…' : 'Run Full Pipeline…'}
                     </button>
                     <button
                       onClick={() => { setActionsMenuOpen(false); void crossSpeakerJob.run(); }}
@@ -3533,6 +3586,12 @@ export function ParseUI() {
       <Modal open={importModalOpen} onClose={() => setImportModalOpen(false)} title="Import Speaker">
         <SpeakerImport onImportComplete={handleImportComplete} />
       </Modal>
+      <PipelineChecklistModal
+        open={pipelineChecklistOpen}
+        speaker={activeActionSpeaker || ''}
+        onClose={() => setPipelineChecklistOpen(false)}
+        onConfirm={handlePipelineConfirm}
+      />
       <Modal
         open={offsetState.phase !== 'idle'}
         onClose={() => setOffsetState({ phase: 'idle' })}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -593,6 +593,40 @@ export async function pollNormalize(jobId: string): Promise<STTStatus> {
   });
 }
 
+// Pipeline state — powers the pre-flight checklist shown before Run Full
+// Pipeline. Each entry's `done` flag means that tier has at least one
+// non-empty text interval (or, for normalize, the working WAV exists). The
+// modal uses `done` to surface overwrite warnings per step.
+export interface PipelineStepState {
+  done: boolean;
+}
+
+export interface PipelineNormalizeState extends PipelineStepState {
+  path: string | null;
+}
+
+export interface PipelineSttState extends PipelineStepState {
+  segments: number;
+}
+
+export interface PipelineTierState extends PipelineStepState {
+  intervals: number;
+}
+
+export interface PipelineState {
+  speaker: string;
+  normalize: PipelineNormalizeState;
+  stt: PipelineSttState;
+  ortho: PipelineTierState;
+  ipa: PipelineTierState;
+}
+
+export async function getPipelineState(speaker: string): Promise<PipelineState> {
+  return apiFetch<PipelineState>(
+    `/api/pipeline/state/${encodeURIComponent(speaker)}`,
+  );
+}
+
 // Onboard Speaker
 export async function onboardSpeaker(
   speakerId: string,

--- a/src/components/shared/PipelineChecklistModal.tsx
+++ b/src/components/shared/PipelineChecklistModal.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { AlertCircle, AudioLines, Loader2, Mic, Type, Workflow } from "lucide-react";
+import { Modal } from "./Modal";
+import { getPipelineState, type PipelineState } from "../../api/client";
+
+export type PipelineStepId = "normalize" | "stt" | "ortho" | "ipa";
+
+const STEP_ORDER: PipelineStepId[] = ["normalize", "stt", "ortho", "ipa"];
+
+const STEP_LABELS: Record<PipelineStepId, string> = {
+  normalize: "Audio normalization",
+  stt: "Speech-to-text",
+  ortho: "Orthographic transcription (razhan)",
+  ipa: "IPA transcription",
+};
+
+const STEP_ICONS: Record<PipelineStepId, React.ComponentType<{ className?: string }>> = {
+  normalize: AudioLines,
+  stt: Mic,
+  ortho: Type,
+  ipa: Type,
+};
+
+export interface PipelineChecklistResult {
+  steps: PipelineStepId[];
+  overwrites: Partial<Record<PipelineStepId, boolean>>;
+}
+
+interface PipelineChecklistModalProps {
+  open: boolean;
+  speaker: string;
+  onClose: () => void;
+  onConfirm: (result: PipelineChecklistResult) => void;
+}
+
+function describeState(step: PipelineStepId, state: PipelineState | null): string {
+  if (!state) return "Checking…";
+  switch (step) {
+    case "normalize":
+      return state.normalize.done
+        ? "Already done (normalized WAV present)"
+        : "Not yet run";
+    case "stt":
+      return state.stt.done
+        ? `Already done (${state.stt.segments} segments cached)`
+        : "Not yet run";
+    case "ortho":
+      return state.ortho.done
+        ? `Already done (${state.ortho.intervals} intervals)`
+        : "Not yet run";
+    case "ipa":
+      return state.ipa.done
+        ? `Already done (${state.ipa.intervals} intervals)`
+        : "Not yet run";
+  }
+}
+
+function isStepDone(step: PipelineStepId, state: PipelineState | null): boolean {
+  if (!state) return false;
+  return state[step].done;
+}
+
+export function PipelineChecklistModal({
+  open,
+  speaker,
+  onClose,
+  onConfirm,
+}: PipelineChecklistModalProps) {
+  const [state, setState] = useState<PipelineState | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Checked steps start as "everything that hasn't been done yet." The user
+  // can opt IN to re-running completed steps by ticking the checkbox — that
+  // tick implicitly grants the overwrite permission the backend needs.
+  const [selected, setSelected] = useState<Record<PipelineStepId, boolean>>({
+    normalize: false,
+    stt: false,
+    ortho: false,
+    ipa: false,
+  });
+
+  useEffect(() => {
+    if (!open || !speaker) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setState(null);
+    getPipelineState(speaker)
+      .then((result) => {
+        if (cancelled) return;
+        setState(result);
+        // Default selection: run everything not yet done.
+        setSelected({
+          normalize: !result.normalize.done,
+          stt: !result.stt.done,
+          ortho: !result.ortho.done,
+          ipa: !result.ipa.done,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err ?? "Failed to load pipeline state");
+        setError(message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, speaker]);
+
+  const toggle = (step: PipelineStepId) => {
+    setSelected((prev) => ({ ...prev, [step]: !prev[step] }));
+  };
+
+  const willOverwriteAny = useMemo(
+    () =>
+      STEP_ORDER.some(
+        (step) => selected[step] && isStepDone(step, state),
+      ),
+    [selected, state],
+  );
+
+  const hasAnySelected = useMemo(
+    () => STEP_ORDER.some((s) => selected[s]),
+    [selected],
+  );
+
+  const handleConfirm = () => {
+    const steps = STEP_ORDER.filter((s) => selected[s]);
+    const overwrites: Partial<Record<PipelineStepId, boolean>> = {};
+    for (const step of steps) {
+      if (isStepDone(step, state)) overwrites[step] = true;
+    }
+    onConfirm({ steps, overwrites });
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title={`Run Full Pipeline — ${speaker || "no speaker"}`}>
+      <div className="flex flex-col gap-3" data-testid="pipeline-checklist-modal">
+        <p className="text-xs text-slate-600">
+          Choose which steps to run. Steps already done are shown; re-ticking one
+          will overwrite its existing data. Unchecked steps are skipped.
+        </p>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-xs text-slate-500">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading pipeline state…
+          </div>
+        )}
+        {error && (
+          <div className="flex items-start gap-2 rounded border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {!loading && !error && (
+          <ul className="flex flex-col gap-1.5">
+            {STEP_ORDER.map((step) => {
+              const Icon = STEP_ICONS[step];
+              const done = isStepDone(step, state);
+              const willOverwrite = done && selected[step];
+              return (
+                <li
+                  key={step}
+                  className={`flex items-start gap-2 rounded-md border px-2.5 py-2 ${
+                    willOverwrite
+                      ? "border-amber-300 bg-amber-50"
+                      : "border-slate-200 bg-white"
+                  }`}
+                >
+                  <input
+                    id={`pipeline-step-${step}`}
+                    data-testid={`pipeline-step-${step}`}
+                    type="checkbox"
+                    className="mt-0.5 h-3.5 w-3.5 shrink-0 rounded border-slate-300"
+                    checked={selected[step]}
+                    onChange={() => toggle(step)}
+                  />
+                  <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-400" />
+                  <label
+                    htmlFor={`pipeline-step-${step}`}
+                    className="flex min-w-0 flex-1 flex-col cursor-pointer"
+                  >
+                    <span className="text-xs font-medium text-slate-700">
+                      {STEP_LABELS[step]}
+                    </span>
+                    <span className="text-[11px] text-slate-500">
+                      {describeState(step, state)}
+                    </span>
+                    {willOverwrite && (
+                      <span className="mt-0.5 text-[11px] font-medium text-amber-700">
+                        Will overwrite existing {step === "normalize" ? "WAV" : "data"}.
+                      </span>
+                    )}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <div className="mt-1 flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded px-3 py-1 text-xs text-slate-600 hover:bg-slate-100"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            data-testid="pipeline-checklist-run"
+            disabled={loading || Boolean(error) || !hasAnySelected}
+            className={`inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50 ${
+              willOverwriteAny ? "bg-amber-600 hover:bg-amber-700" : "bg-indigo-600 hover:bg-indigo-700"
+            }`}
+          >
+            <Workflow className="h-3.5 w-3.5" />
+            {willOverwriteAny ? "Run (with overwrites)" : "Run selected steps"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/shared/__tests__/PipelineChecklistModal.test.tsx
+++ b/src/components/shared/__tests__/PipelineChecklistModal.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { PipelineChecklistModal, type PipelineChecklistResult } from "../PipelineChecklistModal";
+
+vi.mock("../../../api/client", () => ({
+  getPipelineState: vi.fn(),
+}));
+
+import { getPipelineState } from "../../../api/client";
+
+const FAKE_STATE = {
+  speaker: "Fail02",
+  normalize: { done: true, path: "audio/working/Fail02/Fail02.wav" },
+  stt: { done: false, segments: 0 },
+  ortho: { done: true, intervals: 42 },
+  ipa: { done: false, intervals: 0 },
+};
+
+describe("PipelineChecklistModal", () => {
+  beforeEach(() => {
+    vi.mocked(getPipelineState).mockReset();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders one row per pipeline step with current state", async () => {
+    vi.mocked(getPipelineState).mockResolvedValueOnce(FAKE_STATE);
+
+    render(
+      <PipelineChecklistModal
+        open={true}
+        speaker="Fail02"
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("pipeline-step-normalize")).toBeTruthy(),
+    );
+
+    expect(screen.getByTestId("pipeline-step-stt")).toBeTruthy();
+    expect(screen.getByTestId("pipeline-step-ortho")).toBeTruthy();
+    expect(screen.getByTestId("pipeline-step-ipa")).toBeTruthy();
+    expect(screen.getByText(/42 intervals/)).toBeTruthy();
+  });
+
+  it("defaults selected steps to those not yet done", async () => {
+    vi.mocked(getPipelineState).mockResolvedValueOnce(FAKE_STATE);
+
+    render(
+      <PipelineChecklistModal
+        open={true}
+        speaker="Fail02"
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+
+    const normalizeCheckbox = await screen.findByTestId("pipeline-step-normalize") as HTMLInputElement;
+    const sttCheckbox = screen.getByTestId("pipeline-step-stt") as HTMLInputElement;
+    const orthoCheckbox = screen.getByTestId("pipeline-step-ortho") as HTMLInputElement;
+    const ipaCheckbox = screen.getByTestId("pipeline-step-ipa") as HTMLInputElement;
+
+    // Already done → off; not done → on.
+    expect(normalizeCheckbox.checked).toBe(false);
+    expect(sttCheckbox.checked).toBe(true);
+    expect(orthoCheckbox.checked).toBe(false);
+    expect(ipaCheckbox.checked).toBe(true);
+  });
+
+  it("passes ticked steps and implicit overwrite flags to onConfirm", async () => {
+    vi.mocked(getPipelineState).mockResolvedValueOnce(FAKE_STATE);
+
+    const onConfirm = vi.fn<[PipelineChecklistResult], void>();
+    render(
+      <PipelineChecklistModal
+        open={true}
+        speaker="Fail02"
+        onClose={() => {}}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    // Wait for state to load, then tick ortho (which is already done) so the
+    // confirm should carry `overwrites.ortho = true`.
+    const orthoCheckbox = await screen.findByTestId("pipeline-step-ortho") as HTMLInputElement;
+    act(() => { fireEvent.click(orthoCheckbox); });
+
+    const runButton = screen.getByTestId("pipeline-checklist-run");
+    act(() => { fireEvent.click(runButton); });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const result = onConfirm.mock.calls[0][0];
+    // stt (default-on) + ipa (default-on) + ortho (user-ticked) — but
+    // normalize was default-off, so excluded.
+    expect(result.steps).toEqual(["stt", "ortho", "ipa"]);
+    expect(result.overwrites.ortho).toBe(true);
+    expect(result.overwrites.stt).toBeUndefined();
+    expect(result.overwrites.ipa).toBeUndefined();
+  });
+
+  it("disables Run when nothing is selected", async () => {
+    vi.mocked(getPipelineState).mockResolvedValueOnce({
+      ...FAKE_STATE,
+      normalize: { done: true, path: "x" },
+      stt: { done: true, segments: 1 },
+      ortho: { done: true, intervals: 1 },
+      ipa: { done: true, intervals: 1 },
+    });
+
+    render(
+      <PipelineChecklistModal
+        open={true}
+        speaker="Fail02"
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+
+    // Everything is done → default selection is empty → Run is disabled.
+    const runButton = await screen.findByTestId("pipeline-checklist-run") as HTMLButtonElement;
+    expect(runButton.disabled).toBe(true);
+  });
+
+  it("surfaces a fetch error", async () => {
+    vi.mocked(getPipelineState).mockRejectedValueOnce(new Error("boom"));
+
+    render(
+      <PipelineChecklistModal
+        open={true}
+        speaker="Fail02"
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText(/boom/)).toBeTruthy());
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes **\"Unsupported compute type: full_pipeline\"** — the button in the Actions menu was wired but the backend handler didn't exist. Now it does, and it's fronted by a pre-flight checklist modal so each step runs only when the user asks for it.
- Adds a dedicated **ORTHO** step: \`razhan/whisper-base-sdh\` run full-file on the working WAV, writing razhan's own segmentation to the ortho tier. Razhan runs independently of STT (design C — boundary errors from the language-agnostic STT model can't propagate into the Kurdish-aware transcript).
- Pipeline sequencer runs \`normalize → stt → ortho → ipa\` in canonical order, skipping unselected steps and enforcing per-step overwrite consent. Inline failure of any step aborts the pipeline.

## What's new

### Backend
- \`python/server.py\`
  - \`_compute_speaker_ortho\` — razhan full-file, writes \`ortho\` tier. Overwrite semantics: any existing non-empty ortho text blocks the run unless \`overwrite=True\` (razhan's segmentation isn't stable across runs so fill-empty doesn't map cleanly).
  - \`_compute_full_pipeline\` — sequencer over \`{normalize, stt, ortho, ipa}\`. Calls \`_run_normalize_job\` / \`_run_stt_job\` inline, re-raising on error so the outer job fails loud instead of silently swallowing step errors.
  - \`_pipeline_state_for_speaker\` + \`GET /api/pipeline/state/<speaker>\` — powers the checklist modal; returns \`{normalize, stt, ortho, ipa}\` with \`done\` flags and counts.
  - \`_run_compute_job\` dispatch extended with \`ortho\` / \`full_pipeline\` routes.
- \`python/ai/provider.py\`
  - \`LocalWhisperProvider\` takes a \`config_section\` (\"stt\" or \"ortho\") so the ORTHO provider can read from its own config block — different model / language / device than STT.
  - \`get_ortho_provider()\` factory returns a \`LocalWhisperProvider\` pinned to \`config_section=\"ortho\"\`.
- \`config/ai_config.example.json\` + \`_DEFAULT_AI_CONFIG\`: razhan/whisper-base-sdh installed as the default ORTHO model.

### Frontend
- \`src/components/shared/PipelineChecklistModal.tsx\` — new. Probes \`getPipelineState(speaker)\`, shows one row per step with current state, warns in amber when re-ticking a done step (\"Will overwrite existing data.\"). Default selection is \"everything not yet done.\"
- \`src/ParseUI.tsx\` — adds \`orthoJob\` + \"Generate ORTHO (razhan)\" menu entry, and rewires \"Run Full Pipeline\" to open the checklist instead of firing blind.
- \`src/api/client.ts\` — \`getPipelineState\` + typed \`PipelineState\`.

### Tests
- \`python/test_compute_speaker_ortho.py\` — 11 tests covering: empty-tier populate, populated-tier skip-without-overwrite, overwrite=True replaces, normalized-WAV preferred over raw source, missing-annotation raises, dispatch via \`_run_compute_job\`, pipeline-state probe for fresh and populated speakers, sequencer runs only selected steps, canonical ordering enforced, step failure aborts pipeline.
- \`src/components/shared/__tests__/PipelineChecklistModal.test.tsx\` — 5 tests: renders all step rows, default selection reflects done-state, confirm passes steps + implicit overwrite flags, Run disabled when nothing selected, fetch error surfaced.

## Test plan

- [x] \`npx vitest run\` — 33 files, 194 tests pass (includes the 5 new modal tests).
- [x] \`npx tsc --noEmit\` — clean.
- [x] \`python3 -m pytest python/test_compute_speaker_ortho.py\` — 11/11 pass.
- [x] Full-suite python: 157 pass. 6 pre-existing failures unrelated to this change (chat/audio-info/text-preview fixtures — same failures on \`main\`).
- [ ] Needs verification on the PC (razhan is GPU-bound; local Mac can't run the real model): open Actions → Run Full Pipeline… with a speaker selected, confirm the checklist shows current state, confirm ORTHO step runs razhan and populates the ortho lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)