### PR TITLE
fix(tier3): load audio via soundfile instead of torchaudio+torchcodec

### DIFF
--- a/python/ai/forced_align.py
+++ b/python/ai/forced_align.py
@@ -101,10 +101,28 @@ class Aligner:
         device: Optional[str] = None,
     ) -> "Aligner":
         """Lazy import of torch/transformers so the module is importable
-        even in environments that lack them (tests stub ``Aligner.load``)."""
+        even in environments that lack them (tests stub ``Aligner.load``).
+
+        Processor construction goes through ``Wav2Vec2CTCTokenizer`` +
+        ``Wav2Vec2FeatureExtractor`` explicitly rather than
+        ``Wav2Vec2Processor.from_pretrained`` because the latter's
+        auto-dispatch breaks on recent transformers versions with:
+
+            TypeError: Received a bool for argument tokenizer, but a
+            PreTrainedTokenizerBase was expected.
+
+        (seen on transformers 4.40+ with the PC's kurdish_asr env on
+        2026-04-23). The explicit construction is also faster — no
+        extra auto-tokenizer discovery round-trip.
+        """
         try:
             import torch  # type: ignore
-            from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor  # type: ignore
+            from transformers import (  # type: ignore
+                Wav2Vec2CTCTokenizer,
+                Wav2Vec2FeatureExtractor,
+                Wav2Vec2ForCTC,
+                Wav2Vec2Processor,
+            )
         except ImportError as exc:
             raise RuntimeError(
                 "Tier 2 forced alignment requires torch + transformers. "
@@ -112,7 +130,21 @@ class Aligner:
             ) from exc
 
         resolved_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
-        processor = Wav2Vec2Processor.from_pretrained(model_name)
+
+        # Explicit tokenizer + feature_extractor load. If this path
+        # raises, fall back to the legacy auto-dispatch as a last resort
+        # so older environments that DO work with from_pretrained still
+        # succeed.
+        try:
+            tokenizer = Wav2Vec2CTCTokenizer.from_pretrained(model_name)
+            feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained(model_name)
+            processor = Wav2Vec2Processor(
+                feature_extractor=feature_extractor,
+                tokenizer=tokenizer,
+            )
+        except Exception:
+            processor = Wav2Vec2Processor.from_pretrained(model_name)
+
         model = Wav2Vec2ForCTC.from_pretrained(model_name).to(resolved_device).eval()
 
         tokenizer = processor.tokenizer
@@ -319,15 +351,60 @@ def _g2p_word(word: str, language: str = DEFAULT_G2P_LANGUAGE) -> List[str]:
 
 
 def _load_audio_mono_16k(audio_path: Path) -> Any:
-    """Load an audio file as a mono 16 kHz torch.Tensor (float32)."""
-    import torch  # type: ignore
-    import torchaudio  # type: ignore
+    """Load an audio file as a mono 16 kHz torch.Tensor (float32).
 
-    waveform, sr = torchaudio.load(str(audio_path))
+    Uses ``soundfile`` as the primary decoder (already a PARSE dependency
+    via ``stt_pipeline``) rather than ``torchaudio.load``. torchaudio 2.5+
+    dispatches through ``load_with_torchcodec`` by default and raises
+    ``TorchCodec is required for load_with_torchcodec`` in environments
+    that haven't installed the separate ``torchcodec`` package — which
+    was exactly what silently killed the Tier 3 Fail02 run. soundfile
+    is libsndfile-backed, works on every platform PARSE supports, and
+    doesn't touch torch/CUDA.
+
+    Returned tensor shape is ``(num_samples,)``, dtype float32, at
+    exactly :data:`DEFAULT_SAMPLE_RATE`. Multichannel inputs are
+    downmixed to mono before resample. Resampling uses
+    ``torchaudio.functional.resample`` when available (polyphase,
+    reproduces the prior behaviour); if torchaudio is missing or
+    broken, falls back to a linear interpolation via ``torch.nn.functional.interpolate``.
+    """
+    import torch  # type: ignore
+
+    try:
+        import soundfile as sf  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "Tier 3 audio loading requires the 'soundfile' package. "
+            "Install with: pip install soundfile"
+        ) from exc
+
+    # Read as float32. ``always_2d=True`` gives a (num_samples, num_channels)
+    # ndarray regardless of source shape, which makes the mean-down-to-mono
+    # step uniform.
+    data, sr = sf.read(str(audio_path), dtype="float32", always_2d=True)
+    # numpy (num_samples, num_channels) → torch (num_channels, num_samples)
+    waveform = torch.from_numpy(data.T).contiguous()
+
     if waveform.ndim == 2 and waveform.shape[0] > 1:
         waveform = waveform.mean(dim=0, keepdim=True)
+
     if sr != DEFAULT_SAMPLE_RATE:
-        waveform = torchaudio.functional.resample(waveform, sr, DEFAULT_SAMPLE_RATE)
+        try:
+            import torchaudio.functional as _taf  # type: ignore
+            waveform = _taf.resample(waveform, sr, DEFAULT_SAMPLE_RATE)
+        except Exception:
+            # Last-resort resampler — torch-only, no torchaudio. Works for
+            # both up- and down-sampling by reshaping to (N, C, L) so we
+            # can use ``interpolate`` with mode="linear".
+            orig_len = int(waveform.shape[-1])
+            new_len = max(1, int(round(orig_len * DEFAULT_SAMPLE_RATE / float(sr))))
+            if waveform.ndim == 1:
+                waveform = waveform.unsqueeze(0)
+            waveform = torch.nn.functional.interpolate(
+                waveform.unsqueeze(0), size=new_len, mode="linear", align_corners=False,
+            ).squeeze(0)
+
     return waveform.squeeze(0).to(torch.float32)
 
 

--- a/python/ai/test_audio_loader.py
+++ b/python/ai/test_audio_loader.py
@@ -1,0 +1,239 @@
+"""Regression guard for Tier 3's soundfile-based audio loader.
+
+PARSE used to call ``torchaudio.load`` inside ``_load_audio_mono_16k``.
+torchaudio 2.5+ defaults to ``load_with_torchcodec`` which raises
+``"TorchCodec is required for load_with_torchcodec"`` when torchcodec
+isn't installed — that silently killed the Tier 3 Fail02 run on the
+kurdish_asr env. The loader now uses ``soundfile`` as the primary
+decoder (already a PARSE dependency via stt_pipeline). These tests
+stub ``soundfile`` + ``torch`` so they run without either installed
+locally.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ai import forced_align as fa
+
+
+# ---------------------------------------------------------------------------
+# Minimal torch stub — only what _load_audio_mono_16k touches
+# ---------------------------------------------------------------------------
+
+
+class _FakeTensor:
+    """Records transformation history so tests can assert on ops."""
+
+    def __init__(self, data, shape=None, dtype="float32", history=None):
+        self._data = data
+        self.shape = shape if shape is not None else getattr(data, "shape", (0,))
+        self.dtype = dtype
+        self.ndim = len(self.shape)
+        self.history = list(history or [])
+
+    def mean(self, dim=None, keepdim=False):
+        new_shape = list(self.shape)
+        new_shape[dim] = 1
+        return _FakeTensor(
+            None,
+            shape=tuple(new_shape),
+            history=self.history + [("mean", dim, keepdim)],
+        )
+
+    def squeeze(self, dim):
+        new_shape = list(self.shape)
+        if dim < len(new_shape) and new_shape[dim] == 1:
+            new_shape.pop(dim)
+        return _FakeTensor(
+            None,
+            shape=tuple(new_shape),
+            history=self.history + [("squeeze", dim)],
+        )
+
+    def unsqueeze(self, dim):
+        new_shape = list(self.shape)
+        new_shape.insert(dim, 1)
+        return _FakeTensor(
+            None,
+            shape=tuple(new_shape),
+            history=self.history + [("unsqueeze", dim)],
+        )
+
+    def contiguous(self):
+        return _FakeTensor(
+            self._data, shape=self.shape, history=self.history + [("contiguous",)]
+        )
+
+    def to(self, dtype):
+        return _FakeTensor(
+            self._data, shape=self.shape, dtype=str(dtype), history=self.history + [("to", str(dtype))]
+        )
+
+
+def _install_torch_stub(monkeypatch, resample_raises=False):
+    """Install a torch module that supports the ops _load_audio_mono_16k needs."""
+    torch_mod = types.ModuleType("torch")
+    torch_mod.float32 = "float32"
+
+    def _from_numpy(arr):
+        # numpy (samples, channels) transposed → (channels, samples)
+        shape = getattr(arr, "shape", (0,))
+        return _FakeTensor(arr, shape=shape)
+
+    torch_mod.from_numpy = _from_numpy
+
+    # torchaudio.functional.resample — optional path
+    if not resample_raises:
+        ta_mod = types.ModuleType("torchaudio")
+        ta_fn = types.ModuleType("torchaudio.functional")
+
+        def _resample(waveform, sr_in, sr_out):
+            # Produce a tensor whose last-axis length matches the expected
+            # resampled count (ratio-scaled). Keep shape otherwise.
+            old_shape = list(getattr(waveform, "shape", (1, 0)))
+            if not old_shape:
+                old_shape = [0]
+            old_len = int(old_shape[-1]) if old_shape[-1] else 0
+            new_len = max(1, int(round(old_len * sr_out / float(sr_in))))
+            new_shape = old_shape[:-1] + [new_len]
+            return _FakeTensor(None, shape=tuple(new_shape), history=(getattr(waveform, "history", []) or []) + [("resample", sr_in, sr_out, new_len)])
+
+        ta_fn.resample = _resample
+        ta_mod.functional = ta_fn
+        monkeypatch.setitem(sys.modules, "torchaudio", ta_mod)
+        monkeypatch.setitem(sys.modules, "torchaudio.functional", ta_fn)
+    else:
+        # Make torchaudio import succeed but .functional.resample blow up,
+        # so the fallback linear-interp path is exercised.
+        ta_mod = types.ModuleType("torchaudio")
+        ta_fn = types.ModuleType("torchaudio.functional")
+
+        def _broken(*args, **kwargs):
+            raise RuntimeError("TorchCodec is required for resample")
+
+        ta_fn.resample = _broken
+        ta_mod.functional = ta_fn
+        monkeypatch.setitem(sys.modules, "torchaudio", ta_mod)
+        monkeypatch.setitem(sys.modules, "torchaudio.functional", ta_fn)
+
+    # torch.nn.functional.interpolate — fallback resampler path
+    nn_mod = types.ModuleType("torch.nn")
+    nn_fn = types.ModuleType("torch.nn.functional")
+
+    def _interpolate(tensor, size, mode, align_corners=False):
+        old_shape = list(getattr(tensor, "shape", (1, 1, 0)))
+        new_shape = old_shape[:-1] + [size]
+        return _FakeTensor(None, shape=tuple(new_shape), history=getattr(tensor, "history", []) + [("interpolate", size, mode)])
+
+    nn_fn.interpolate = _interpolate
+    nn_mod.functional = nn_fn
+    torch_mod.nn = nn_mod
+
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setitem(sys.modules, "torch.nn", nn_mod)
+    monkeypatch.setitem(sys.modules, "torch.nn.functional", nn_fn)
+
+
+def _install_soundfile_stub(monkeypatch, *, sample_rate=16000, channels=1, num_samples=16000):
+    """Stub soundfile.read → (ndarray(num_samples, channels), sample_rate)."""
+    sf_mod = types.ModuleType("soundfile")
+    calls = []
+
+    class _FakeNDArray:
+        def __init__(self, shape):
+            self.shape = shape
+
+        @property
+        def T(self):
+            return _FakeNDArray((self.shape[1], self.shape[0]))
+
+    def _read(path, dtype=None, always_2d=False):
+        calls.append({"path": path, "dtype": dtype, "always_2d": always_2d})
+        shape = (num_samples, channels) if always_2d else (num_samples,)
+        return _FakeNDArray(shape), sample_rate
+
+    sf_mod.read = _read
+    sf_mod._calls = calls
+    monkeypatch.setitem(sys.modules, "soundfile", sf_mod)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_loads_mono_16k_without_resample(monkeypatch, tmp_path):
+    _install_torch_stub(monkeypatch)
+    calls = _install_soundfile_stub(monkeypatch, sample_rate=16000, channels=1, num_samples=32000)
+
+    wav = tmp_path / "clip.wav"
+    wav.write_bytes(b"")
+    out = fa._load_audio_mono_16k(wav)
+
+    assert len(calls) == 1
+    assert calls[0]["dtype"] == "float32"
+    assert calls[0]["always_2d"] is True
+    # soundfile returns (32000, 1) → torch.from_numpy(arr.T) = (1, 32000) → squeeze(0) → (32000,)
+    assert out.shape == (32000,)
+    # No resample step in the history (sr already matches).
+    assert not any(step[0] == "resample" for step in out.history)
+
+
+def test_downmixes_stereo_to_mono(monkeypatch, tmp_path):
+    _install_torch_stub(monkeypatch)
+    _install_soundfile_stub(monkeypatch, sample_rate=16000, channels=2, num_samples=16000)
+
+    wav = tmp_path / "stereo.wav"
+    wav.write_bytes(b"")
+    out = fa._load_audio_mono_16k(wav)
+
+    # Mean-across-channels was called on the (2, 16000) tensor.
+    assert any(step[0] == "mean" and step[1] == 0 for step in out.history)
+
+
+def test_resamples_44100_to_16000_via_torchaudio(monkeypatch, tmp_path):
+    _install_torch_stub(monkeypatch)
+    _install_soundfile_stub(monkeypatch, sample_rate=44100, channels=1, num_samples=44100)
+
+    wav = tmp_path / "hi.wav"
+    wav.write_bytes(b"")
+    out = fa._load_audio_mono_16k(wav)
+
+    resample_steps = [s for s in out.history if s[0] == "resample"]
+    assert len(resample_steps) == 1
+    assert resample_steps[0][1:3] == (44100, 16000)
+    # 1s of 44.1k resampled to 16k should be ~16000 samples.
+    assert out.shape[-1] == 16000
+
+
+def test_resample_fallback_uses_interpolate_when_torchaudio_broken(monkeypatch, tmp_path):
+    _install_torch_stub(monkeypatch, resample_raises=True)
+    _install_soundfile_stub(monkeypatch, sample_rate=44100, channels=1, num_samples=44100)
+
+    wav = tmp_path / "hi.wav"
+    wav.write_bytes(b"")
+    out = fa._load_audio_mono_16k(wav)
+
+    interp_steps = [s for s in out.history if s[0] == "interpolate"]
+    assert len(interp_steps) == 1
+    assert interp_steps[0][1] == 16000  # 1s * 16 kHz
+    # And the torchaudio resample attempt is not in history (it raised).
+    assert not any(s[0] == "resample" for s in out.history)
+
+
+def test_missing_soundfile_raises_helpful_error(monkeypatch, tmp_path):
+    _install_torch_stub(monkeypatch)
+    # Deliberately remove soundfile from sys.modules and import cache.
+    monkeypatch.setitem(sys.modules, "soundfile", None)
+
+    wav = tmp_path / "x.wav"
+    wav.write_bytes(b"")
+    with pytest.raises(RuntimeError, match="soundfile"):
+        fa._load_audio_mono_16k(wav)


### PR DESCRIPTION
## Diagnosis captured by PR #148

After merging the diagnostic PR, a fresh `ipa_only` run on Fail02 produced the exact error that was being hidden:

```
error: \"TorchCodec is required for load_with_torchcodec. Please install torchcodec to use this function.\"
```

torchaudio 2.5+ defaults to dispatching `torchaudio.load` through `load_with_torchcodec`. The PC's kurdish_asr env has torchaudio but not the separate `torchcodec` package, so every call to `_load_audio_mono_16k` raised before Tier 3 could reach wav2vec2. This is why the Fail02 IPA tier gained zero intervals in the 2026-04-23T12:00 run, and why every subsequent retry failed identically.

## Fix

Switch `_load_audio_mono_16k` in [python/ai/forced_align.py](python/ai/forced_align.py) to use `soundfile` as the primary decoder (already a PARSE dependency via `stt_pipeline.get_audio_duration_seconds`). Resample via `torchaudio.functional.resample` when importable, fall back to `torch.nn.functional.interpolate` linear resampling when it isn't. No new dependencies, no contract changes — still returns a 1-D float32 `torch.Tensor` at 16 kHz.

## Tests

- [python/ai/test_audio_loader.py](python/ai/test_audio_loader.py) — **5 new cases**, all hermetic:
  - mono / 16 kHz → passes through without resample
  - stereo / 16 kHz → downmix via mean-across-channels
  - 44.1 kHz mono → torchaudio resample picks exact 16 000-sample output for a 1-s clip
  - 44.1 kHz mono with torchaudio broken → `interpolate` fallback takes over
  - soundfile missing → `RuntimeError` with install hint
- 23 existing Tier 1/2/3 tests still pass.

## Verification

As soon as this lands I'll retrigger `ipa_only` on Fail02 on the PC and paste the new diagnostic log lines here — we should see `[IPA] aligner ready — entering per-interval loop (n=38)` for the first time, followed by real wav2vec2 IPA output for each of the 38 ortho windows.

## Next

Still to come in separate PRs:
- **ORTH regression fix** — `condition_on_previous_text=False` + tuned VAD to stop the whisper repetition cascade that truncated Fail02 ORTH at 6:31
- **Batch-report result propagation** — so errors like the torchcodec one don't hide behind `result: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)