### PR TITLE
fix: replace ThreadingHTTPServer with bounded 4-worker pool

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -6481,6 +6481,37 @@ def _startup_banner_lines(
     return lines
 
 
+class _BoundedThreadHTTPServer(http.server.HTTPServer):
+    """HTTP server backed by a fixed-size thread pool.
+
+    ThreadingHTTPServer spawns one OS thread per request. Under sustained
+    CPU IPA loads with 2-second status polls this creates hundreds of
+    threads and eventually hits a resource limit in WSL2. A bounded pool
+    of 4 workers caps OS thread creation: the same threads are reused for
+    every request, so the count never grows beyond max_workers.
+    """
+
+    def __init__(self, server_address, RequestHandlerClass, max_workers: int = 4):
+        import concurrent.futures
+        super().__init__(server_address, RequestHandlerClass)
+        self._pool = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+
+    def process_request(self, request, client_address):
+        self._pool.submit(self._handle_in_pool, request, client_address)
+
+    def _handle_in_pool(self, request, client_address):
+        try:
+            self.finish_request(request, client_address)
+        except Exception:
+            self.handle_error(request, client_address)
+        finally:
+            self.shutdown_request(request)
+
+    def server_close(self):
+        super().server_close()
+        self._pool.shutdown(wait=False)
+
+
 def main() -> None:
     import argparse as _argparse
     parser = _argparse.ArgumentParser(description="PARSE HTTP server")
@@ -6525,8 +6556,7 @@ def main() -> None:
     os.chdir(serve_dir)
 
     server_address = (HOST, PORT)
-    httpd = http.server.ThreadingHTTPServer(server_address, RangeRequestHandler)
-    httpd.daemon_threads = True
+    httpd = _BoundedThreadHTTPServer(server_address, RangeRequestHandler)
     local_ips = _get_local_ips()
 
     for line in _startup_banner_lines(serve_dir, local_ips):


### PR DESCRIPTION
## Summary
- Replaces `ThreadingHTTPServer` (one new OS thread per request) with `_BoundedThreadHTTPServer` — a fixed `ThreadPoolExecutor(max_workers=4)` so the same 4 threads handle all HTTP requests forever
- Thread count stays constant at 4 regardless of how long the IPA job runs or how many status polls arrive

## Root cause
After the daemon_threads fix (PR #167), the server was still creating a new OS thread per request. Over 4+ minutes of 2-second status polls (~180 requests) something in the WSL2 VM hit a resource wall and the server raised `RuntimeError: can't start new thread` → 500 to client → WSL E_UNEXPECTED crash shortly after.

The OS `threads-max` is 224,506, so it's not the kernel limit — likely per-process stack memory or WSL VM resource exhaustion from creating/tearing down hundreds of thread stacks while PyTorch also holds internal thread pool state.

## Test plan
- [ ] Merge, pull on PC, `pm2 restart parse-api`
- [ ] Trigger IPA for Fail02, monitor `pm2 logs parse-api` — expect steady 200s for the full run (30-60 min on CPU)
- [ ] Confirm word-level IPA intervals appear in PARSE UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)