### PR TITLE
fix(batch-report): forward per-step results on error + surface empty cells

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -666,6 +666,22 @@ export interface PipelineStepResultBase {
   reason?: string;
   error?: string;
   traceback?: string;
+  /** IPA-specific: categorised skip counters added in server.py on
+   *  2026-04-23 (see fix/ortho-regression-tier3-silent). When ``filled=0``
+   *  with ``total>0`` the cause is in this breakdown — usually
+   *  ``exception`` (torch/CUDA init) or ``empty_ipa_from_model``
+   *  (wav2vec2 decoded silence). The UI renders this as an expandable
+   *  reason block on the "Empty" step cell so the user sees why
+   *  nothing got written without opening the raw JSON. */
+  skip_breakdown?: {
+    empty_ortho?: number;
+    existing_ipa_no_overwrite?: number;
+    zero_range?: number;
+    exception?: number;
+    empty_ipa_from_model?: number;
+  };
+  /** First 1-3 caught exceptions from the per-interval decode loop. */
+  exception_samples?: string[];
   // Shape overlaps below are step-specific; carry them loosely — the
   // UI only pulls what it knows about.
   [key: string]: unknown;

--- a/src/components/shared/BatchReportModal.tsx
+++ b/src/components/shared/BatchReportModal.tsx
@@ -3,6 +3,7 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
+  CircleSlash,
   Copy,
   Download,
   RotateCw,
@@ -73,7 +74,7 @@ function okDetail(step: PipelineStepId, cell: PipelineStepResultBase): string {
   }
 }
 
-type CellKind = "ok" | "skipped" | "error" | "unknown";
+type CellKind = "ok" | "skipped" | "empty" | "error" | "unknown";
 
 /** Classify a step-result object into one of four visual kinds.
  *
@@ -90,9 +91,26 @@ type CellKind = "ok" | "skipped" | "error" | "unknown";
  *  JSON download).
  */
 function classifyCell(cell: PipelineStepResultBase): CellKind {
-  // 1. Explicit status field wins.
+  // 1. Explicit status field wins — BUT promote "ok" to "empty" when
+  //    the step ran against real work and wrote nothing. This is the
+  //    Fail02 Tier-3 case: status=ok, filled=0, total=38 means the
+  //    server did not raise, yet no intervals landed. The user needs
+  //    to see that immediately — an OK badge on an empty step hides
+  //    the failure mode we added diagnostics for.
   const explicit = cell["status"];
   if (explicit === "ok" || explicit === "skipped" || explicit === "error") {
+    if (explicit === "ok") {
+      const filled = cell["filled"];
+      const total = cell["total"];
+      if (
+        typeof filled === "number" &&
+        filled === 0 &&
+        typeof total === "number" &&
+        total > 0
+      ) {
+        return "empty";
+      }
+    }
     return explicit;
   }
   // 2. An error string implies error regardless of other fields.
@@ -123,7 +141,12 @@ function speakerHasFailure(outcome: BatchSpeakerOutcome): boolean {
   if (outcome.result) {
     for (const step of Object.keys(outcome.result.results) as PipelineStepId[]) {
       const cell = outcome.result.results[step];
-      if (cell && classifyCell(cell) === "error") return true;
+      if (!cell) continue;
+      const kind = classifyCell(cell);
+      // "empty" (filled=0 total>0) counts as a failure for re-run
+      // purposes: the step ran but produced nothing, so the user
+      // almost always wants to rerun-failed with that step included.
+      if (kind === "error" || kind === "empty") return true;
     }
   }
   return false;
@@ -132,9 +155,10 @@ function speakerHasFailure(outcome: BatchSpeakerOutcome): boolean {
 function countTotals(
   outcomes: BatchSpeakerOutcome[],
   stepsRun: PipelineStepId[],
-): { ok: number; skipped: number; errored: number } {
+): { ok: number; skipped: number; empty: number; errored: number } {
   let ok = 0;
   let skipped = 0;
+  let empty = 0;
   let errored = 0;
   for (const outcome of outcomes) {
     if (outcome.status === "error" && !outcome.result) {
@@ -149,10 +173,11 @@ function countTotals(
       const kind = classifyCell(cell);
       if (kind === "ok") ok += 1;
       else if (kind === "skipped") skipped += 1;
+      else if (kind === "empty") empty += 1;
       else if (kind === "error") errored += 1;
     }
   }
-  return { ok, skipped, errored };
+  return { ok, skipped, empty, errored };
 }
 
 function DetailsBlock({
@@ -303,6 +328,89 @@ function StepCell({
             <span className="text-[11px] text-slate-500">
               {truncate(reason)}
             </span>
+          )}
+        </div>
+      </td>
+    );
+  }
+
+  if (kind === "empty") {
+    // Step ran, returned status:ok, but wrote zero intervals. The
+    // user needs to see this immediately — a green OK badge on a
+    // zero-filled step is the exact trap that hid the Fail02 Tier 3
+    // torchcodec crash for a day. Pull the skip_breakdown and
+    // first exception sample (populated by the diagnostic commit
+    // in server.py) into an expandable details block.
+    const filled = typeof cell.filled === "number" ? cell.filled : 0;
+    const total = typeof cell.total === "number" ? cell.total : 0;
+    const breakdown = cell.skip_breakdown ?? null;
+    const samples = Array.isArray(cell.exception_samples)
+      ? (cell.exception_samples as unknown[]).filter(
+          (s): s is string => typeof s === "string" && s.length > 0,
+        )
+      : [];
+    const hasDetails =
+      samples.length > 0 ||
+      (breakdown &&
+        Object.values(breakdown).some(
+          (v) => typeof v === "number" && v > 0,
+        ));
+
+    return (
+      <td className="border-b border-slate-100 bg-amber-50/60 px-2 py-1.5 align-top">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-1.5 text-amber-800">
+            <CircleSlash className="h-3.5 w-3.5 shrink-0" />
+            <span className="text-xs font-semibold">Empty</span>
+            <span className="text-[11px] text-amber-900/80 tabular-nums">
+              {filled}/{total} written
+            </span>
+          </div>
+          {hasDetails && (
+            <>
+              <button
+                type="button"
+                onClick={onToggle}
+                className="inline-flex w-fit items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-amber-800 hover:bg-amber-100"
+                aria-expanded={isOpen}
+              >
+                {isOpen ? (
+                  <ChevronDown className="h-3 w-3" />
+                ) : (
+                  <ChevronRight className="h-3 w-3" />
+                )}
+                Why
+              </button>
+              {isOpen && (
+                <div
+                  role="region"
+                  aria-label={`Empty-step details for ${outcome.speaker} ${step}`}
+                  className="mt-1 rounded border border-amber-200 bg-white p-2 text-[11px] text-amber-900"
+                >
+                  {breakdown && (
+                    <dl className="grid grid-cols-2 gap-x-3 gap-y-0.5">
+                      {Object.entries(breakdown)
+                        .filter(([, v]) => typeof v === "number" && v > 0)
+                        .map(([k, v]) => (
+                          <React.Fragment key={k}>
+                            <dt className="font-mono text-amber-800/80">
+                              {k}
+                            </dt>
+                            <dd className="text-right font-mono tabular-nums">
+                              {String(v)}
+                            </dd>
+                          </React.Fragment>
+                        ))}
+                    </dl>
+                  )}
+                  {samples.length > 0 && (
+                    <pre className="mt-1 max-h-[160px] overflow-auto whitespace-pre-wrap break-words rounded bg-amber-50 p-1.5 font-mono text-[10.5px] leading-snug text-amber-900">
+                      {samples.join("\n")}
+                    </pre>
+                  )}
+                </div>
+              )}
+            </>
           )}
         </div>
       </td>
@@ -550,7 +658,8 @@ export function BatchReportModal({
   };
 
   const columnCount = stepsRun.length + 2; // speaker col + steps + trailing status col
-  const allClean = totals.errored === 0 && totals.skipped === 0;
+  const allClean =
+    totals.errored === 0 && totals.skipped === 0 && totals.empty === 0;
 
   const title = `Batch Report — ${outcomes.length} speakers × ${stepsRun.length} steps`;
 
@@ -576,6 +685,16 @@ export function BatchReportModal({
             <SkipForward className="h-3 w-3" />
             {totals.skipped} skipped
           </span>
+          {totals.empty > 0 && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800"
+              data-testid="batch-report-chip-empty"
+              title="Step ran but wrote zero intervals — see per-cell details"
+            >
+              <CircleSlash className="h-3 w-3" />
+              {totals.empty} empty
+            </span>
+          )}
           <span
             className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-medium text-rose-800"
             data-testid="batch-report-chip-errored"

--- a/src/hooks/useBatchPipelineJob.ts
+++ b/src/hooks/useBatchPipelineJob.ts
@@ -322,17 +322,27 @@ export function useBatchPipelineJob(): UseBatchPipelineJobResult {
               currentMessage: message,
             }));
 
+            // Regardless of terminal status (complete OR error), the backend
+            // may have populated ``result`` with step-level details — e.g.
+            // a full_pipeline that completed STT then errored on IPA returns
+            // a ``results`` dict with per-step status/error/traceback even
+            // when the job-level status is "error". Previously we dropped
+            // that on the error branch, leaving the user with only the
+            // top-line "Pipeline failed" message and no way to see which
+            // step actually failed or why. Capture it on both paths.
+            const raw = poll as unknown as { result?: PipelineRunResult };
+
             if (isCompleteStatus(status)) {
-              // `pollCompute` returns ComputeStatus; the full PipelineRunResult
-              // lives under `result` on the same payload (shape documented in
-              // api/client.ts). Pull it off the raw response if present.
-              const raw = poll as unknown as { result?: PipelineRunResult };
               pollResult = raw.result ?? null;
               break;
             }
             if (isErrorStatus(status)) {
               pollErrored = true;
               pollErrorMessage = poll.error ?? poll.message ?? "Pipeline failed";
+              // Keep any partial per-step results so the modal can still
+              // render step-by-step status. A job-level error does NOT
+              // invalidate the steps that completed before it.
+              pollResult = raw.result ?? null;
               break;
             }
 
@@ -349,6 +359,9 @@ export function useBatchPipelineJob(): UseBatchPipelineJobResult {
                 ...nextOutcomes[i],
                 status: "error",
                 error: pollErrorMessage,
+                // Partial per-step data where present — see the comment in
+                // the poll loop for why we forward this on the error path.
+                result: pollResult,
               };
             } else {
               nextOutcomes[i] = {


### PR DESCRIPTION
## The Fail02 trap

The pipeline that wrote zero IPA intervals produced this batch-report JSON:

\`\`\`json
{
  "outcomes": [
    {"speaker": "Fail02", "status": "complete", "error": null, "result": null}
  ]
}
\`\`\`

In the modal: a green ✅ **OK 0 ivs** chip. No indication that Tier 3 had silently died on a torchcodec import. The server (after PR #148) was already capturing skip counters, exception samples, and full tracebacks — the frontend just wasn't reading them.

## Three UI fixes

### 1. Hook forwards \`result\` on the error path
\`useBatchPipelineJob\` dropped \`poll.result\` whenever the job ended in \`error\` status — losing the entire per-step breakdown for any pipeline that made partial progress then errored. Both terminal branches now capture \`raw.result\`.

### 2. New \`"empty"\` cell kind
\`classifyCell\` used to treat \`{status: "ok", filled: 0, total: 38}\` as plain OK. That promoted the exact failure mode that hid Fail02's torchcodec crash. New \`"empty"\` kind catches this:

- Amber styling (distinct from green OK, grey skipped, red error)
- \`filled/total written\` badge inline
- Expandable "Why" block showing the server's \`skip_breakdown\` counters (\`empty_ortho\`, \`existing_ipa_no_overwrite\`, \`zero_range\`, \`exception\`, \`empty_ipa_from_model\`) and first-3 \`exception_samples\`
- Counts as a failure in \`speakerHasFailure\` so it's offered by the rerun-failed flow

### 3. Empty summary chip + typed surface
- New amber \`N empty\` chip in the summary strip (only when >0)
- \`countTotals\` returns \`empty\`; \`allClean\` requires \`empty === 0\`
- \`PipelineStepResultBase\` gains typed \`skip_breakdown\` / \`exception_samples\` fields matching the server contract

## Zero backend changes

The server has been returning this data since PR #148 landed. The UI just wasn't looking at it. Any run where Tier 3 skips every interval will now expose exactly which failure mode in the modal without the user having to download and read the raw JSON.

## Tests

Existing \`BatchReportModal.test.tsx\` (12 cases) and \`useBatchPipelineJob.test.ts\` (9 cases) don't exercise the new empty-path yet; they still pass because \`classifyCell\`'s change only fires on the specific \`filled=0 total>0\` shape. Follow-up test coverage for the empty path + the error-with-result path would be nice but isn't blocking.

## Next

Separate investigation: the Windows \`python.exe\` + CUDA + threading server wedge that blocks \`POST /api/compute/ipa_only\` on the PC even though the code is proven correct standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)