### PR TITLE
fix: surface schema_version mismatch instead of silently showing no speakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ This matters for thesis workflows where the richest aligned source is not a fres
 
 The active frontend speaker list comes from the live workspace behind `/api/config`, not necessarily from the bare repo checkout. When running PARSE with `PARSE_WORKSPACE_ROOT` set, imports and runtime writes must land in that workspace for the UI to see them.
 
+> **API schema version contract:** Every `/api/config` response carries `schema_version: 1`. The React client validates this on boot; a mismatch (old server code running against a new frontend) surfaces as a banner instead of a silent empty workspace. When a breaking change to the config payload shape is needed, bump `_CONFIG_SCHEMA_VERSION` in `python/server.py` **and** `EXPECTED_CONFIG_SCHEMA_VERSION` in `src/api/client.ts` together in the same PR.
+
 ---
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ This matters for thesis workflows where the richest aligned source is not a fres
 
 The active frontend speaker list comes from the live workspace behind `/api/config`, not necessarily from the bare repo checkout. When running PARSE with `PARSE_WORKSPACE_ROOT` set, imports and runtime writes must land in that workspace for the UI to see them.
 
-> **API schema version contract:** Every `/api/config` response carries `schema_version: 1`. The React client validates this on boot; a mismatch (old server code running against a new frontend) surfaces as a banner instead of a silent empty workspace. When a breaking change to the config payload shape is needed, bump `_CONFIG_SCHEMA_VERSION` in `python/server.py` **and** `EXPECTED_CONFIG_SCHEMA_VERSION` in `src/api/client.ts` together in the same PR.
+> **API schema version contract:** Every `/api/config` response carries `schema_version: 1`. The React client validates this on boot; a mismatch (old server code running against a new frontend) surfaces as a banner instead of a silent empty workspace. When a breaking change to the config payload shape is needed, bump `CONFIG_SCHEMA_VERSION` in `python/server.py` **and** `EXPECTED_CONFIG_SCHEMA_VERSION` in `src/api/client.ts` together in the same PR.
 
 ---
 

--- a/python/server.py
+++ b/python/server.py
@@ -703,6 +703,7 @@ def _workspace_frontend_config(base_config: Optional[Dict[str, Any]] = None) -> 
     config["concepts"] = concepts
     config["audio_dir"] = str(project_payload.get("audio_dir") or config.get("audio_dir") or "audio")
     config["annotations_dir"] = str(project_payload.get("annotations_dir") or config.get("annotations_dir") or "annotations")
+    config["schema_version"] = 1
     return config
 
 

--- a/python/server.py
+++ b/python/server.py
@@ -36,6 +36,7 @@ except Exception:
 HOST = "0.0.0.0"
 PORT = 8766
 JOB_RETENTION_SECONDS = 60 * 60
+_CONFIG_SCHEMA_VERSION = 1
 
 CORS_HEADERS = {
     "Access-Control-Allow-Origin": "*",
@@ -703,7 +704,7 @@ def _workspace_frontend_config(base_config: Optional[Dict[str, Any]] = None) -> 
     config["concepts"] = concepts
     config["audio_dir"] = str(project_payload.get("audio_dir") or config.get("audio_dir") or "audio")
     config["annotations_dir"] = str(project_payload.get("annotations_dir") or config.get("annotations_dir") or "annotations")
-    config["schema_version"] = 1
+    config["schema_version"] = _CONFIG_SCHEMA_VERSION
     return config
 
 

--- a/python/server.py
+++ b/python/server.py
@@ -36,7 +36,7 @@ except Exception:
 HOST = "0.0.0.0"
 PORT = 8766
 JOB_RETENTION_SECONDS = 60 * 60
-_CONFIG_SCHEMA_VERSION = 1
+CONFIG_SCHEMA_VERSION = 1
 
 CORS_HEADERS = {
     "Access-Control-Allow-Origin": "*",
@@ -704,7 +704,7 @@ def _workspace_frontend_config(base_config: Optional[Dict[str, Any]] = None) -> 
     config["concepts"] = concepts
     config["audio_dir"] = str(project_payload.get("audio_dir") or config.get("audio_dir") or "audio")
     config["annotations_dir"] = str(project_payload.get("annotations_dir") or config.get("annotations_dir") or "annotations")
-    config["schema_version"] = _CONFIG_SCHEMA_VERSION
+    config["schema_version"] = CONFIG_SCHEMA_VERSION
     return config
 
 

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1760,6 +1760,7 @@ export function ParseUI() {
   const loadConfig       = useConfigStore(s => s.load);
   const rawSpeakers      = useConfigStore(s => s.config?.speakers ?? []);
   const rawConcepts      = useConfigStore(s => s.config?.concepts ?? []);
+  const configError      = useConfigStore(s => s.error);
   const storeTags        = useTagStore(s => s.tags);
   const storeAddTag      = useTagStore(s => s.addTag);
   const hydrateTagStore  = useTagStore(s => s.hydrate);
@@ -2266,7 +2267,7 @@ export function ParseUI() {
     useEnrichmentStore.setState({ data: {}, loading: false });
     useTagStore.setState({ tags: [] });
     usePlaybackStore.setState({ activeSpeaker: null, currentTime: 0 });
-    useConfigStore.setState({ config: null, loading: false });
+    useConfigStore.setState({ config: null, loading: false, error: null });
     crossSpeakerJob.reset();
     batch.reset();
     resetComputeJob();
@@ -2940,6 +2941,15 @@ export function ParseUI() {
           </div>
         </div>
       </header>
+      {configError && (
+        <div className="shrink-0 flex items-start gap-3 border-b border-rose-200 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <span className="font-semibold">Server error—speakers may not load. </span>
+            {configError}
+          </div>
+        </div>
+      )}
 
       {/* ============ BODY: left sidebar / main / right panel ============ */}
       <div className="flex min-h-0 flex-1">

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1761,6 +1761,7 @@ export function ParseUI() {
   const rawSpeakers      = useConfigStore(s => s.config?.speakers ?? []);
   const rawConcepts      = useConfigStore(s => s.config?.concepts ?? []);
   const configError      = useConfigStore(s => s.error);
+  const [dismissedConfigError, setDismissedConfigError] = useState<string | null>(null);
   const storeTags        = useTagStore(s => s.tags);
   const storeAddTag      = useTagStore(s => s.addTag);
   const hydrateTagStore  = useTagStore(s => s.hydrate);
@@ -2941,13 +2942,22 @@ export function ParseUI() {
           </div>
         </div>
       </header>
-      {configError && (
-        <div className="shrink-0 flex items-start gap-3 border-b border-rose-200 bg-rose-50 px-5 py-3 text-sm text-rose-700">
+      {configError && configError !== dismissedConfigError && (
+        <div className="shrink-0 flex items-center gap-3 border-b border-rose-200 bg-rose-50 px-5 py-3 text-sm text-rose-700">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <div>
+          <div className="flex-1">
             <span className="font-semibold">Server error—speakers may not load. </span>
             {configError}
           </div>
+          <button
+            onClick={() => { setDismissedConfigError(null); loadConfig(); }}
+            className="shrink-0 rounded px-2 py-1 text-xs font-medium hover:bg-rose-100"
+          >Retry</button>
+          <button
+            onClick={() => setDismissedConfigError(configError)}
+            className="shrink-0 rounded p-1 hover:bg-rose-100"
+            aria-label="Dismiss"
+          ><X className="h-3.5 w-3.5" /></button>
         </div>
       )}
 

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runChat, startChatSession } from "./client";
+import { getConfig, runChat, startChatSession } from "./client";
 
 describe("chat API client contracts", () => {
   const fetchMock = vi.fn();
@@ -29,5 +29,52 @@ describe("chat API client contracts", () => {
     await expect(runChat("chat_123", "hello")).rejects.toThrow(
       /Could not reach the PARSE API.*8766/i,
     );
+  });
+});
+
+describe("getConfig / unwrapConfig schema-version guard", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves when schema_version matches", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        config: { schema_version: 1, speakers: [], concepts: [], project_name: "t", language_code: "und", audio_dir: "audio", annotations_dir: "annotations" },
+      }),
+    });
+    await expect(getConfig()).resolves.toMatchObject({ schema_version: 1, speakers: [] });
+  });
+
+  it("rejects with an actionable message when schema_version is missing", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ config: { project_name: "test" } }),
+    });
+    await expect(getConfig()).rejects.toThrow(/outdated/i);
+  });
+
+  it("rejects when schema_version is a future version", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ config: { schema_version: 99 } }),
+    });
+    await expect(getConfig()).rejects.toThrow(/outdated/i);
+  });
+
+  it("rejects when the {config} wrapper is missing (old flat-format server)", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ project_name: "test", speakers: [] }),
+    });
+    await expect(getConfig()).rejects.toThrow(/outdated/i);
   });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,11 +42,24 @@ function resolveJobId(payload: unknown): string {
   return "";
 }
 
+const EXPECTED_CONFIG_SCHEMA_VERSION = 1;
+
 function unwrapConfig(payload: unknown): ProjectConfig {
   if (isRecord(payload) && isRecord(payload.config)) {
-    return payload.config as ProjectConfig;
+    const cfg = payload.config;
+    if (cfg.schema_version !== EXPECTED_CONFIG_SCHEMA_VERSION) {
+      const got = cfg.schema_version === undefined ? "missing" : String(cfg.schema_version);
+      throw new Error(
+        `PARSE server is outdated (config schema_version: ${got}, expected: ${EXPECTED_CONFIG_SCHEMA_VERSION}). ` +
+        "Restart the Python server with the latest code and reload the page."
+      );
+    }
+    return cfg as ProjectConfig;
   }
-  return (payload ?? {}) as ProjectConfig;
+  throw new Error(
+    "PARSE server is outdated: /api/config response is missing the expected wrapper. " +
+    "Restart the Python server with the latest code and reload the page."
+  );
 }
 
 function unwrapEnrichments(payload: unknown): EnrichmentsPayload {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,15 +42,20 @@ function resolveJobId(payload: unknown): string {
   return "";
 }
 
-const EXPECTED_CONFIG_SCHEMA_VERSION = 1;
+const CONFIG_SCHEMA_VERSION = 1;
 
+// Validates the {config: ...} wrapper and schema_version added in PR #155.
+// Before that fix, a stale server (pre-PR #24 code) returned speakers as a
+// plain dict instead of string[]; TypeScript cast it silently and the UI
+// rendered an empty workspace with no error. schema_version makes the mismatch
+// explicit so the banner fires instead.
 function unwrapConfig(payload: unknown): ProjectConfig {
   if (isRecord(payload) && isRecord(payload.config)) {
     const cfg = payload.config;
-    if (cfg.schema_version !== EXPECTED_CONFIG_SCHEMA_VERSION) {
+    if (cfg.schema_version !== CONFIG_SCHEMA_VERSION) {
       const got = cfg.schema_version === undefined ? "missing" : String(cfg.schema_version);
       throw new Error(
-        `PARSE server is outdated (config schema_version: ${got}, expected: ${EXPECTED_CONFIG_SCHEMA_VERSION}). ` +
+        `PARSE server is outdated (config schema_version: ${got}, expected: ${CONFIG_SCHEMA_VERSION}). ` +
         "Restart the Python server with the latest code and reload the page."
       );
     }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -56,6 +56,7 @@ export interface ProjectConfig {
   concepts: ConceptEntry[];
   audio_dir: string;
   annotations_dir: string;
+  schema_version?: number;
   [key: string]: unknown;
 }
 

--- a/src/stores/configStore.ts
+++ b/src/stores/configStore.ts
@@ -5,6 +5,7 @@ import { getConfig } from "../api/client";
 interface ConfigStore {
   config: ProjectConfig | null;
   loading: boolean;
+  error: string | null;
   load: () => Promise<void>;
   update: (patch: Partial<ProjectConfig>) => Promise<void>;
 }
@@ -12,18 +13,19 @@ interface ConfigStore {
 export const useConfigStore = create<ConfigStore>()((set, get) => ({
   config: null,
   loading: false,
+  error: null,
 
   load: async () => {
     const { config, loading } = get();
     if (config !== null && !loading) return;
     if (loading) return; // don't double-fetch
-    set({ loading: true });
+    set({ loading: true, error: null });
     try {
       const data = await getConfig();
       set({ config: data, loading: false });
     } catch (err) {
-      set({ loading: false });
-      throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      set({ loading: false, error: message });
     }
   },
 


### PR DESCRIPTION
## What broke and why

After a reboot the Python API server was running stale code (pre-PR `#24`). The `project.json` workspace stores speakers as a dict (`{"Fail01": {}, ...}`), and the old server returned that dict without the dict-to-list conversion added in later PRs. The new React frontend expected `speakers: string[]`, so speakers silently came back empty.

The silent-failure chain:

1. `apiFetch("/api/config")` succeeded (HTTP 200) — old server responded
2. `unwrapConfig` fell back to casting the raw payload as `ProjectConfig`
3. At runtime `config.speakers` was a dict — array methods return 0 elements silently
4. UI rendered an empty speaker list with no error, no warning

## What this PR does

**`python/server.py`** — adds `schema_version: 1` to every `/api/config` response.

**`src/api/types.ts`** — adds `schema_version?: number` to `ProjectConfig`.

**`src/api/client.ts`** — `unwrapConfig` now throws a descriptive `Error` when either:
- the `{config: ...}` wrapper is missing (old server format)
- `schema_version` doesn't match `EXPECTED_CONFIG_SCHEMA_VERSION`

Both were previously silent data loss.

**`src/stores/configStore.ts`** — adds `error: string | null`. `load()` now stores errors instead of rethrowing, so failures surface in the store rather than being swallowed by `.catch(console.error)`.

**`src/ParseUI.tsx`** — renders a rose banner below the top bar when `configStore.error` is set. Also clears `error` in `resetProject()`.

## Behaviour after this PR

Old server running → banner: *"Server error — speakers may not load. PARSE server is outdated (schema_version missing). Restart the Python server with the latest code and reload."*

New server running → no banner, normal load.
