### PR TITLE
fix(ipa): skip GPU kernel when targets > log_probs; empty_cache every 50 words

### DIFF
--- a/python/ai/forced_align.py
+++ b/python/ai/forced_align.py
@@ -263,6 +263,11 @@ class Aligner:
             log_probs = torch.log_softmax(logits, dim=-1)
 
         targets = torch.tensor([target_ids], dtype=torch.int32, device=self.device)
+        # CTC requires log_probs_len >= targets_len + blank_frames. Skip the
+        # GPU kernel entirely when this can't hold — it would throw a CUDA
+        # error that destabilises the driver even though Python catches it.
+        if log_probs.shape[1] < targets.shape[1]:
+            return None
         try:
             alignments, scores = AF.forced_align(
                 log_probs,

--- a/python/ai/ipa_transcribe.py
+++ b/python/ai/ipa_transcribe.py
@@ -219,6 +219,15 @@ def transcribe_words_with_forced_align(
     for idx, spec in enumerate(word_intervals):
         ipa = transcribe_slice(audio, spec.start, spec.end, local_aligner)
         out.append({"start": spec.start, "end": spec.end, "ipa": ipa})
+        # Release cached GPU allocations every 50 words to prevent VRAM
+        # accumulation across thousands of short inference calls.
+        if idx % 50 == 49:
+            try:
+                import torch
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except Exception:
+                pass
         if progress_callback is not None:
             try:
                 progress_callback((idx + 1) / float(total) * 100.0, idx + 1)


### PR DESCRIPTION
## Summary
Two root causes of WSL `E_UNEXPECTED` crash during large IPA runs (Fail02, 3507 words):

- **`forced_align.py`**: The CTC CUDA kernel was called even when `targets_len > log_probs_len`, which is guaranteed to fail. Python catches the exception, but repeated GPU kernel errors destabilise the driver. Added a pre-check that returns `None` immediately instead of hitting the GPU.
- **`ipa_transcribe.py`**: Tier 3 loop runs `transcribe_slice` for every word (~3500) with no GPU memory release. Added `torch.cuda.empty_cache()` every 50 words to keep peak VRAM bounded.

## Test plan
- [ ] Merge and pull on PC, restart PM2
- [ ] Re-trigger IPA for Fail02 — should complete without WSL crash
- [ ] Confirm no `[WARN] forced_align failed` lines in `pm2 logs` (pre-check silently skips instead)
- [ ] Confirm word-level IPA intervals appear in PARSE UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)