### PR TITLE
fix: prevent thread exhaustion during long CPU IPA jobs

### DIFF
--- a/deploy/pm2-ecosystem.config.cjs
+++ b/deploy/pm2-ecosystem.config.cjs
@@ -32,6 +32,11 @@ module.exports = {
       env: {
         PARSE_WORKSPACE_ROOT: "/home/lucas/parse-workspace",
         PARSE_AI_CONFIG: "/home/lucas/parse-workspace/config/ai_config.json",
+        OMP_NUM_THREADS: "1",
+        MKL_NUM_THREADS: "1",
+        OPENBLAS_NUM_THREADS: "1",
+        VECLIB_MAXIMUM_THREADS: "1",
+        NUMEXPR_NUM_THREADS: "1",
       },
     },
   ],

--- a/python/server.py
+++ b/python/server.py
@@ -6526,6 +6526,7 @@ def main() -> None:
 
     server_address = (HOST, PORT)
     httpd = http.server.ThreadingHTTPServer(server_address, RangeRequestHandler)
+    httpd.daemon_threads = True
     local_ips = _get_local_ips()
 
     for line in _startup_banner_lines(serve_dir, local_ips):


### PR DESCRIPTION
## Summary
- `daemon_threads = True` on `ThreadingHTTPServer` so finished request threads are reaped; status polls every 2s during a multi-minute IPA job were accumulating 35+ live threads
- Added `OMP_NUM_THREADS=1`, `MKL_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`, `VECLIB_MAXIMUM_THREADS=1`, `NUMEXPR_NUM_THREADS=1` to PM2 env so native BLAS/OpenMP pools are capped before Python starts

## Root cause
`ThreadingHTTPServer` spawns one OS thread per request and never reaps them until the main thread exits. A CPU IPA job for Fail02 (~65 min, 3507 words) with 2-second status polls creates 35+ threads in the first minute; combined with PyTorch's CPU inter-op/intra-op workers this eventually exhausts the OS thread limit → `RuntimeError: can't start new thread`.

## Test plan
- [ ] Merge, pull on PC, `pm2 restart parse-api`
- [ ] Trigger IPA for Fail02; monitor with `pm2 logs parse-api`
- [ ] Verify job runs to completion and word-level IPA intervals appear in PARSE UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)