### PR TITLE
feat(api): GET /api/worker/status health check

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -4568,6 +4568,10 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             self._api_auth_status()
             return
 
+        if request_path == "/api/worker/status":
+            self._api_get_worker_status()
+            return
+
         if request_path == "/api/export/lingpy":
             self._api_get_export_lingpy()
             return
@@ -5312,6 +5316,43 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         """Return a list of currently-running jobs so the UI can rehydrate
         progress after a page reload. See ``_list_active_jobs_snapshots``."""
         self._send_json(HTTPStatus.OK, {"jobs": _list_active_jobs_snapshots()})
+
+    def _api_get_worker_status(self) -> None:
+        """Health check for the persistent compute worker.
+
+        Returns 200 with ``{mode, alive, pid, jobs_in_flight}`` when the
+        worker is healthy (persistent mode + process alive) or when
+        persistent mode is not active (thread/subprocess modes always
+        report ``alive: null`` since there is no long-lived worker to
+        probe). Returns 503 when persistent mode is active but the
+        worker has exited — suitable for an external monitor (PM2,
+        uptime-robot, Grafana) to trigger a restart.
+        """
+        mode = _resolve_compute_mode()
+        payload: Dict[str, Any] = {"mode": mode}
+
+        if mode != "persistent":
+            payload["alive"] = None
+            payload["message"] = "Persistent worker mode is not active"
+            self._send_json(HTTPStatus.OK, payload)
+            return
+
+        handle = _PERSISTENT_WORKER_HANDLE
+        if handle is None:
+            payload["alive"] = False
+            payload["message"] = "Persistent worker handle not initialised"
+            self._send_json(HTTPStatus.SERVICE_UNAVAILABLE, payload)
+            return
+
+        alive = handle.is_alive()
+        payload["alive"] = alive
+        payload["pid"] = handle.process_pid()
+        payload["jobs_in_flight"] = handle.in_flight_count()
+        if alive:
+            self._send_json(HTTPStatus.OK, payload)
+            return
+        payload["message"] = "Persistent worker process has exited"
+        self._send_json(HTTPStatus.SERVICE_UNAVAILABLE, payload)
 
     def _api_post_stt_start(self) -> None:
         body = self._expect_object(self._read_json_body(), "Request body")

--- a/python/workers/compute_worker.py
+++ b/python/workers/compute_worker.py
@@ -151,6 +151,16 @@ class WorkerHandle:
     def is_alive(self) -> bool:
         return bool(self._process is not None and self._process.is_alive())
 
+    def process_pid(self) -> Optional[int]:
+        if self._process is None:
+            return None
+        return self._process.pid
+
+    def in_flight_count(self) -> int:
+        """Number of jobs submitted to the worker that have not yet emitted
+        a terminal (complete/error) event. Cheap — plain ``len`` on a dict."""
+        return len(self._in_flight)
+
     # -- event-pump -----------------------------------------------------
 
     def _monitor_loop(self) -> None:


### PR DESCRIPTION
## Summary

Follow-up to the reviewer notes on #171. Adds a simple HTTP health-check endpoint for the persistent compute worker, suitable for external monitors (PM2, uptime-robot, Grafana) to detect a crashed worker and trigger a restart.

**Stacked on #171** — base branch is \`feat/train-ipa-stub\`. Once #171 merges, GitHub auto-rebases the base of this PR to \`main\`.

## Endpoint

\`GET /api/worker/status\`

| state | HTTP | body |
|---|---|---|
| persistent mode, worker alive | 200 | \`{mode:"persistent", alive:true, pid:<int>, jobs_in_flight:<int>}\` |
| persistent mode, worker dead | 503 | \`{mode:"persistent", alive:false, pid:<int>, jobs_in_flight:<int>, message}\` |
| thread / subprocess mode | 200 | \`{mode:"thread"|"subprocess", alive:null, message}\` |

Non-persistent modes return 200 with \`alive:null\` because there is no long-lived worker to probe — the server's own liveness implies health for those modes.

## Internals

Two new accessors on \`WorkerHandle\`:

- \`process_pid()\` — returns the child's OS pid (\`None\` if not started).
- \`in_flight_count()\` — \`len(self._in_flight)\`; jobs submitted but not yet ack'd with a terminal event.

Both are cheap and thread-safe-enough (dict len read is atomic under the GIL). The in-flight count is a hint, not an authoritative count — events can race with submission — but it's accurate within a progress tick.

## Test plan

- [ ] \`curl http://127.0.0.1:8766/api/worker/status\` on a thread-mode server returns 200 with \`mode:"thread", alive:null\`.
- [ ] Same on a persistent-mode server with no jobs: 200 \`{mode:"persistent", alive:true, pid:<n>, jobs_in_flight:0}\`.
- [ ] Kill the worker process (\`kill \$(jq .pid < <(curl .../api/worker/status))\`), re-poll: 503 with \`alive:false\`.
- [ ] Submit a long IPA job, poll while running: \`jobs_in_flight: 1\`; after complete: \`0\`.

## Rollback

Two-line revert — the route dispatch and the handler are self-contained. \`WorkerHandle\` accessors are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)