### PR TITLE
feat(compute): STT/ORTH share the persistent worker + preloaded models

### DIFF
--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -1133,6 +1133,16 @@ class LocalWhisperProvider(AIProvider):
         self._effective_device: Optional[str] = None
         self._effective_compute_type: Optional[str] = None
 
+    def warm_up(self) -> None:
+        """Force the faster-whisper model to load now.
+
+        Call once at persistent-worker startup so the first
+        ``transcribe()`` call doesn't pay the ~1-5 s cold-load cost.
+        Safe to call from non-worker contexts — just an eager version
+        of the normal lazy load.
+        """
+        self._load_whisper_model()
+
     def _load_whisper_model(self) -> Any:
         """Lazy-load faster-whisper model.
 
@@ -1642,12 +1652,78 @@ def _resolve_provider_name(
     return default
 
 
-def get_stt_provider(config: Optional[Dict[str, Any]] = None) -> AIProvider:
-    """Factory for STT providers resolved from `stt.provider`."""
+# Persistent-worker preload cache. Set by ``preload_stt_provider`` /
+# ``preload_ortho_provider`` (called once at worker startup) so the
+# factory getters below skip the model build when no custom config is
+# requested. Non-worker callers never touch these globals — the cache
+# stays None and the factories behave as before.
+_PRELOADED_STT_PROVIDER: Optional[AIProvider] = None
+_PRELOADED_ORTHO_PROVIDER: Optional[AIProvider] = None
+
+
+def preload_stt_provider(config: Optional[Dict[str, Any]] = None) -> Optional[AIProvider]:
+    """Build the STT provider, warm its Whisper model, and cache it.
+
+    Returns the cached instance, or ``None`` if anything fails (missing
+    model, CUDA runtime error, etc.). Worker startup calls this; a
+    failure is non-fatal — the factory still works on-demand.
+    """
+    global _PRELOADED_STT_PROVIDER
+    try:
+        provider = _build_stt_provider(config)
+        if isinstance(provider, LocalWhisperProvider):
+            provider.warm_up()
+        _PRELOADED_STT_PROVIDER = provider
+        return provider
+    except Exception as exc:
+        print(
+            "[provider] STT preload failed: {0}".format(exc),
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+
+
+def preload_ortho_provider(config: Optional[Dict[str, Any]] = None) -> Optional[AIProvider]:
+    """Build the ORTH provider, warm its Whisper model, and cache it."""
+    global _PRELOADED_ORTHO_PROVIDER
+    try:
+        provider = _build_ortho_provider(config)
+        provider.warm_up()
+        _PRELOADED_ORTHO_PROVIDER = provider
+        return provider
+    except Exception as exc:
+        print(
+            "[provider] ORTH preload failed: {0}".format(exc),
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+
+
+def _build_stt_provider(config: Optional[Dict[str, Any]]) -> AIProvider:
     override = config or {}
     merged = _deep_merge_dicts(load_ai_config(), override)
     provider_name = _resolve_provider_name(merged, ["stt"], override_config=override)
     return _build_provider(provider_name, merged)
+
+
+def _build_ortho_provider(config: Optional[Dict[str, Any]]) -> LocalWhisperProvider:
+    override = config or {}
+    merged = _deep_merge_dicts(load_ai_config(), override)
+    return LocalWhisperProvider(config=merged, config_section="ortho")
+
+
+def get_stt_provider(config: Optional[Dict[str, Any]] = None) -> AIProvider:
+    """Factory for STT providers resolved from `stt.provider`.
+
+    Returns the preloaded singleton when available and the caller did
+    not pass a custom ``config`` override. Custom configs always get a
+    fresh build so tests and ad-hoc callers see the correct provider.
+    """
+    if _PRELOADED_STT_PROVIDER is not None and config is None:
+        return _PRELOADED_STT_PROVIDER
+    return _build_stt_provider(config)
 
 
 def get_ortho_provider(config: Optional[Dict[str, Any]] = None) -> AIProvider:
@@ -1657,10 +1733,13 @@ def get_ortho_provider(config: Optional[Dict[str, Any]] = None) -> AIProvider:
     distinct from whatever general-purpose model STT uses. This goes straight
     to ``LocalWhisperProvider`` with ``config_section="ortho"`` so
     model_path / device / language come from the ortho block rather than stt.
+
+    Returns the preloaded singleton when available and no custom
+    ``config`` was passed (see ``preload_ortho_provider``).
     """
-    override = config or {}
-    merged = _deep_merge_dicts(load_ai_config(), override)
-    return LocalWhisperProvider(config=merged, config_section="ortho")
+    if _PRELOADED_ORTHO_PROVIDER is not None and config is None:
+        return _PRELOADED_ORTHO_PROVIDER
+    return _build_ortho_provider(config)
 
 
 def get_llm_provider(config: Optional[Dict[str, Any]] = None) -> AIProvider:

--- a/python/server.py
+++ b/python/server.py
@@ -1671,12 +1671,10 @@ def _chat_start_stt_job(speaker: str, source_wav: str, language: Optional[str]) 
         },
     )
 
-    thread = threading.Thread(
-        target=_run_stt_job,
-        args=(job_id, speaker, source_wav, language),
-        daemon=True,
+    _launch_compute_runner(
+        job_id, "stt",
+        {"speaker": speaker, "sourceWav": source_wav, "language": language},
     )
-    thread.start()
 
     return job_id
 
@@ -1969,6 +1967,8 @@ def _compute_subprocess_entry(
             result = _server._compute_full_pipeline("child-{0}".format(job_id), payload)
         elif normalized_type in {"train_ipa_model", "train-ipa-model", "train_ipa"}:
             result = _server._compute_training_job("child-{0}".format(job_id), payload)
+        elif normalized_type == "stt":
+            result = _server._compute_stt("child-{0}".format(job_id), payload)
         else:
             raise RuntimeError("Unsupported compute type: {0}".format(normalized_type))
 
@@ -2649,72 +2649,98 @@ def _load_cached_suggestions(speaker: str, concept_ids: List[str]) -> List[Dict[
     return output
 
 
-def _run_stt_job(job_id: str, speaker: str, source_wav: str, language: Optional[str]) -> None:
+def _run_stt_job(
+    job_id: str, speaker: str, source_wav: str, language: Optional[str]
+) -> Dict[str, Any]:
+    """Run STT for ``speaker`` and return the result dict.
+
+    Raises on failure. Terminal job state (_set_job_complete /
+    _set_job_error) is now the dispatcher's responsibility — this
+    function only reports in-progress via _set_job_progress. That
+    lets the same function run cleanly under every compute mode
+    (thread, subprocess, persistent) via the unified compute
+    dispatcher, and also keeps direct callers like
+    ``_compute_full_pipeline`` simple (try/except + read return value).
+    """
+    audio_path = _resolve_project_path(source_wav)
+    if not audio_path.exists():
+        raise FileNotFoundError("Audio file not found: {0}".format(audio_path))
+
+    # NB: the frontend normalizes backend progress values >1 as "percent"
+    # and values in [0,1] as "fraction". Sending exactly 1.0 was
+    # interpreted as 100%, so the bar flashed full before decoding even
+    # started. Use 0.5 (half a percent) for the initial splash.
+    _set_job_progress(job_id, 0.5, message="Initializing STT provider ({0})".format(language or "auto"))
     try:
-        audio_path = _resolve_project_path(source_wav)
-        if not audio_path.exists():
-            raise FileNotFoundError("Audio file not found: {0}".format(audio_path))
+        provider = get_stt_provider()
+    except Exception as exc:
+        # Capture the full traceback so downstream users see *why* the
+        # provider failed to initialize (missing model, CUDA not available,
+        # bad config), not just the generic last-message banner.
+        import traceback
+        tb = traceback.format_exc()
+        print("[stt] get_stt_provider failed for speaker={0!r}: {1}".format(speaker, tb), file=sys.stderr, flush=True)
+        raise RuntimeError("STT provider init failed: {0}".format(exc)) from exc
 
-        # NB: the frontend normalizes backend progress values >1 as "percent"
-        # and values in [0,1] as "fraction". Sending exactly 1.0 was
-        # interpreted as 100%, so the bar flashed full before decoding even
-        # started. Use 0.5 (half a percent) for the initial splash.
-        _set_job_progress(job_id, 0.5, message="Initializing STT provider ({0})".format(language or "auto"))
-        try:
-            provider = get_stt_provider()
-        except Exception as exc:
-            # Capture the full traceback so downstream users see *why* the
-            # provider failed to initialize (missing model, CUDA not available,
-            # bad config), not just the generic last-message banner.
-            import traceback
-            tb = traceback.format_exc()
-            print("[stt] get_stt_provider failed for speaker={0!r}: {1}".format(speaker, tb), file=sys.stderr, flush=True)
-            raise RuntimeError("STT provider init failed: {0}".format(exc)) from exc
+    _set_job_progress(job_id, 2.0, message="Loading model")
 
-        _set_job_progress(job_id, 2.0, message="Loading model")
-
-        # faster-whisper emits segments whose `end` can equal `total_duration`
-        # on the very first yield (VAD fuses everything into one chunk for
-        # short clips). That makes the raw per-segment progress jump to 100%
-        # while decoding is still underway. Cap mid-job progress at 98% so
-        # only `_set_job_complete` actually fills the bar.
-        def _progress_callback(progress: float, segments_processed: int) -> None:
-            clamped = min(float(progress) if progress is not None else 0.0, 98.0)
-            _set_job_progress(
-                job_id,
-                max(2.0, clamped),
-                message="Transcribing ({0} segments)".format(segments_processed),
-                segments_processed=segments_processed,
-            )
-
-        try:
-            segments = provider.transcribe(
-                audio_path=audio_path,
-                language=language,
-                progress_callback=_progress_callback,
-            )
-        except Exception as exc:
-            import traceback
-            tb = traceback.format_exc()
-            print("[stt] transcribe failed for speaker={0!r} path={1!r}: {2}".format(speaker, str(audio_path), tb), file=sys.stderr, flush=True)
-            raise RuntimeError("STT transcription failed: {0}".format(exc)) from exc
-
-        result = {
-            "speaker": speaker,
-            "sourceWav": str(audio_path),
-            "language": language,
-            "segments": segments,
-        }
-        _write_stt_cache(speaker, str(audio_path), language, segments)
-        _set_job_complete(
+    # faster-whisper emits segments whose `end` can equal `total_duration`
+    # on the very first yield (VAD fuses everything into one chunk for
+    # short clips). That makes the raw per-segment progress jump to 100%
+    # while decoding is still underway. Cap mid-job progress at 98% so
+    # only the dispatcher's _set_job_complete actually fills the bar.
+    def _progress_callback(progress: float, segments_processed: int) -> None:
+        clamped = min(float(progress) if progress is not None else 0.0, 98.0)
+        _set_job_progress(
             job_id,
-            result,
-            message="STT complete — {0} segments".format(len(segments)),
-            segments_processed=len(segments),
-            total_segments=len(segments),
+            max(2.0, clamped),
+            message="Transcribing ({0} segments)".format(segments_processed),
+            segments_processed=segments_processed,
+        )
+
+    try:
+        segments = provider.transcribe(
+            audio_path=audio_path,
+            language=language,
+            progress_callback=_progress_callback,
         )
     except Exception as exc:
-        _set_job_error(job_id, str(exc))
+        import traceback
+        tb = traceback.format_exc()
+        print("[stt] transcribe failed for speaker={0!r} path={1!r}: {2}".format(speaker, str(audio_path), tb), file=sys.stderr, flush=True)
+        raise RuntimeError("STT transcription failed: {0}".format(exc)) from exc
+
+    result = {
+        "speaker": speaker,
+        "sourceWav": str(audio_path),
+        "language": language,
+        "segments": segments,
+    }
+    _write_stt_cache(speaker, str(audio_path), language, segments)
+    return result
+
+
+def _compute_stt(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute-dispatcher adapter for STT.
+
+    Unpacks the HTTP/chat payload into ``_run_stt_job``'s positional
+    signature. The dispatcher (or persistent worker) handles the
+    terminal _set_job_complete / _set_job_error — this wrapper only
+    translates payload shapes.
+    """
+    speaker = str(payload.get("speaker") or "").strip()
+    source_wav = str(
+        payload.get("sourceWav") or payload.get("source_wav") or ""
+    ).strip()
+    language_raw = payload.get("language")
+    language = str(language_raw).strip() if language_raw is not None else None
+    if not language:
+        language = None
+    if not speaker:
+        raise ValueError("stt payload missing 'speaker'")
+    if not source_wav:
+        raise ValueError("stt payload missing 'sourceWav'")
+    return _run_stt_job(job_id, speaker, source_wav, language)
 
 
 def _parse_concepts_csv(csv_path: pathlib.Path) -> List[Dict[str, str]]:
@@ -4215,19 +4241,18 @@ def _compute_full_pipeline(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
                     audio_path = _pipeline_audio_path_for_speaker(speaker)
                 except (RuntimeError, FileNotFoundError) as exc:
                     raise RuntimeError("Cannot run STT for {0!r}: {1}".format(speaker, exc))
-                _run_stt_job(job_id, speaker, str(audio_path), language_str)
-                snapshot = _get_job_snapshot(job_id) or {}
-                if str(snapshot.get("status") or "") == "error":
-                    raise RuntimeError(
-                        "stt step failed: {0}".format(snapshot.get("error") or "unknown error")
-                    )
-                sub_result = snapshot.get("result") if isinstance(snapshot.get("result"), dict) else {}
+                try:
+                    stt_result = _run_stt_job(job_id, speaker, str(audio_path), language_str)
+                except Exception as exc:
+                    raise RuntimeError("stt step failed: {0}".format(exc)) from exc
                 results["stt"] = {
                     "status": "ok",
-                    "segments": len(sub_result.get("segments") or []) if isinstance(sub_result, dict) else 0,
+                    "segments": len(stt_result.get("segments") or []),
                     "done": True,
                 }
-                _reset_job_to_running(job_id)
+                # _run_stt_job no longer calls _set_job_complete (dispatcher
+                # owns terminal state), so we don't need _reset_job_to_running
+                # before the next pipeline step.
                 steps_run.append(step)
 
             elif step == "ortho":
@@ -4389,6 +4414,8 @@ def _run_compute_job(job_id: str, compute_type: str, payload: Dict[str, Any]) ->
             result = _compute_full_pipeline(job_id, payload)
         elif normalized_type in {"train_ipa_model", "train-ipa-model", "train_ipa"}:
             result = _compute_training_job(job_id, payload)
+        elif normalized_type == "stt":
+            result = _compute_stt(job_id, payload)
         else:
             raise RuntimeError("Unsupported compute type: {0}".format(normalized_type))
 
@@ -5378,12 +5405,10 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             },
         )
 
-        thread = threading.Thread(
-            target=_run_stt_job,
-            args=(job_id, speaker, source_wav, language),
-            daemon=True,
+        _launch_compute_runner(
+            job_id, "stt",
+            {"speaker": speaker, "sourceWav": source_wav, "language": language},
         )
-        thread.start()
 
         self._send_json(
             HTTPStatus.OK,

--- a/python/test_run_stt_job.py
+++ b/python/test_run_stt_job.py
@@ -1,6 +1,15 @@
-"""Tests for _run_stt_job progress reporting and error wrapping."""
+"""Tests for _run_stt_job progress reporting and error wrapping.
+
+_run_stt_job returns the result dict on success and raises on failure;
+terminal job state (_set_job_complete / _set_job_error) is now the
+dispatcher's responsibility. These tests verify that contract + the
+in-progress behaviour (<1% initial splash, 98% mid-job cap, wrapped
+error messages).
+"""
 import pathlib
 import sys
+
+import pytest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import server
@@ -52,14 +61,16 @@ def test_initial_progress_is_well_below_one_percent(tmp_path, monkeypatch):
 
     monkeypatch.setattr(server, "_set_job_progress", spy)
 
-    # Provider that never calls the callback — so only the init splash shows.
     stub = _StubProvider(emit_progresses=[], emit_segments=[])
     job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
 
-    server._run_stt_job(job_id, "s", "t.wav", "ckb")
+    result = server._run_stt_job(job_id, "s", "t.wav", "ckb")
     assert captured_progress, "no progress updates emitted"
     assert captured_progress[0] < 1.0, captured_progress
-    assert server._jobs[job_id]["status"] == "complete"
+    # New contract: _run_stt_job returns the result dict; terminal state
+    # (status=complete, progress=100) is the dispatcher's responsibility.
+    assert result["speaker"] == "s"
+    assert result["segments"] == []
 
 
 def test_mid_job_progress_is_capped_at_98(tmp_path, monkeypatch):
@@ -78,38 +89,59 @@ def test_mid_job_progress_is_capped_at_98(tmp_path, monkeypatch):
     stub = _StubProvider(emit_progresses=[(100.0, 1), (100.0, 2)], emit_segments=[])
     job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
 
-    server._run_stt_job(job_id, "s", "t.wav", "ckb")
-    # Find the mid-job values (not the final 100 from _set_job_complete)
-    job = server._jobs[job_id]
-    assert job["status"] == "complete"
-    # No mid-job progress should exceed 98
-    mid = [p for p in captured]
-    assert all(p <= 98.0 for p in mid), mid
-    # And the final stored progress is 100 from _set_job_complete
-    assert job["progress"] == 100.0
+    result = server._run_stt_job(job_id, "s", "t.wav", "ckb")
+    # No mid-job progress reported by _run_stt_job should exceed 98.
+    assert all(p <= 98.0 for p in captured), captured
+    # Result dict is returned (dispatcher fills progress to 100 on complete).
+    assert result["segments"] == []
 
 
 def test_provider_init_failure_is_wrapped_with_context(tmp_path, monkeypatch):
     """get_stt_provider exceptions must surface as 'STT provider init failed:
     …' so the UI banner isn't stuck on the stale 'Initializing STT provider'
-    message."""
+    message. _run_stt_job now raises instead of calling _set_job_error."""
     def factory():
         raise RuntimeError("no CUDA")
 
     job_id, _ = _prepare_job(tmp_path, monkeypatch, provider_factory=factory)
-    server._run_stt_job(job_id, "s", "t.wav", "ckb")
-    job = server._jobs[job_id]
-    assert job["status"] == "error"
-    assert "STT provider init failed" in job["error"]
-    assert "no CUDA" in job["error"]
+    with pytest.raises(RuntimeError) as exc_info:
+        server._run_stt_job(job_id, "s", "t.wav", "ckb")
+    assert "STT provider init failed" in str(exc_info.value)
+    assert "no CUDA" in str(exc_info.value)
 
 
 def test_transcribe_failure_is_wrapped_with_context(tmp_path, monkeypatch):
     """Transcribe exceptions likewise must be labeled."""
     stub = _StubProvider(raise_on_transcribe=RuntimeError("out of memory"))
     job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
-    server._run_stt_job(job_id, "s", "t.wav", "ckb")
-    job = server._jobs[job_id]
-    assert job["status"] == "error"
-    assert "STT transcription failed" in job["error"]
-    assert "out of memory" in job["error"]
+    with pytest.raises(RuntimeError) as exc_info:
+        server._run_stt_job(job_id, "s", "t.wav", "ckb")
+    assert "STT transcription failed" in str(exc_info.value)
+    assert "out of memory" in str(exc_info.value)
+
+
+def test_compute_stt_wrapper_unpacks_payload(tmp_path, monkeypatch):
+    """_compute_stt adapts the HTTP payload shape to _run_stt_job args."""
+    stub = _StubProvider(emit_progresses=[], emit_segments=[{"text": "hi"}])
+    job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
+    result = server._compute_stt(
+        job_id,
+        {"speaker": "s", "sourceWav": "t.wav", "language": "ckb"},
+    )
+    assert result["speaker"] == "s"
+    assert result["language"] == "ckb"
+    assert result["segments"] == [{"text": "hi"}]
+
+
+def test_compute_stt_rejects_missing_speaker(tmp_path, monkeypatch):
+    stub = _StubProvider(emit_progresses=[], emit_segments=[])
+    job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
+    with pytest.raises(ValueError, match="speaker"):
+        server._compute_stt(job_id, {"sourceWav": "t.wav"})
+
+
+def test_compute_stt_rejects_missing_source_wav(tmp_path, monkeypatch):
+    stub = _StubProvider(emit_progresses=[], emit_segments=[])
+    job_id, _ = _prepare_job(tmp_path, monkeypatch, provider=stub)
+    with pytest.raises(ValueError, match="sourceWav"):
+        server._compute_stt(job_id, {"speaker": "s"})

--- a/python/workers/compute_worker.py
+++ b/python/workers/compute_worker.py
@@ -321,6 +321,60 @@ def _install_aligner_preload() -> Any:
     return aligner
 
 
+def _install_stt_preload() -> None:
+    """Pre-load the faster-whisper STT provider. Non-fatal on failure.
+
+    The compute worker gets one persistent process — we want the
+    Razhan (or user-configured) CT2 model loaded once at startup so
+    the first ``/api/stt`` job doesn't pay the 1-5 s cold-load cost
+    (and every subsequent one is free instead of re-loading).
+    """
+    try:
+        from ai.provider import preload_stt_provider
+    except Exception as exc:
+        print(
+            f"[WORKER] STT preload import failed: {exc}",
+            file=sys.stderr, flush=True,
+        )
+        return
+    provider = preload_stt_provider()
+    if provider is None:
+        print(
+            "[WORKER] STT provider not preloaded — first /api/stt call will load on demand",
+            file=sys.stderr, flush=True,
+        )
+        return
+    device = getattr(provider, "_effective_device", None) or getattr(provider, "device", "?")
+    print(
+        f"[WORKER] STT provider pre-loaded on {device}",
+        file=sys.stderr, flush=True,
+    )
+
+
+def _install_ortho_preload() -> None:
+    """Pre-load the ORTH (razhan) faster-whisper provider. Non-fatal on failure."""
+    try:
+        from ai.provider import preload_ortho_provider
+    except Exception as exc:
+        print(
+            f"[WORKER] ORTH preload import failed: {exc}",
+            file=sys.stderr, flush=True,
+        )
+        return
+    provider = preload_ortho_provider()
+    if provider is None:
+        print(
+            "[WORKER] ORTH provider not preloaded — first ortho job will load on demand",
+            file=sys.stderr, flush=True,
+        )
+        return
+    device = getattr(provider, "_effective_device", None) or getattr(provider, "device", "?")
+    print(
+        f"[WORKER] ORTH provider pre-loaded on {device}",
+        file=sys.stderr, flush=True,
+    )
+
+
 def _dispatch(
     server_mod: Any, compute_type: str, job_id: str, payload: Dict[str, Any]
 ) -> Any:
@@ -345,6 +399,8 @@ def _dispatch(
         return server_mod._compute_full_pipeline(job_id, payload)
     if normalized in {"train_ipa_model", "train-ipa-model", "train_ipa"}:
         return server_mod._compute_training_job(job_id, payload)
+    if normalized == "stt":
+        return server_mod._compute_stt(job_id, payload)
     raise RuntimeError("Unsupported compute type: {0}".format(normalized))
 
 
@@ -381,6 +437,12 @@ def worker_main(job_queue: Any, event_queue: Any) -> None:
         )
         # Do NOT emit ready — parent's wait() will time out and report.
         return
+
+    # STT / ORTH preloads are best-effort: a missing Razhan model or a
+    # CUDA runtime gap shouldn't block the worker from serving wav2vec2
+    # jobs. The factory will fall back to on-demand load if we skip here.
+    _install_stt_preload()
+    _install_ortho_preload()
 
     try:
         import server as server_mod  # noqa: F401


### PR DESCRIPTION
## Summary

Extends the persistent-worker pattern from PR #171 to **STT and ORTH**. Before this PR:

- **STT** spawned a plain \`threading.Thread\` inside the HTTP server process (the same hazard class wav2vec2 had pre-#171).
- **ORTH** dispatched through the worker (✓ process isolation) but **re-built** \`LocalWhisperProvider\` on every call — the faster-whisper model loaded cold each time.
- Neither model was pre-loaded at worker startup.

After this PR:

| | thread/subprocess mode | persistent mode |
|---|---|---|
| STT process isolation | thread (shared address space) | dedicated worker process ✓ |
| ORTH process isolation | thread (shared) | dedicated worker process ✓ |
| STT model preload | on-demand (per call) | **once, at startup** ✓ |
| ORTH model preload | on-demand (per call) | **once, at startup** ✓ |

## Files

**[\`python/ai/provider.py\`](python/ai/provider.py)** — +86 LOC:
- Added \`LocalWhisperProvider.warm_up()\` (just calls the existing lazy \`_load_whisper_model()\` eagerly).
- Added \`_PRELOADED_STT_PROVIDER\` / \`_PRELOADED_ORTHO_PROVIDER\` module globals.
- Added \`preload_stt_provider()\` / \`preload_ortho_provider()\` that build + warm + cache. Non-fatal on failure.
- Split factory internals into \`_build_stt_provider\` / \`_build_ortho_provider\`; the public \`get_stt_provider\` / \`get_ortho_provider\` check the cache when no custom \`config\` was passed.

**[\`python/workers/compute_worker.py\`](python/workers/compute_worker.py)** — +62 LOC:
- Added \`_install_stt_preload()\` and \`_install_ortho_preload()\` helpers.
- Called them in \`worker_main\` after the Aligner preload. Failures are logged and skipped — the factory still works on-demand, so a missing Razhan CT2 doesn't block wav2vec2 work.
- Added \`stt\` route in \`_dispatch\`.

**[\`python/server.py\`](python/server.py)** — +77 / -100 LOC:
- Refactored \`_run_stt_job\` to the compute-function contract: **returns the result dict** on success, **raises** on failure. The dispatcher/worker now owns terminal \`_set_job_*\` state.
- Added \`_compute_stt(job_id, payload)\` wrapper to translate HTTP/chat payload shape → positional args.
- Wired \`stt\` into both existing dispatch tables (\`_run_compute_job\`, \`_compute_subprocess_entry\`).
- Changed \`_api_post_stt_start\` + \`_chat_start_stt_job\` to call \`_launch_compute_runner(job_id, \"stt\", payload)\` instead of spawning a Thread directly.
- Simplified \`_compute_full_pipeline\`'s STT step — now just \`try / except\` around the return value. Removed the \`_reset_job_to_running\` dance (no longer needed since \`_run_stt_job\` doesn't call \`_set_job_complete\`).

**[\`python/test_run_stt_job.py\`](python/test_run_stt_job.py)** — 4 tests updated + 3 tests added for the new \`_compute_stt\` wrapper. 53/53 passing on the affected test modules.

## Trade-offs

- **Final job message regression**: STT jobs used to land with \`message=\"STT complete — N segments\"\`; now they land with the dispatcher's generic \`message=\"Compute complete\"\`. Matches the IPA/ORTH behaviour post-#171. The per-segment progress messages during the run are unchanged.
- **Startup cost**: worker now loads 3 Whisper-class models at boot (wav2vec2 Aligner + STT Whisper + ORTH Whisper). First \`/api/worker/status\` readiness takes ~10-30 s longer. All subsequent jobs get zero model-load cost in return.
- Preloads are **best-effort**. If Razhan CT2 isn't installed on the PC or CUDA isn't available, the worker logs the skip and boots anyway. The factories fall back to on-demand load for any call that hits an un-preloaded provider.

## Test plan

- [x] Unit: 53/53 pass across \`test_run_stt_job\`, \`test_compute_speaker_ipa\`, \`test_compute_speaker_ortho\`, \`test_forced_align\`, \`test_ipa_transcribe_acoustic\`.
- [ ] PC smoke: launch the worker in persistent mode, hit \`GET /api/worker/status\` — confirm \`alive: true\` after all three preload log lines (\`Aligner pre-loaded\`, \`STT provider pre-loaded\`, \`ORTH provider pre-loaded\`).
- [ ] PC regression: re-run Mand01 IPA + Fail02 IPA — must still succeed with no regression vs. #174.
- [ ] PC STT: submit \`/api/compute/\` with \`computeType: \"stt\"\` (or legacy \`POST /api/stt\`) on a short clip. Confirm completes + STT cache populated.
- [ ] PC ORTH: submit ortho compute on a short speaker. Confirm Razhan loads at worker startup (log line) and the ortho job finishes without a second model load.

## Rollback

Any single layer is revertable independently:
- Factory caches: set \`_PRELOADED_STT_PROVIDER = None\` / \`_PRELOADED_ORTHO_PROVIDER = None\` or revert provider.py.
- STT dispatch route: revert the 5 call-site edits in server.py; the legacy threading code path was only lightly altered.
- Worker preloads: revert compute_worker.py's two new install helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)