### PR TITLE
fix: WSL always forces CPU even when config sets device=cuda

### DIFF
--- a/python/ai/forced_align.py
+++ b/python/ai/forced_align.py
@@ -49,11 +49,11 @@ def resolve_device(requested: Optional[str] = None) -> str:
     WSL2 GPU passthrough is unstable for sustained CTC workloads on RTX 5090
     (Blackwell/sm_120): repeated kernel errors from bad CTC inputs destabilise
     the Hyper-V VM host and crash WSL with E_UNEXPECTED. CPU is slower but
-    completes reliably. Pass requested="cuda" to override when needed.
+    completes reliably. WSL always wins — even if config says "cuda".
     """
     if requested == "cpu":
         return "cpu"
-    if requested != "cuda" and _is_wsl():
+    if _is_wsl():
         return "cpu"
     try:
         import torch  # type: ignore


### PR DESCRIPTION
## Summary
- `resolve_device()` had `requested != "cuda" and _is_wsl()` — if `ai_config.json` sets `"device": "cuda"`, the WSL guard was bypassed and GPU CTC ran, crashing WSL with `E_UNEXPECTED`
- Removed the `requested != "cuda"` condition: on WSL, CPU is always returned regardless of config

## Root cause
The guard was meant to allow explicit `requested="cuda"` to bypass WSL protection, but the live `ai_config.json` always passes `"cuda"`, so the protection never fired. Every IPA run was going to GPU on WSL.

## Test plan
- [ ] Merge, pull on PC, restart WSL + `pm2 restart parse-api`
- [ ] Trigger IPA for Fail02; verify `[COMPUTE] WSL detected` log line and no `E_UNEXPECTED` crash
- [ ] Confirm word-level IPA intervals appear in PARSE UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)