### PR TITLE
Fix pipeline STT audio path + rebase conflict from PR #135

### DIFF
--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -1012,13 +1012,13 @@ class LocalWhisperProvider(AIProvider):
         )
 
         try:
-            self.beam_size = max(1, int(stt_config.get("beam_size", 5) or 5))
+            self.beam_size = max(1, int(section_config.get("beam_size", 5) or 5))
         except (TypeError, ValueError):
             self.beam_size = 5
-        task_raw = str(stt_config.get("task", "transcribe") or "transcribe").strip().lower()
+        task_raw = str(section_config.get("task", "transcribe") or "transcribe").strip().lower()
         self.task = task_raw if task_raw in {"transcribe", "translate"} else "transcribe"
-        self.vad_filter = bool(stt_config.get("vad_filter", True))
-        vad_params_raw = stt_config.get("vad_parameters")
+        self.vad_filter = bool(section_config.get("vad_filter", True))
+        vad_params_raw = section_config.get("vad_parameters")
         # Only forward a dict when the user has set explicit parameters;
         # an empty {} falls through to faster-whisper's Silero defaults.
         self.vad_parameters: Optional[Dict[str, Any]] = (

--- a/python/server.py
+++ b/python/server.py
@@ -3120,11 +3120,12 @@ def _compute_full_pipeline(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
             steps_run.append(step)
 
         elif step == "stt":
-            source_rel = _annotation_primary_source_wav(speaker)
-            if not source_rel:
-                raise RuntimeError(
-                    "Cannot run STT for {0!r}: no source_audio on annotation".format(speaker)
-                )
+            # Resolve the audio the same way the ORTHO step does — prefer the
+            # normalized working WAV if it exists, fall back to the raw source.
+            # Using ``_annotation_primary_source_wav`` directly would pass a
+            # bare filename (e.g. ``SK_Faili_F_1968.wav``) which fails to
+            # resolve when the raw file lives under ``audio/working/<speaker>/``
+            # and the bare-root copy has been cleaned up.
             cached = _latest_stt_segments_for_speaker(speaker)
             if cached and not overwrites.get("stt", False):
                 results["stt"] = {
@@ -3134,7 +3135,11 @@ def _compute_full_pipeline(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
                 }
                 steps_run.append(step)
                 continue
-            _run_stt_job(job_id, speaker, source_rel, language_str)
+            try:
+                audio_path = _pipeline_audio_path_for_speaker(speaker)
+            except (RuntimeError, FileNotFoundError) as exc:
+                raise RuntimeError("Cannot run STT for {0!r}: {1}".format(speaker, exc))
+            _run_stt_job(job_id, speaker, str(audio_path), language_str)
             snapshot = _get_job_snapshot(job_id) or {}
             if str(snapshot.get("status") or "") == "error":
                 raise RuntimeError(

--- a/python/test_compute_speaker_ortho.py
+++ b/python/test_compute_speaker_ortho.py
@@ -285,6 +285,64 @@ def test_full_pipeline_enforces_canonical_order(tmp_path, monkeypatch):
     assert called == ["ortho", "ipa"]
 
 
+def test_full_pipeline_stt_step_uses_normalized_working_wav(tmp_path, monkeypatch):
+    """The STT branch must resolve audio via _pipeline_audio_path_for_speaker —
+    i.e. prefer ``audio/working/<speaker>/<name>.wav`` over the bare source
+    filename, which fails to resolve when the raw file has been cleaned up
+    post-normalization. Regression guard for an error surfaced in prod where
+    the pipeline looked for ``SK_Faili_F_1968.wav`` at the project root even
+    though the normalized copy sat under ``audio/working/Fail02/``.
+    """
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _seed_annotation(tmp_path, "Fail02", source_audio="SK_Faili_F_1968.wav")
+    # Deliberately NOT writing the raw source at project root — only the
+    # normalized working copy exists, mirroring the failure mode.
+    normalized = _write_fake_source_wav(
+        tmp_path, "audio/working/Fail02/SK_Faili_F_1968.wav",
+    )
+
+    observed: dict = {}
+
+    def fake_stt(job_id, speaker, source_wav, language):
+        observed["source_wav"] = source_wav
+        observed["speaker"] = speaker
+
+    monkeypatch.setattr(server, "_run_stt_job", fake_stt)
+    monkeypatch.setattr(server, "_latest_stt_segments_for_speaker", lambda s: None)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+    # After _run_stt_job returns (no-op in this stub), the sequencer checks
+    # the job snapshot for errors and resets it to running. Return a running
+    # snapshot so the sequencer doesn't treat the no-op as a failure.
+    monkeypatch.setattr(server, "_get_job_snapshot", lambda jid: {"status": "running"})
+    monkeypatch.setattr(server, "_reset_job_to_running", lambda jid: None)
+
+    server._compute_full_pipeline(
+        "j1",
+        {"speaker": "Fail02", "steps": ["stt"], "overwrites": {"stt": True}},
+    )
+
+    # The audio path handed to _run_stt_job must resolve — it's the
+    # normalized working copy, not the bare filename.
+    assert observed["source_wav"] == str(normalized)
+
+
+def test_full_pipeline_stt_raises_when_no_audio_reachable(tmp_path, monkeypatch):
+    """If neither normalized nor raw source exists, STT must abort cleanly."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    _seed_annotation(tmp_path, "Fail02", source_audio="SK_Faili_F_1968.wav")
+    # No audio file written anywhere — simulate the prod-error condition.
+
+    monkeypatch.setattr(server, "_run_stt_job", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_latest_stt_segments_for_speaker", lambda s: None)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+
+    with pytest.raises(RuntimeError, match="Cannot run STT"):
+        server._compute_full_pipeline(
+            "j1",
+            {"speaker": "Fail02", "steps": ["stt"], "overwrites": {"stt": True}},
+        )
+
+
 def test_full_pipeline_propagates_step_failure(tmp_path, monkeypatch):
     """A step raising should abort the pipeline and propagate the error."""
     monkeypatch.setattr(server, "_project_root", lambda: tmp_path)


### PR DESCRIPTION
## Summary

Follow-up to PR #137. Two bugs that surfaced when actually exercising the sequencer end-to-end:

1. **STT step in the full pipeline was passing a bare filename** (e.g. \`SK_Faili_F_1968.wav\`) to \`_run_stt_job\`, which resolved it against project root and failed with \`Audio file not found: parse-workspace/SK_Faili_F_1968.wav\` — because the raw copy had been cleaned up post-normalize and the actual file lived under \`audio/working/Fail02/\`. The ORTHO branch already used \`_pipeline_audio_path_for_speaker\` (which prefers normalized) and didn't have this bug; STT now matches.
2. **\`LocalWhisperProvider\` NameError** at runtime after PR #135 + PR #137 both merged. PR #135 added lines reading \`stt_config.get(\"beam_size\", ...)\`, PR #137 renamed that variable to \`section_config\` (to make the provider config-section-aware). Git merged both mechanically, no conflict flagged, but the result crashed as \`name 'stt_config' is not defined\` whenever any STT/ORTHO provider was instantiated. Fixed by pointing those reads at \`section_config\` so each provider reads \`beam_size\`/\`task\`/\`vad_filter\`/\`vad_parameters\` from its own section of the config.

## Root cause of (1)

I verified PR #137 on the PC with \`overwrite=false\` — every step correctly skipped, so the bug hid. What I missed: the **execute** path for STT was only covered by the unit tests, and those didn't exercise the audio-resolution logic (they mocked \`_run_stt_job\` directly). Added two regression tests that do.

## Changes

- \`python/server.py\` — \`_compute_full_pipeline\` STT branch now uses \`_pipeline_audio_path_for_speaker\` (same resolver ORTHO uses), passing an absolute path to \`_run_stt_job\`. Clean failure if neither normalized nor raw source is reachable.
- \`python/ai/provider.py\` — four references from \`stt_config\` → \`section_config\` in \`LocalWhisperProvider.__init__\`. This also makes the \`ortho\` block's \`beam_size\`/\`task\`/\`vad_filter\`/\`vad_parameters\` actually take effect (they were being silently ignored).
- \`python/test_compute_speaker_ortho.py\` — two new regression tests.

## Verified

- [x] \`pytest python/test_compute_speaker_ortho.py\` — 13/13 pass (was 11, plus the 2 new ones).
- [x] **Actual end-to-end on the PC**: ran \`POST /api/compute/full_pipeline {speaker: Fail02, steps: [stt], overwrites: {stt: true}}\`. Before this fix: immediate \`Audio file not found\` error. After this fix: model loaded, transcribing past audio resolution (81 segments at 56s mark, \`running\` state).
- [x] \`LocalWhisperProvider\` smoke test confirms \`stt\` and \`ortho\` sections each read their own \`beam_size\`/VAD knobs.

## Why this wasn't caught in PR #137

I tested the skip-because-populated path against the live \`parse-workspace\` on the PC, where every tier had data. I should have forced a real execution by passing \`overwrites.stt = true\` — which is the path the user actually took when they clicked through the checklist. Noted for future verification runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)