### PR TITLE
fix: two pre-existing test failures (missing os import + stale chat fakes)

### DIFF
--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/python/test_chat_job_result_shape.py
+++ b/python/test_chat_job_result_shape.py
@@ -22,7 +22,7 @@ def test_run_chat_job_stores_assistant_string_as_result(monkeypatch) -> None:
     )
 
     class _FakeOrchestrator:
-        def run(self, session_id, session_messages):
+        def run(self, session_id, session_messages, on_tool_call=None):
             return {
                 "assistant": {"content": "hello from grok"},
                 "model": "grok-4.20-0309-reasoning",
@@ -57,7 +57,7 @@ def test_run_chat_job_result_falls_back_to_default_when_content_missing(monkeypa
     )
 
     class _EmptyOrchestrator:
-        def run(self, session_id, session_messages):
+        def run(self, session_id, session_messages, on_tool_call=None):
             return {}
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Fixes the 6 pre-existing test failures that turned up while running the suite during the acoustic-alignment work. Two independent regressions, one-line fix each.

## The bugs

**Bug A — `python/ai/chat_tools.py:258` uses `os.name` but `os` isn't imported** (4 tests)
- `_wsl_to_windows_path` was added in `ef66e0f fix(chat-tools): translate WSL /mnt/X/ paths on Windows Python` without the matching `import os`.
- Every tool handler routed through `_resolve_readable_path` crashes with `NameError: name 'os' is not defined` at the first character of the input path.
- Failing tests: `test_read_csv_preview_rejects_traversal`, `test_read_csv_preview_still_works_for_valid_path`, `test_read_text_preview_reads_markdown_in_project_root`, `test_read_text_preview_rejects_non_text_extension`.

**Bug B — `on_tool_call` kwarg passed to stale chat-job test fakes** (2 tests)
- `_run_chat_job` in [python/server.py:1898-1902](python/server.py:1898) calls `orchestrator.run(session_id=..., session_messages=..., on_tool_call=_tool_progress)`. The real `ChatOrchestrator.run` accepts it; the test fakes in `test_chat_job_result_shape.py` don't.
- Regression from `cff7a4a feat(chat): show live tool-call status and fix activity-based timeout` — production + real orchestrator updated, fakes missed.
- Failing tests: `test_run_chat_job_stores_assistant_string_as_result`, `test_run_chat_job_result_falls_back_to_default_when_content_missing`.

## Fix

- [commit 1d38701](https://github.com/ArdeleanLucas/PARSE/commit/1d38701): `import os` in `python/ai/chat_tools.py` (+1 line)
- [commit 99c9201](https://github.com/ArdeleanLucas/PARSE/commit/99c9201): add `on_tool_call=None` to both fake orchestrators in `python/test_chat_job_result_shape.py` (+2/-2 lines)

No production behaviour change: Bug A is a missing-import that was always reachable on every platform (the `os.name != 'nt'` early-return still requires `os` to be resolved). Bug B is a test-only update bringing fakes in line with the real `ChatOrchestrator.run` signature.

## Test plan

Before: 6 failed, 7 passed.

After:
- [x] `pytest python/ai/test_read_audio_info_tool.py python/ai/test_read_text_preview_tool.py python/test_chat_job_result_shape.py` → **13 passed**
- [ ] Full backend suite stays green on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)