### PR TITLE
fix(ipa): cache EspeakBackend + report Tier 2 progress

### DIFF
--- a/python/ai/forced_align.py
+++ b/python/ai/forced_align.py
@@ -33,6 +33,7 @@ import json
 import platform
 import sys
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypedDict
 
@@ -375,6 +376,38 @@ _PRELOADED_ALIGNER: Optional["Aligner"] = None
 # ---------------------------------------------------------------------------
 
 
+@lru_cache(maxsize=4)
+def _get_espeak_backend(language: str) -> Optional[Any]:
+    """Memoized ``EspeakBackend`` factory — one instance per language.
+
+    ``EspeakBackend.__init__`` loads libespeak-ng via ctypes and calls
+    ``espeak_Initialize()``. That's cheap on the first call but leaks
+    process state and thread handles when repeated thousands of times
+    per speaker (the Tier 2 forced-align path calls ``_g2p_word`` once
+    per word). On Fail02 (2026-04-24) the uncached path produced
+    ~800 MB/min memory growth and ``bash: fork: Resource temporarily
+    unavailable`` before WSL crashed with E_UNEXPECTED. Caching the
+    backend collapses thousands of loads to one.
+
+    Returns ``None`` when phonemizer is unavailable or the language
+    voice is missing — callers treat that as "G2P unavailable, fall
+    back to proportional alignment." Failures are cached too, which is
+    desirable: we don't want to retry an unresolvable voice 3,300 times.
+    """
+    try:
+        from phonemizer.backend import EspeakBackend  # type: ignore
+    except ImportError:
+        return None
+    try:
+        return EspeakBackend(
+            language,
+            preserve_punctuation=False,
+            with_stress=True,
+        )
+    except Exception:
+        return None
+
+
 def _g2p_word(word: str, language: str = DEFAULT_G2P_LANGUAGE) -> List[str]:
     """Convert a single orthographic word to a list of IPA phoneme tokens.
 
@@ -384,19 +417,9 @@ def _g2p_word(word: str, language: str = DEFAULT_G2P_LANGUAGE) -> List[str]:
     Returns an empty list when phonemizer is unavailable so the caller can
     fall back to proportional subdivision.
     """
-    try:
-        from phonemizer.backend import EspeakBackend  # type: ignore
-    except ImportError:
-        return []
-
     for lang in (language, FALLBACK_G2P_LANGUAGE):
-        try:
-            backend = EspeakBackend(
-                lang,
-                preserve_punctuation=False,
-                with_stress=True,
-            )
-        except Exception:
+        backend = _get_espeak_backend(lang)
+        if backend is None:
             continue
         try:
             phonemised = backend.phonemize([word], strip=True)

--- a/python/ai/ipa_transcribe.py
+++ b/python/ai/ipa_transcribe.py
@@ -22,6 +22,7 @@ Library API:
 from __future__ import annotations
 
 import argparse
+import gc
 import json
 import sys
 from dataclasses import dataclass
@@ -185,7 +186,13 @@ def transcribe_words_with_forced_align(
     seg_list = list(segments)
     word_intervals: List[IntervalSpec] = []
 
-    # Tier 2: forced alignment in batches to bound peak GPU memory
+    # Tier 2: forced alignment in batches to bound peak GPU memory.
+    # Report progress after each batch so long Tier 2 runs (Fail02-scale
+    # speakers can be minutes per batch on CPU) don't look stuck at 0%.
+    # Tier 2 occupies the 0-50% range; Tier 3 picks up at 50%.
+    tier2_total_words = sum(len(s.get("words") or []) for s in seg_list)
+    tier2_words_done = 0
+
     for batch_start in range(0, len(seg_list), segment_batch_size):
         batch = seg_list[batch_start: batch_start + segment_batch_size]
         aligned_batch = _align_segments(
@@ -202,12 +209,27 @@ def transcribe_words_with_forced_align(
                 e = float(word.get("end", 0.0) or 0.0)
                 if e > s:
                     word_intervals.append(IntervalSpec(start=s, end=e))
+        # Count every word in the batch (aligned or not) so the progress
+        # counter advances monotonically even when some words fall through
+        # to proportional fallback.
+        tier2_words_done += sum(len(s.get("words") or []) for s in batch)
+        if progress_callback is not None:
+            try:
+                pct = (tier2_words_done / float(max(1, tier2_total_words))) * 50.0
+                progress_callback(pct, tier2_words_done)
+            except Exception:
+                pass
         try:
             import torch
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
         except Exception:
             pass
+        # Force a GC cycle between batches to reclaim the Tier 2 tensors
+        # (CTC logits, forced_align outputs, phonemizer temporaries).
+        # Python's generational GC lags significantly inside a tight
+        # tensor loop, compounding the memory pressure seen on Fail02.
+        gc.collect()
 
     if not word_intervals:
         # No words produced — fall back to segment-level coarse transcription
@@ -244,7 +266,9 @@ def transcribe_words_with_forced_align(
             out.append({"start": spec.start, "end": spec.end, "ipa": ipa})
             if progress_callback is not None:
                 try:
-                    progress_callback((global_idx + 1) / float(total) * 100.0, global_idx + 1)
+                    # Tier 3 occupies the 50-100% range (Tier 2 took 0-50%).
+                    pct = 50.0 + (global_idx + 1) / float(total) * 50.0
+                    progress_callback(pct, global_idx + 1)
                 except Exception:
                     pass
         _gpu_cleanup()


### PR DESCRIPTION
## Summary

Two targeted fixes for the Fail02 failure mode observed during PR #171/#173 validation on 2026-04-24. Memory climbed ~800 MB/min while progress stayed at 0.0%, then bash hit \`fork: Resource temporarily unavailable\` and WSL crashed with \`Wsl/Service/E_UNEXPECTED\`.

### 1. Cache \`EspeakBackend\` per language

[\`python/ai/forced_align.py\`](python/ai/forced_align.py) — \`_g2p_word\` previously instantiated a fresh \`EspeakBackend(lang, ...)\` on every call. For Fail02 that's ~3,300 constructions per run. Each constructor loads \`libespeak-ng\` via ctypes + calls \`espeak_Initialize()\`, leaking process state and thread handles that Python's GC doesn't reclaim fast enough inside the tight Tier 2 loop.

Fix: \`functools.lru_cache(maxsize=4)\` on a new \`_get_espeak_backend(language)\` helper. One instance per language, reused across all ~3,300 word calls. Phonemizer itself designed \`EspeakBackend\` for reuse — the old pattern was just expensive. Failures (import error, missing voice) are cached as \`None\` too, so an unresolvable voice doesn't retry thousands of times.

**Expected impact on Fail02:** memory growth should flatten to near-steady-state, and \`fork: Resource temporarily unavailable\` should not recur.

### 2. Report progress during Tier 2 (previously silent)

[\`python/ai/ipa_transcribe.py\`](python/ai/ipa_transcribe.py) — \`transcribe_words_with_forced_align\` has two phases:

- **Tier 2**: forced alignment in batches of \`segment_batch_size=5\` segments.
- **Tier 3**: wav2vec2 CTC greedy decode on each aligned word window, in chunks of 150.

The old code only called \`progress_callback\` in Tier 3. Fail02's Tier 2 phase alone is roughly 7 min on CPU — the UI showed \`0.0%\` the whole time, and there was no way to tell progress from wedge.

Fix: split the progress band 0–50% (Tier 2) / 50–100% (Tier 3) and invoke \`progress_callback\` after each Tier 2 batch. For Fail02 with ~280 segments → 56 batches → a tick every ~8 s.

### Bonus: \`gc.collect()\` between Tier 2 batches

Python's generational GC lags inside tight tensor loops. An explicit \`gc.collect()\` after each batch reclaims the CTC logits + forced_align outputs + phonemizer temporaries before peak memory keeps climbing. Cheap (~5 ms), belt-and-braces alongside the existing \`torch.cuda.empty_cache()\`.

## Test plan

- [x] \`python -m pytest ai/test_forced_align.py ai/test_ipa_transcribe_acoustic.py\` — 17/17 pass (tests monkeypatch \`_g2p_word\` directly and are unaffected).
- [x] \`python -m pytest test_compute_speaker_ipa.py test_compute_speaker_ortho.py\` — all pass.
- [ ] **PC acid test**: re-run Fail02 on WSL. Expected: progress ticks at ~8 s intervals during Tier 2 (0-50%) then ~seconds during Tier 3 (50-100%). Memory should NOT climb to 10 GB+ this time.
- [ ] If a WSL crash still occurs: the phonemizer hypothesis was incomplete, and we'll need to capture the Windows Event Viewer entry to identify the actual driver/kernel fault.

## Rollback

Pure additive in \`forced_align.py\` (cached helper + simplified \`_g2p_word\`). \`ipa_transcribe.py\` changes are additive progress reporting + one \`gc.collect()\`. Either file can be reverted independently.

## Notes

Pre-existing broken test on main: \`ai/test_acoustic_alignment_mcp_tools.py::test_forced_align_start_live_dispatches_forced_align_compute\`. Expected payload drifted from reality (missing \`overwrite\`, \`language\`, \`padMs\`, \`emitPhonemes\` keys). Not caused by this PR — reproduces on \`main\` @ a7782af. Worth a separate trivial cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)