### PR TITLE
Fix pipeline silent no-op: cwd-aware ai_config + pollCompute result passthrough

### DIFF
--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -268,9 +268,41 @@ def _coerce_float(
 
 
 def resolve_ai_config_path(config_path: Optional[Path] = None) -> Path:
-    """Resolve ai_config.json path, defaulting to parse/config/ai_config.json."""
+    """Resolve ai_config.json path.
+
+    Search order (first match wins):
+      1. ``config_path`` arg, if provided.
+      2. ``PARSE_AI_CONFIG`` env var (escape hatch for operators).
+      3. ``<cwd>/config/ai_config.json`` — matches server.py's ``_config_path()``
+         which reads from cwd. The server runs with cwd set to the
+         project workspace (e.g. ``/home/lucas/parse-workspace``), so
+         this is where the user's real config lives.
+      4. ``<repo>/config/ai_config.json`` — the historical location,
+         relative to this module's path. Kept as a fallback for
+         scripts/tests that import ``load_ai_config`` without a
+         meaningful cwd.
+
+    Returns the *first existing* path, else the repo path (so the
+    "missing" WARN in ``load_ai_config`` surfaces a coherent message).
+
+    Fixes a silent bug where the server reported
+    ``stt.model_path: C:\\...razhan-whisper-ct2`` via ``/api/config``
+    (which reads from cwd) while ``get_stt_provider()`` fell back to
+    defaults — because this function was only checking the repo path,
+    which is empty on a fresh deploy. ORTHO in particular needs razhan
+    configured; defaults hand it the HF repo id which faster-whisper
+    can't load, and every ORTH run silently errored.
+    """
     if config_path is not None:
         return Path(config_path).expanduser().resolve()
+
+    env_override = os.environ.get("PARSE_AI_CONFIG", "").strip()
+    if env_override:
+        return Path(env_override).expanduser().resolve()
+
+    cwd_candidate = Path.cwd() / "config" / "ai_config.json"
+    if cwd_candidate.exists():
+        return cwd_candidate.resolve()
 
     return Path(__file__).resolve().parents[2] / "config" / "ai_config.json"
 

--- a/python/ai/test_ortho_provider_fallback.py
+++ b/python/ai/test_ortho_provider_fallback.py
@@ -173,6 +173,53 @@ def test_ortho_vad_filter_explicit_override_wins(tmp_path):
     assert provider.vad_filter is True
 
 
+def test_resolve_ai_config_explicit_arg_wins(tmp_path):
+    from ai.provider import resolve_ai_config_path
+    explicit = tmp_path / "my-config.json"
+    explicit.write_text("{}")
+    assert resolve_ai_config_path(explicit) == explicit.resolve()
+
+
+def test_resolve_ai_config_env_var(tmp_path, monkeypatch):
+    """``PARSE_AI_CONFIG`` env var is the operator escape hatch — takes
+    precedence over every path-based lookup but the explicit arg."""
+    from ai.provider import resolve_ai_config_path
+    special = tmp_path / "special.json"
+    special.write_text("{}")
+    monkeypatch.setenv("PARSE_AI_CONFIG", str(special))
+    assert resolve_ai_config_path() == special.resolve()
+
+
+def test_resolve_ai_config_prefers_cwd_over_repo_path(tmp_path, monkeypatch):
+    """The server runs with ``cwd = <project-workspace>`` — that's where
+    the real ai_config.json lives. A prior revision only checked the
+    repo path, which was empty on a fresh deploy, so providers silently
+    fell back to defaults and every razhan/ortho run errored out with
+    the HF-id model_path crash. Regression guard.
+    """
+    from ai.provider import resolve_ai_config_path
+    monkeypatch.delenv("PARSE_AI_CONFIG", raising=False)
+    cwd_cfg_dir = tmp_path / "config"
+    cwd_cfg_dir.mkdir()
+    cwd_cfg = cwd_cfg_dir / "ai_config.json"
+    cwd_cfg.write_text("{}")
+    monkeypatch.chdir(tmp_path)
+    resolved = resolve_ai_config_path()
+    assert resolved == cwd_cfg.resolve()
+
+
+def test_resolve_ai_config_falls_back_to_repo_when_nothing_found(tmp_path, monkeypatch):
+    from ai.provider import resolve_ai_config_path
+    monkeypatch.delenv("PARSE_AI_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    resolved = resolve_ai_config_path()
+    # Lands on repo-relative ai_config.json path (which may or may not
+    # exist) — this lets the caller emit a clean "AI config not found"
+    # warning with a stable path instead of a cwd-dependent one.
+    assert resolved.name == "ai_config.json"
+    assert resolved.parent.name == "config"
+
+
 def test_collect_nvidia_wheel_bin_dirs_returns_empty_when_nvidia_absent(monkeypatch):
     """No nvidia wheels installed → empty list, no exception."""
     import sys as _sys

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -547,6 +547,14 @@ export async function pollCompute(computeType: string, jobId: string): Promise<C
           ? payload.error
           : undefined,
     error: typeof payload.error === "string" ? payload.error : undefined,
+    // Forward the backend's opaque ``result`` field. ``full_pipeline``
+    // returns its per-step results here; ``useBatchPipelineJob`` reads
+    // this to populate the BatchReportModal. Previously this field was
+    // silently dropped, causing every batch report to show 0/0/0 with
+    // em-dashes even when the server completed the work. Callers that
+    // don't care about the payload ignore it; typed callers cast to
+    // their expected compute-specific shape.
+    result: payload.result,
   };
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -130,6 +130,12 @@ export interface ComputeStatus {
   progress: number;
   message?: string;
   error?: string;
+  /** Opaque result payload the backend attaches when a compute job
+   *  completes (e.g. full_pipeline returns its per-step results here).
+   *  Callers cast this to the specific type they expect for their
+   *  compute_type — ``PipelineRunResult`` for ``full_pipeline``,
+   *  raw objects for the legacy per-step computes. */
+  result?: unknown;
 }
 
 export interface ContactLexemeCoverage {


### PR DESCRIPTION
## Problem

User ran the batch pipeline on Fail02 with ORTH + IPA ticked and overwrite=true. Report said "All 1 speaker processed cleanly" with **0 ok · 0 skipped · 0 errored**. Downloaded JSON confirmed \`outcomes[0].result: null\`. Waveform tiers untouched.

The server's access log showed the pipeline POST completed in ~6 seconds — far too fast for a real razhan run (which needs ~60s just to load the model). So the server didn't do any actual work, but reported complete.

## Root cause (two independent bugs)

### 1. \`resolve_ai_config_path\` didn't check the server's cwd

The live PARSE server runs with \`cwd = /home/lucas/parse-workspace\` — that's where the user's real \`ai_config.json\` lives. \`server.py\`'s \`/api/config\` endpoint reads from cwd via \`_config_path()\` and returns the right config (which is why my earlier PC verification saw the razhan path and thought everything was fine).

But \`resolve_ai_config_path\` in \`python/ai/provider.py\` resolved to \`<repo>/config/ai_config.json\` — relative to the module \`__file__\`, not cwd. That path was empty on the user's deploy. Every provider instantiation logged \`[WARN] AI config not found at …\\ardeleanlucas\\parse\\config\\ai_config.json; using defaults\` and fell back to \`_DEFAULT_AI_CONFIG\`.

For ORTH, defaults hand it \`model_path: "razhan/whisper-base-sdh"\` (an HF repo id, not a CT2 path). faster-whisper can't load HF Transformers checkpoints → crashes with \`Unable to open file 'model.bin'\`. PR #139's HF-id → \`stt.model_path\` fallback was meant to catch this, but it didn't fire either because \`stt.model_path\` in the defaults is also empty (the fallback only activates when it has something to fall back TO).

### 2. \`pollCompute\` silently dropped the \`result\` field

The backend's \`full_pipeline\` job completes with:

\`\`\`json
{ "status": "complete", "progress": 100, "result": { "steps_run": [...], "results": {...}, "summary": {...} } }
\`\`\`

\`pollCompute\` in \`src/api/client.ts\` only forwarded \`{status, progress, message, error}\` — it never passed \`result\` through. \`useBatchPipelineJob\` read \`poll.result\` expecting the pipeline payload and always got \`undefined\`, so every \`outcomes[i].result\` was \`null\`. \`BatchReportModal\` then classified every cell as em-dash and chipped 0/0/0, silently hiding whatever the server had actually reported (which, thanks to bug #1, was an error for ORTH).

So: bug #1 broke ORTH, bug #2 hid the error from the UI. Together they produced a batch that reported "processed cleanly" while doing nothing.

## Fix

### Resolver (python/ai/provider.py)

New resolution order in \`resolve_ai_config_path\`:

1. Explicit \`config_path\` argument (for tests + scripts)
2. \`PARSE_AI_CONFIG\` env var (operator escape hatch)
3. **\`<cwd>/config/ai_config.json\`** — matches what server.py already does
4. \`<repo>/config/ai_config.json\` (historical fallback)

This makes the provider-side loader agree with the server endpoint.

### Client (src/api/client.ts + src/api/types.ts)

\`pollCompute\` now forwards \`payload.result\` as \`unknown\` on \`ComputeStatus\`. Callers cast to the compute-specific shape they expect (\`PipelineRunResult\` for full_pipeline).

## Tests

Four new resolver tests: explicit-arg, env-var, cwd-preference, repo-fallback. Existing hook tests already mocked \`pollCompute\` to return \`result\` (the bug was in the real implementation, not the mock) — they continue to pass.

- \`npx tsc --noEmit\` clean
- \`npx vitest run\` — 213/213
- \`pytest python/ai/test_ortho_provider_fallback.py\` — 14/14

## Deployment note for the user

After this lands, your \`/home/lucas/parse-workspace/config/ai_config.json\` will finally be picked up by the provider. The file already has the razhan \`stt.model_path\` configured — that alone unblocks ORTH via the HF-id fallback from PR #139. Add an explicit \`ortho\` block if you want to tune it further; defaults (including PR #141's \`vad_filter: false\`) otherwise apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)