### PR TITLE
docs: add README MCP agent tools callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,10 @@ The built-in assistant operates with both read and write access to the project, 
 
 ## MCP Server Mode
 
+### Agent Tools (MCP)
+
+PARSE can run as an **MCP server**, exposing a curated subset of **29 tools** (out of **47** total `ParseChatTools`). This lets third-party agents — Claude Code, Cursor, Cline, Hermes, Windsurf, Codex, or any MCP-compatible client — call PARSE functions programmatically without ever touching the browser UI.
+
 PARSE can run as an **MCP (Model Context Protocol) server**, exposing **29 MCP tools** from its PARSE-specific AI tooling surface over the standard MCP protocol. This is a curated subset of the broader 47-tool in-app `ParseChatTools` surface — not every chat tool is exported over MCP. Third-party agents — Claude Code, Cursor, Codex, Windsurf, or any MCP-compatible client — can call these PARSE tools programmatically without going through the browser UI.
 
 ```bash


### PR DESCRIPTION
## Summary
- add a small README follow-up callout for agent-oriented users under the MCP section
- keep `ParseChatTools` as the technical/internal name while giving the user-facing docs a clearer "Agent Tools (MCP)" entry point
- no code changes; README-only

## What changed
- add `### Agent Tools (MCP)` beneath `## MCP Server Mode`
- add a short paragraph that says PARSE exposes a curated subset of **29 tools** out of **47** total `ParseChatTools`
- explicitly name external agent clients in that framing: Claude Code, Cursor, Cline, Hermes, Windsurf, Codex, etc.

## Why
The existing README already documents the MCP surface correctly, but this tweak makes the agent story more legible for readers who care about external AI control of PARSE more than the internal `ParseChatTools` implementation name.

## Verification
- diff is README-only
- branch differs from `origin/main` by 4 added README lines only
