### PR TITLE
fix: force CPU for all ML (STT/ORTH) via PM2 env

### DIFF
--- a/deploy/pm2-ecosystem.config.cjs
+++ b/deploy/pm2-ecosystem.config.cjs
@@ -37,6 +37,11 @@ module.exports = {
         OPENBLAS_NUM_THREADS: "1",
         VECLIB_MAXIMUM_THREADS: "1",
         NUMEXPR_NUM_THREADS: "1",
+        // WSL2 GPU passthrough crashes the VM under sustained ML workloads,
+        // even on Whisper STT/ORTH (not just wav2vec2). Force everything
+        // to CPU until the WSL/dxg stability issue is resolved.
+        PARSE_STT_FORCE_CPU: "1",
+        CUDA_VISIBLE_DEVICES: "",
       },
     },
   ],


### PR DESCRIPTION
## Summary
- Add \`PARSE_STT_FORCE_CPU=1\` (existing escape hatch that already forces faster-whisper CPU path for both STT and ORTH)
- Add \`CUDA_VISIBLE_DEVICES=\"\"\` so no PyTorch process can see the GPU at all

## Root cause
STT+ORTH jobs crashed WSL with E_UNEXPECTED after ~3-7 min of sustained load (same signature as IPA crashes). ai_config.json sets \`device: cuda\` for stt/ortho and \`LocalWhisperProvider\` uses that by default. WSL2 GPU passthrough (dxg driver) is unstable for sustained ML workloads on this RTX 5090 / Blackwell setup regardless of which model hits the GPU.

Bumping .wslconfig memory to 48GB didn't help — the crash is a Hyper-V / GPU driver issue, not OOM.

## Test plan
- [ ] Merge, pull on PC, \`pm2 restart parse-api\`
- [ ] Confirm \`[WARN] PARSE_STT_FORCE_CPU set; overriding stt.device 'cuda' → 'cpu'\` log line
- [ ] Run STT+ORTH across all 10 speakers, expect slow but crash-free