### PR TITLE
fix(ipa): stricter CTC pre-check; empty_cache after Tier 2 batches; batch_size 5

### DIFF
--- a/python/ai/forced_align.py
+++ b/python/ai/forced_align.py
@@ -263,10 +263,11 @@ class Aligner:
             log_probs = torch.log_softmax(logits, dim=-1)
 
         targets = torch.tensor([target_ids], dtype=torch.int32, device=self.device)
-        # CTC requires log_probs_len >= targets_len + blank_frames. Skip the
-        # GPU kernel entirely when this can't hold — it would throw a CUDA
-        # error that destabilises the driver even though Python catches it.
-        if log_probs.shape[1] < targets.shape[1]:
+        # CTC requires log_probs_len >= targets_len + repeat_blanks. Use a
+        # 4-frame buffer to cover near-miss cases where repeats in the phoneme
+        # sequence would still violate the constraint. Hitting the kernel with
+        # bad inputs causes CUDA errors that destabilise the WSL GPU driver.
+        if log_probs.shape[1] < targets.shape[1] + 4:
             return None
         try:
             alignments, scores = AF.forced_align(

--- a/python/ai/ipa_transcribe.py
+++ b/python/ai/ipa_transcribe.py
@@ -149,7 +149,7 @@ def transcribe_words_with_forced_align(
     pad_ms: int = DEFAULT_PAD_MS,
     aligner: Optional[Aligner] = None,
     progress_callback: Optional[Any] = None,
-    segment_batch_size: int = 20,
+    segment_batch_size: int = 5,
 ) -> List[IpaResult]:
     """Full 3-tier IPA: G2P + torchaudio forced alignment → word windows → wav2vec2 CTC.
 
@@ -201,6 +201,12 @@ def transcribe_words_with_forced_align(
                 e = float(word.get("end", 0.0) or 0.0)
                 if e > s:
                     word_intervals.append(IntervalSpec(start=s, end=e))
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            pass
 
     if not word_intervals:
         # No words produced — fall back to segment-level coarse transcription


### PR DESCRIPTION
## Summary
Follow-up to PR #161 — WSL still crashed from near-miss CTC kernel calls and accumulated Tier 2 GPU memory.

- **`forced_align.py`**: Widen pre-check from `< targets` to `< targets + 4`. Near-miss cases (`log_probs == targets + 1` with ≥1 repeat) still hit the GPU kernel and crash it. A 4-frame buffer covers all practically observed repeat counts.
- **`ipa_transcribe.py`**: Add `torch.cuda.empty_cache()` after each Tier 2 segment batch, not just in the Tier 3 loop.
- **`ipa_transcribe.py`**: Lower default `segment_batch_size` from 20 → 5 to reduce peak VRAM per batch on large speakers (154 segments).

## Test plan
- [ ] Merge, pull on PC, restart PM2
- [ ] Re-trigger IPA for Fail02 — zero `[WARN] forced_align failed` lines in logs
- [ ] Job completes without WSL crash
- [ ] Word-level IPA intervals visible in PARSE UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)