### PR TITLE
fix(ipa): force CPU on WSL; add force_cpu toggle in ai_config.json

### DIFF
--- a/config/ai_config.example.json
+++ b/config/ai_config.example.json
@@ -49,6 +49,7 @@
   "wav2vec2": {
     "provider": "wav2vec2-ipa",
     "model": "facebook/wav2vec2-xlsr-53-espeak-cv-ft",
-    "device": "cuda"
+    "device": "cuda",
+    "force_cpu": false
   }
 }

--- a/python/ai/forced_align.py
+++ b/python/ai/forced_align.py
@@ -30,10 +30,36 @@ from __future__ import annotations
 
 import argparse
 import json
+import platform
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypedDict
+
+
+def _is_wsl() -> bool:
+    """Return True when running inside WSL (Windows Subsystem for Linux)."""
+    release = platform.uname().release.lower()
+    return "microsoft" in release or "wsl" in release
+
+
+def resolve_device(requested: Optional[str] = None) -> str:
+    """Resolve compute device, forcing CPU on WSL to avoid GPU driver crashes.
+
+    WSL2 GPU passthrough is unstable for sustained CTC workloads on RTX 5090
+    (Blackwell/sm_120): repeated kernel errors from bad CTC inputs destabilise
+    the Hyper-V VM host and crash WSL with E_UNEXPECTED. CPU is slower but
+    completes reliably. Pass requested="cuda" to override when needed.
+    """
+    if requested == "cpu":
+        return "cpu"
+    if requested != "cuda" and _is_wsl():
+        return "cpu"
+    try:
+        import torch  # type: ignore
+        return requested or ("cuda" if torch.cuda.is_available() else "cpu")
+    except ImportError:
+        return "cpu"
 
 try:
     from .provider import SegmentWithWords, WordSpan
@@ -129,7 +155,7 @@ class Aligner:
                 "Install: pip install torch torchaudio transformers"
             ) from exc
 
-        resolved_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        resolved_device = resolve_device(device)
 
         # Explicit tokenizer + feature_extractor load. If this path
         # raises, fall back to the legacy auto-dispatch as a last resort

--- a/python/server.py
+++ b/python/server.py
@@ -3137,9 +3137,22 @@ def _get_ipa_aligner() -> Any:
         file=sys.stderr,
         flush=True,
     )
+    # Honour wav2vec2.force_cpu from ai_config.json, or auto-detect via
+    # resolve_device() which forces CPU on WSL to avoid GPU driver crashes.
+    try:
+        import json as _json
+        _ai_cfg = _json.loads((_project_root() / "config" / "ai_config.json").read_text())
+        _w2v = _ai_cfg.get("wav2vec2", {})
+        if _w2v.get("force_cpu"):
+            _ipa_device: Optional[str] = "cpu"
+        else:
+            _ipa_device = _w2v.get("device") or None
+    except Exception:
+        _ipa_device = None
+
     try:
         _compute_checkpoint("ALIGNER.load_begin")
-        _IPA_ALIGNER = Aligner.load()
+        _IPA_ALIGNER = Aligner.load(device=_ipa_device)
         _compute_checkpoint("ALIGNER.load_done", elapsed=round(_time.time() - t0, 2))
     except Exception as exc:
         elapsed = _time.time() - t0


### PR DESCRIPTION
## Summary
WSL2 GPU passthrough crashes (`E_UNEXPECTED`) under sustained CTC workloads on RTX 5090/Blackwell. Repeated CUDA kernel errors from bad `forced_align` inputs destabilise the Hyper-V VM host even when Python catches each exception. CPU is slower but completes reliably.

- **`forced_align.py`**: Added `_is_wsl()` (checks `platform.uname().release` for `microsoft`/`wsl`) and `resolve_device()`. On WSL, `resolve_device()` returns `"cpu"` by default — override with explicit `device="cuda"` if needed. `Aligner.load()` now calls `resolve_device()` instead of the inline ternary.
- **`server.py`**: `_get_ipa_aligner()` reads `wav2vec2.device` and `wav2vec2.force_cpu` from `ai_config.json` and passes the resolved device to `Aligner.load()`.
- **`ai_config.example.json`**: Documents the new `force_cpu` field.

## Toggle (no code change needed)
```json
"wav2vec2": { "force_cpu": true }
```
Restart server — aligner loads on CPU. Remove or set `false` to revert to auto-detect (still CPU on WSL, CUDA elsewhere).

## Test plan
- [ ] Merge, pull on PC, restart PM2
- [ ] Confirm logs show `device=cpu` in `[IPA] Aligner ready`
- [ ] Re-trigger IPA for Fail02 — job completes without WSL crash
- [ ] Word-level IPA intervals visible in PARSE UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)