### PR TITLE
fix(ipa): batch forced-align segments + PM2 ecosystem config

### DIFF
--- a/deploy/pm2-ecosystem.config.js
+++ b/deploy/pm2-ecosystem.config.js
@@ -1,0 +1,38 @@
+/**
+ * PM2 ecosystem config for the PARSE API server on the PC (WSL2/Ubuntu).
+ *
+ * Usage (run once after each WSL cycle, or wire into `pm2 startup`):
+ *
+ *   pm2 start deploy/pm2-ecosystem.config.js
+ *   pm2 save
+ *
+ * IMPORTANT — cwd must be the live workspace, NOT the git repo clone.
+ * The server resolves annotation/audio paths relative to cwd. Running from
+ * the repo clone causes annotation writes to land inside the git working
+ * tree instead of the workspace directory.
+ *
+ * Known issue — branch auto-switching:
+ *   Something on the PC (Hermes skill, cron, or another PM2 process) issues
+ *   `git checkout` against /home/lucas/gh/ardeleanlucas/parse and switches it
+ *   away from the desired branch between deployments. Until that is tracked
+ *   down, verify the branch before restarting the server:
+ *
+ *     cd /home/lucas/gh/ardeleanlucas/parse && git branch --show-current
+ *
+ *   Expected: feat/ipa-forced-align-pipeline (or main after merge)
+ */
+module.exports = {
+  apps: [
+    {
+      name: "parse-api",
+      script: "/usr/bin/python3",
+      args: "-u /home/lucas/gh/ardeleanlucas/parse/python/server.py --compute-mode=thread",
+      // cwd MUST be the workspace, not the repo clone — see note above
+      cwd: "/home/lucas/parse-workspace",
+      env: {
+        PARSE_WORKSPACE_ROOT: "/home/lucas/parse-workspace",
+        PARSE_AI_CONFIG: "/home/lucas/parse-workspace/config/ai_config.json",
+      },
+    },
+  ],
+};

--- a/python/ai/ipa_transcribe.py
+++ b/python/ai/ipa_transcribe.py
@@ -149,6 +149,7 @@ def transcribe_words_with_forced_align(
     pad_ms: int = DEFAULT_PAD_MS,
     aligner: Optional[Aligner] = None,
     progress_callback: Optional[Any] = None,
+    segment_batch_size: int = 20,
 ) -> List[IpaResult]:
     """Full 3-tier IPA: G2P + torchaudio forced alignment → word windows → wav2vec2 CTC.
 
@@ -160,6 +161,13 @@ def transcribe_words_with_forced_align(
     Returns one :class:`IpaResult` per word. Segments that carry no
     ``words[]`` are skipped. Falls back to segment-level
     :func:`transcribe_intervals` when no words are found at all.
+
+    ``segment_batch_size`` controls how many Whisper segments are fed to
+    ``align_segments`` at a time. Processing all segments in one call
+    accumulates GPU state across hundreds of forced-align invocations and
+    can exhaust VRAM / WSL memory on long recordings (≥150 segments).
+    Batching keeps peak memory proportional to the batch rather than the
+    full recording.
     """
     try:
         from .forced_align import align_segments as _align_segments
@@ -173,29 +181,32 @@ def transcribe_words_with_forced_align(
     local_aligner = aligner or Aligner.load(model_name=model_name, device=device)
     audio = _load_audio_mono_16k(path)
 
-    # Tier 2: forced alignment — pass pre-loaded tensor to avoid double-load
-    aligned = _align_segments(
-        audio_path=path,
-        segments=list(segments),
-        language=language,
-        pad_ms=pad_ms,
-        aligner=local_aligner,
-        audio_tensor=audio,
-    )
-
+    seg_list = list(segments)
     word_intervals: List[IntervalSpec] = []
-    for seg_words in aligned:
-        for word in seg_words:
-            s = float(word.get("start", 0.0) or 0.0)
-            e = float(word.get("end", 0.0) or 0.0)
-            if e > s:
-                word_intervals.append(IntervalSpec(start=s, end=e))
+
+    # Tier 2: forced alignment in batches to bound peak GPU memory
+    for batch_start in range(0, len(seg_list), segment_batch_size):
+        batch = seg_list[batch_start: batch_start + segment_batch_size]
+        aligned_batch = _align_segments(
+            audio_path=path,
+            segments=batch,
+            language=language,
+            pad_ms=pad_ms,
+            aligner=local_aligner,
+            audio_tensor=audio,
+        )
+        for seg_words in aligned_batch:
+            for word in seg_words:
+                s = float(word.get("start", 0.0) or 0.0)
+                e = float(word.get("end", 0.0) or 0.0)
+                if e > s:
+                    word_intervals.append(IntervalSpec(start=s, end=e))
 
     if not word_intervals:
         # No words produced — fall back to segment-level coarse transcription
         seg_intervals = [
             {"start": s.get("start", 0.0), "end": s.get("end", 0.0)}
-            for s in segments
+            for s in seg_list
         ]
         return transcribe_intervals(
             path, seg_intervals, aligner=local_aligner,


### PR DESCRIPTION
Follow-up to #156. Documents and fixes four deployment issues found during the Fail02 full-recording run on the PC (RTX 5090, WSL2, torch 2.11+cu130).

---

## Issue 1 — WSL OOM crash on large coarse_transcripts (FIXED)

**Symptom:** `POST /api/compute/ipa_only` on Fail02 crashes WSL with `Wsl/Service/E_UNEXPECTED` (~10–15 min into the run) when the workspace `coarse_transcripts/Fail02.json` has 154 segments × 3507 words. Smaller inputs (16 seg / 506 words) complete fine.

**Root cause:** `transcribe_words_with_forced_align()` passed all segments to `align_segments()` in one call. Each `torchaudio.functional.forced_align` invocation against the full GPU context accumulated state across 154 × ~23 words, exhausting WSL's addressable memory before the CTC pass began.

**Fix:** Added `segment_batch_size=20` parameter to `transcribe_words_with_forced_align()`. Forced-align now runs in batches of 20 segments, keeping peak GPU state proportional to the batch rather than the full recording.

---

## Issue 2 — PM2 cwd misconfiguration (FIXED)

**Symptom:** After restarting PM2 with the new server code, annotation writes landed in `/home/lucas/gh/ardeleanlucas/parse/annotations/` (the git repo clone) instead of `/home/lucas/parse-workspace/annotations/`. The workspace annotation file stayed at its pre-run mtime; the git working tree accumulated 449 result intervals.

**Root cause:** PM2 `cwd` was set to the repo clone. The server uses `os.getcwd()` as the workspace root, so all path resolution (annotations, audio, coarse_transcripts) pointed into the repo rather than the live workspace.

**Fix:** Committed `deploy/pm2-ecosystem.config.js` with `cwd: "/home/lucas/parse-workspace"` and both `PARSE_WORKSPACE_ROOT` + `PARSE_AI_CONFIG` env vars. Run once after each WSL cycle:
```bash
pm2 start deploy/pm2-ecosystem.config.js && pm2 save
```

---

## Issue 3 — Branch auto-switching (UNRESOLVED — needs investigation)

**Symptom:** Between deployments, the git branch in `/home/lucas/gh/ardeleanlucas/parse` silently switches away from `feat/ipa-forced-align-pipeline` (or `main`) to an unrelated branch (observed: `fix/config-schema-version-check`, `docs/readme-post-142-audit`). The server then imports the pre-soundfile version of `forced_align._load_audio_mono_16k` which raises `ImportError: TorchCodec is required` and silently kills the compute thread — no exception logged, job evicted from the in-memory store.

**Suspected cause:** A Hermes skill or cron job on the PC is running `git checkout` or `git pull` against this repo. The `hermes-parse-builder.service` and `hermes-parse-gpt.service` systemd units are running at all times and have skill access to the filesystem.

**Workaround:** Before restarting the server, verify: `cd /home/lucas/gh/ardeleanlucas/parse && git branch --show-current` → expected `main`.

**Proper fix:** Identify and patch the Hermes skill that is issuing git checkouts, OR decouple the server's Python path from the git working tree (e.g. install the `ai/` package into the virtualenv so the live import doesn't depend on which branch is checked out).

---

## Issue 4 — `torchaudio.load` → torchcodec (ALREADY FIXED, documented here)

**Symptom:** Any code calling `torchaudio.load()` directly raises `ImportError: TorchCodec is required for load_with_torchcodec` on this environment (torchaudio 2.5+, torch 2.11+cu130, torchcodec not installed).

**Already fixed in:** `python/ai/forced_align._load_audio_mono_16k` (PR #142) and `scripts/validate_acoustic_alignment._slice_audio` (PR #156). Documented here as a warning: **do not add new calls to `torchaudio.load()` in this codebase** — always use `soundfile.read()` + manual tensor conversion.

---

## Confirmed working result (from PR #156 run)

On the 16-segment / 506-word repo coarse_transcripts, the full forced-align pipeline completed without batching:

| Metric | Before | After |
|--------|:------:|:-----:|
| IPA intervals | 131 (coarse ORTH) | **449** (word-level) |
| Filled | ~117 | **364** |
| Word-level < 2s | 0 | **415** |

The 154-segment workspace run is expected to produce ~1 400–1 800 word-level intervals once the batching fix lands and WSL no longer crashes.

## Test plan
- [ ] Trigger `POST /api/compute/ipa_only {"speaker":"Fail02","overwrite":true}` after cycling WSL with the batching fix — confirm no WSL crash and workspace annotation is written
- [ ] Confirm interval count is >449 (full workspace has ~7× more segments than repo coarse_transcripts)
- [ ] Identify the process switching git branches (check `hermes-parse-builder` skill code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)