### PR TITLE
feat(alignment): auto-refine ORTH tier + ortho_words + precise lexeme lookup

### DIFF
--- a/config/ai_config.example.json
+++ b/config/ai_config.example.json
@@ -15,14 +15,16 @@
     "model_only": true
   },
   "ortho": {
-    "_comment": "Orthographic transcription (e.g. Kurdish Arabic script). Razhan is the canonical SDH model. model_path may be a HuggingFace repo id (razhan/whisper-base-sdh) or a local CTranslate2 path. vad_filter defaults to false for ortho so razhan produces full-waveform coverage; leave it false unless you've tuned vad_parameters for your recordings.",
+    "_comment": "Orthographic transcription (e.g. Kurdish Arabic script). Razhan is the canonical SDH model. model_path may be a HuggingFace repo id (razhan/whisper-base-sdh) or a local CTranslate2 path. vad_filter defaults to false for ortho so razhan produces full-waveform coverage; leave it false unless you've tuned vad_parameters for your recordings. initial_prompt primes the Whisper decoder — useful on elicited word-list recordings. refine_lexemes=true enables a short-clip Whisper pass over every concept after Tier-2 forced alignment; adds ~1-2 min on thesis-scale audio but yields clean per-lexeme text in tiers.ortho_words even when the coarse ortho tier is monolithic.",
     "provider": "faster-whisper",
     "model_path": "razhan/whisper-base-sdh",
     "language": "sd",
     "device": "cuda",
     "compute_type": "float16",
     "beam_size": 5,
-    "vad_filter": false
+    "vad_filter": false,
+    "initial_prompt": "",
+    "refine_lexemes": false
   },
   "llm": {
     "provider": "openai",

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -1369,18 +1369,18 @@ class LocalWhisperProvider(AIProvider):
         initial_prompt: Optional[str] = None,
         language: Optional[str] = None,
     ) -> Tuple[str, float]:
-        """Transcribe a preloaded mono-16kHz numpy array and return ``(text, confidence)``.
+        """Transcribe a preloaded mono-16kHz numpy array.
 
-        Unlike :meth:`transcribe` this takes an in-memory audio array (not a
-        file path) and returns a flat ``(text, confidence)`` tuple rather
-        than a list of segments. ``confidence`` is derived from the best
-        segment ``avg_logprob`` the same way :meth:`transcribe` does; the
-        returned text is the concatenation of all segments (usually 1 for
-        short clips). Empty input yields ``("", 0.0)``.
+        Returns ``(text: str, confidence: float)`` where ``text`` is the
+        concatenation of all decoded segments (usually one for a short clip)
+        and ``confidence`` is in ``[0, 1]`` derived from the best segment
+        ``avg_logprob`` via the same formula used by :meth:`transcribe`.
+        Empty or ``None`` input yields ``("", 0.0)``.
 
-        Used by the ORTH compute runner's short-clip fallback — the caller
-        has already sliced a ±0.8s window around a concept anchor and loaded
-        the audio once via ``ai.forced_align._load_audio_mono_16k``.
+        Unlike :meth:`transcribe` this accepts an in-memory audio array
+        rather than a file path, so the caller can reuse an already-loaded
+        waveform (e.g. from ``ai.forced_align._load_audio_mono_16k``) and
+        slice ±0.8 s windows without re-reading the file per concept.
         """
         if audio_array is None:
             return ("", 0.0)

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -1369,9 +1369,11 @@ class LocalWhisperProvider(AIProvider):
         initial_prompt: Optional[str] = None,
         language: Optional[str] = None,
     ) -> Tuple[str, float]:
-        """Transcribe a preloaded mono-16kHz numpy array (not a file path).
+        """Transcribe a preloaded mono-16kHz numpy array and return ``(text, confidence)``.
 
-        Returns ``(text, confidence)``. ``confidence`` is derived from the
+        Unlike :meth:`transcribe` this takes an in-memory audio array (not a
+        file path) and returns a flat ``(text, confidence)`` tuple rather
+        than a list of segments. ``confidence`` is derived from the best
         segment ``avg_logprob`` the same way :meth:`transcribe` does; the
         returned text is the concatenation of all segments (usually 1 for
         short clips). Empty input yields ``("", 0.0)``.

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -118,6 +118,14 @@ _DEFAULT_AI_CONFIG: Dict[str, Any] = {
         # back to higher temperature (or drops the segment) earlier
         # when it detects repetition.
         "compression_ratio_threshold": 1.8,
+        # Optional decoder priming string for elicited word-list recordings.
+        # Empty = not passed to faster-whisper.
+        "initial_prompt": "",
+        # When True the ORTH compute runner will also do a short-clip
+        # Whisper pass per concept after Tier-2 forced alignment. Off by
+        # default — opt in per speaker via the compute payload or per
+        # machine via ai_config.json.
+        "refine_lexemes": False,
     },
     "llm": {
         "provider": "openai",
@@ -1119,6 +1127,22 @@ class LocalWhisperProvider(AIProvider):
         except (TypeError, ValueError):
             self.compression_ratio_threshold = ratio_default
 
+        # initial_prompt: optional Whisper decoder priming string. Useful for
+        # ORTH on elicited word-list recordings to bias decoding toward known
+        # concepts and spellings. Empty string = not passed to faster-whisper.
+        prompt_raw = section_config.get("initial_prompt", "")
+        self.initial_prompt: str = (
+            str(prompt_raw).strip() if isinstance(prompt_raw, str) else ""
+        )
+
+        # refine_lexemes: ORTH-only hook read by the compute runner. When True,
+        # the ORTH job runs a short-clip Whisper fallback for concepts whose
+        # forced-alignment match is weak or missing. Default False so existing
+        # users aren't surprised by the extra ~1-2 min on thesis-scale audio.
+        self.refine_lexemes: bool = _coerce_bool(
+            section_config.get("refine_lexemes", False), default=False
+        )
+
         if _stt_force_cpu_env() and self.device.lower().startswith("cuda"):
             print(
                 "[WARN] PARSE_STT_FORCE_CPU set; overriding stt.device "
@@ -1268,6 +1292,8 @@ class LocalWhisperProvider(AIProvider):
                 transcribe_kwargs["vad_parameters"] = self.vad_parameters
             if self.compression_ratio_threshold is not None:
                 transcribe_kwargs["compression_ratio_threshold"] = self.compression_ratio_threshold
+            if self.initial_prompt:
+                transcribe_kwargs["initial_prompt"] = self.initial_prompt
             segs_iter, info = m.transcribe(str(path), **transcribe_kwargs)
             total_duration = float(getattr(info, "duration", 0.0) or 0.0)
             for segment in segs_iter:
@@ -1335,6 +1361,65 @@ class LocalWhisperProvider(AIProvider):
             progress_callback(100.0, len(segments_out))
 
         return segments_out
+
+    def transcribe_clip(
+        self,
+        audio_array: Any,
+        *,
+        initial_prompt: Optional[str] = None,
+        language: Optional[str] = None,
+    ) -> Tuple[str, float]:
+        """Transcribe a preloaded mono-16kHz numpy array (not a file path).
+
+        Returns ``(text, confidence)``. ``confidence`` is derived from the
+        segment ``avg_logprob`` the same way :meth:`transcribe` does; the
+        returned text is the concatenation of all segments (usually 1 for
+        short clips). Empty input yields ``("", 0.0)``.
+
+        Used by the ORTH compute runner's short-clip fallback — the caller
+        has already sliced a ±0.8s window around a concept anchor and loaded
+        the audio once via ``ai.forced_align._load_audio_mono_16k``.
+        """
+        if audio_array is None:
+            return ("", 0.0)
+
+        model = self._load_whisper_model()
+        selected_language = (language or self.language) or None
+        prompt = initial_prompt if initial_prompt is not None else self.initial_prompt
+
+        kwargs: Dict[str, Any] = {
+            "language": selected_language,
+            "beam_size": self.beam_size,
+            "task": self.task,
+            "vad_filter": False,
+            "word_timestamps": False,
+            "condition_on_previous_text": False,
+        }
+        if self.compression_ratio_threshold is not None:
+            kwargs["compression_ratio_threshold"] = self.compression_ratio_threshold
+        if prompt:
+            kwargs["initial_prompt"] = prompt
+
+        try:
+            segs_iter, _info = model.transcribe(audio_array, **kwargs)
+        except Exception as exc:
+            print(
+                "[WARN] transcribe_clip failed: {0}".format(exc),
+                file=sys.stderr,
+            )
+            return ("", 0.0)
+
+        parts: List[str] = []
+        best_conf = 0.0
+        for seg in segs_iter:
+            text = str(_dict_or_attr(seg, "text", "") or "").strip()
+            if text:
+                parts.append(text)
+                conf = _confidence_from_logprob(_dict_or_attr(seg, "avg_logprob", None))
+                if conf and conf > best_conf:
+                    best_conf = conf
+        return (" ".join(parts).strip(), float(best_conf))
+
 
 class OpenAIProvider(AIProvider):
     """OpenAI-backed provider for STT and IPA conversion."""

--- a/python/server.py
+++ b/python/server.py
@@ -3989,27 +3989,274 @@ def _pipeline_state_for_speaker(speaker: str) -> Dict[str, Any]:
     return result
 
 
+def _ortho_tier2_align_to_words(
+    audio_path: pathlib.Path,
+    segments: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Run Tier-2 forced alignment on ORTH segments, returning a flat word tier.
+
+    Takes the full raw segment list (with Whisper ``words[]`` per segment)
+    and returns a flat sorted list of ``{start, end, text, confidence,
+    source}`` dicts suitable for ``tiers.ortho_words.intervals``.
+
+    Any exception is logged and an empty list is returned — alignment is a
+    refinement pass, not a gate; the coarse ortho tier has already been
+    written by the caller.
+    """
+    if not segments:
+        return []
+    has_any_words = any(seg.get("words") for seg in segments)
+    if not has_any_words:
+        print(
+            "[ORTH] Tier-2 skipped: no word-level timestamps on any segment",
+            file=sys.stderr,
+        )
+        return []
+
+    try:
+        from ai.forced_align import align_segments
+    except Exception as exc:  # pragma: no cover - import failure is rare
+        print("[ORTH] Tier-2 import failed: {0}".format(exc), file=sys.stderr)
+        return []
+
+    try:
+        aligned = align_segments(audio_path=audio_path, segments=segments)
+    except Exception as exc:
+        print("[ORTH] Tier-2 alignment failed: {0}".format(exc), file=sys.stderr)
+        return []
+
+    flat: List[Dict[str, Any]] = []
+    for seg_words in aligned:
+        for word in seg_words or []:
+            text = str(word.get("word", "") or "").strip()
+            if not text:
+                continue
+            try:
+                start = float(word.get("start", 0.0) or 0.0)
+                end = float(word.get("end", start) or start)
+            except (TypeError, ValueError):
+                continue
+            if end < start:
+                continue
+            interval: Dict[str, Any] = {
+                "start": start,
+                "end": end,
+                "text": text,
+                "source": "forced_align",
+            }
+            conf = word.get("confidence")
+            if conf is not None:
+                try:
+                    interval["confidence"] = float(conf)
+                except (TypeError, ValueError):
+                    pass
+            flat.append(interval)
+
+    flat.sort(key=lambda iv: (float(iv["start"]), float(iv["end"])))
+    return flat
+
+
+def _short_clip_refine_lexemes(
+    audio_path: pathlib.Path,
+    concept_intervals: List[Dict[str, Any]],
+    ortho_words: List[Dict[str, Any]],
+    provider: Any,
+    *,
+    pad_sec: float = 0.8,
+    weak_conf: float = 0.5,
+    job_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Re-transcribe a ±``pad_sec`` window per concept whose ortho_words
+    match is missing or weak, using a Whisper ``initial_prompt`` built from
+    the concept labels themselves. Returns new ``ortho_words``-shaped
+    entries with ``source="short_clip_whisper"`` that the caller should
+    merge (upsert) into the main list.
+    """
+    if not concept_intervals:
+        return []
+
+    concept_labels = sorted({
+        str(iv.get("text") or "").strip()
+        for iv in concept_intervals
+        if isinstance(iv, dict) and str(iv.get("text") or "").strip()
+    })
+    if not concept_labels:
+        return []
+    # Whisper's prompt is capped around ~224 tokens; keep the concept list
+    # comfortably below that so the slice inference stays fast.
+    initial_prompt = ", ".join(concept_labels)[:400]
+
+    try:
+        from ai.forced_align import _load_audio_mono_16k, DEFAULT_SAMPLE_RATE
+    except Exception as exc:
+        print("[ORTH] short-clip fallback import failed: {0}".format(exc), file=sys.stderr)
+        return []
+
+    try:
+        waveform = _load_audio_mono_16k(audio_path)
+    except Exception as exc:
+        print("[ORTH] short-clip audio load failed: {0}".format(exc), file=sys.stderr)
+        return []
+
+    import numpy as np  # type: ignore
+
+    # waveform may be shape (n,) or (1, n) — normalize to 1-D numpy.
+    try:
+        tensor = waveform
+        if hasattr(tensor, "squeeze"):
+            tensor = tensor.squeeze()
+        audio_np = tensor.numpy() if hasattr(tensor, "numpy") else np.asarray(tensor)
+        audio_np = np.asarray(audio_np, dtype=np.float32).reshape(-1)
+    except Exception as exc:
+        print("[ORTH] short-clip audio conversion failed: {0}".format(exc), file=sys.stderr)
+        return []
+
+    total_samples = audio_np.shape[0]
+    duration_sec = total_samples / float(DEFAULT_SAMPLE_RATE) if total_samples else 0.0
+
+    ortho_sorted = sorted(
+        (w for w in ortho_words if isinstance(w, dict)),
+        key=lambda w: (float(w.get("start", 0.0) or 0.0), float(w.get("end", 0.0) or 0.0)),
+    )
+
+    def _best_match(concept_iv: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        c_start = float(concept_iv.get("start", 0.0) or 0.0)
+        c_end = float(concept_iv.get("end", c_start) or c_start)
+        if c_end <= c_start:
+            return None
+        best: Optional[Dict[str, Any]] = None
+        best_overlap = 0.0
+        for w in ortho_sorted:
+            w_start = float(w.get("start", 0.0) or 0.0)
+            w_end = float(w.get("end", w_start) or w_start)
+            if w_end <= c_start or w_start >= c_end:
+                continue
+            ov = min(c_end, w_end) - max(c_start, w_start)
+            if ov > best_overlap:
+                best_overlap = ov
+                best = w
+        return best
+
+    additions: List[Dict[str, Any]] = []
+    total = len(concept_intervals)
+    for idx, concept_iv in enumerate(concept_intervals):
+        if not isinstance(concept_iv, dict):
+            continue
+        try:
+            c_start = float(concept_iv.get("start", 0.0) or 0.0)
+            c_end = float(concept_iv.get("end", c_start) or c_start)
+        except (TypeError, ValueError):
+            continue
+        if c_end <= c_start or duration_sec <= 0.0:
+            continue
+
+        match = _best_match(concept_iv)
+        match_conf = 0.0
+        if match is not None:
+            try:
+                match_conf = float(match.get("confidence") or 0.0)
+            except (TypeError, ValueError):
+                match_conf = 0.0
+            if match_conf >= weak_conf and str(match.get("text") or "").strip():
+                continue  # strong forced-alignment match — don't re-transcribe.
+
+        slice_start = max(0.0, c_start - pad_sec)
+        slice_end = min(duration_sec, c_end + pad_sec)
+        if slice_end <= slice_start:
+            continue
+        s0 = int(slice_start * DEFAULT_SAMPLE_RATE)
+        s1 = int(slice_end * DEFAULT_SAMPLE_RATE)
+        clip = audio_np[s0:s1]
+        if clip.size == 0:
+            continue
+
+        text, conf = provider.transcribe_clip(
+            clip,
+            initial_prompt=initial_prompt,
+        )
+        text = (text or "").strip()
+        if not text:
+            continue
+
+        additions.append({
+            "start": c_start,
+            "end": c_end,
+            "text": text,
+            "confidence": float(conf or 0.0),
+            "source": "short_clip_whisper",
+        })
+
+        if job_id and idx and idx % 50 == 0:
+            _set_job_progress(
+                job_id,
+                98.0,
+                message="ORTH refine_lexemes ({0}/{1})".format(idx, total),
+            )
+
+    return additions
+
+
+def _merge_ortho_words(
+    aligned: List[Dict[str, Any]],
+    refined: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Merge short-clip refined entries into the forced-alignment list.
+
+    Refined entries replace any aligned entry whose span falls inside the
+    refined ``[start, end]`` window; aligned entries not covered by any
+    refined window are preserved.
+    """
+    if not refined:
+        return list(aligned)
+
+    def _iv_bounds(iv: Dict[str, Any]) -> Tuple[float, float]:
+        return (float(iv.get("start", 0.0) or 0.0), float(iv.get("end", 0.0) or 0.0))
+
+    kept: List[Dict[str, Any]] = []
+    for a in aligned:
+        a_start, a_end = _iv_bounds(a)
+        covered = False
+        for r in refined:
+            r_start, r_end = _iv_bounds(r)
+            if a_start >= r_start and a_end <= r_end:
+                covered = True
+                break
+        if not covered:
+            kept.append(a)
+
+    combined = kept + list(refined)
+    combined.sort(key=lambda iv: (float(iv.get("start", 0.0) or 0.0), float(iv.get("end", 0.0) or 0.0)))
+    return combined
+
+
 def _compute_speaker_ortho(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     """Generate an orthographic transcript for a speaker using the razhan model.
 
     Runs the ORTH provider (faster-whisper with razhan/whisper-base-sdh)
     full-file against the speaker's working WAV (normalized copy preferred,
     raw source as fallback) and writes razhan's own segments to the
-    ``ortho`` tier of the annotation.
+    ``ortho`` tier of the annotation. After the coarse tier is written, a
+    Tier-2 forced-alignment pass refines the Whisper word-level timestamps
+    into ``tiers.ortho_words`` for precise per-lexeme lookup in the UI.
 
-    Payload: ``{"speaker": "Fail02", "overwrite": false}``.
+    Payload: ``{"speaker": "Fail02", "overwrite": false, "refine_lexemes": bool?}``.
+
+    If ``refine_lexemes`` is omitted the provider's config default (from
+    ai_config.json) is used.
 
     Overwrite semantics differ from IPA: razhan's segmentation isn't stable
     across runs, so we can't pair segments by ``(start, end)`` the way IPA
     does. Rule: if the ortho tier already has any non-empty text intervals,
     the caller must set ``overwrite=True`` to replace the whole tier;
     otherwise the run is a no-op and returns ``skipped=True``. Empty tiers
-    are always populated.
+    are always populated. When overwrite runs, ``tiers.ortho_words`` is
+    always rebuilt from scratch alongside ``tiers.ortho``.
     """
     speaker = _normalize_speaker_id(payload.get("speaker"))
     overwrite = bool(payload.get("overwrite", False))
     language = payload.get("language")
     language_str = str(language).strip() if isinstance(language, str) and language.strip() else None
+    refine_payload = payload.get("refine_lexemes")
 
     canonical_path = _project_root() / _annotation_record_relative_path(speaker)
     legacy_path = _project_root() / _annotation_legacy_record_relative_path(speaker)
@@ -4047,7 +4294,7 @@ def _compute_speaker_ortho(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
     provider = get_ortho_provider()
 
     def _progress_callback(progress: float, segments_processed: int) -> None:
-        clamped = min(float(progress) if progress is not None else 0.0, 98.0)
+        clamped = min(float(progress) if progress is not None else 0.0, 94.0)
         _set_job_progress(
             job_id,
             max(2.0, clamped),
@@ -4073,9 +4320,47 @@ def _compute_speaker_ortho(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
     new_intervals.sort(key=lambda iv: (float(iv["start"]), float(iv["end"])))
 
     if ortho_tier is None:
-        ortho_tier = {"type": "interval", "display_order": 2, "intervals": []}
+        ortho_tier = {"type": "interval", "display_order": 3, "intervals": []}
     ortho_tier["intervals"] = new_intervals
     tiers["ortho"] = ortho_tier
+
+    _set_job_progress(job_id, 95.0, message="ORTH Tier-2 forced alignment")
+    ortho_words = _ortho_tier2_align_to_words(audio_path, segments)
+
+    if refine_payload is None:
+        refine_lexemes = bool(getattr(provider, "refine_lexemes", False))
+    else:
+        refine_lexemes = bool(refine_payload)
+
+    refined_additions: List[Dict[str, Any]] = []
+    if refine_lexemes:
+        concept_tier = tiers.get("concept") if isinstance(tiers.get("concept"), dict) else None
+        concept_intervals = [
+            iv for iv in (concept_tier.get("intervals") or [] if concept_tier else [])
+            if isinstance(iv, dict)
+        ]
+        if concept_intervals:
+            _set_job_progress(
+                job_id,
+                97.0,
+                message="ORTH refine_lexemes (short-clip, {0} concepts)".format(len(concept_intervals)),
+            )
+            refined_additions = _short_clip_refine_lexemes(
+                audio_path=audio_path,
+                concept_intervals=concept_intervals,
+                ortho_words=ortho_words,
+                provider=provider,
+                job_id=job_id,
+            )
+
+    merged_words = _merge_ortho_words(ortho_words, refined_additions)
+
+    ortho_words_tier = tiers.get("ortho_words") if isinstance(tiers.get("ortho_words"), dict) else None
+    if ortho_words_tier is None:
+        ortho_words_tier = {"type": "interval", "display_order": 4, "intervals": []}
+    ortho_words_tier["intervals"] = merged_words
+    tiers["ortho_words"] = ortho_words_tier
+
     annotation["tiers"] = tiers
     _annotation_touch_metadata(annotation, preserve_created=True)
 
@@ -4085,11 +4370,20 @@ def _compute_speaker_ortho(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
     if legacy_path != annotation_path:
         _write_json_file(legacy_path, annotation)
 
-    _set_job_progress(job_id, 99.0, message="ORTH written ({0} intervals)".format(len(new_intervals)))
+    _set_job_progress(
+        job_id,
+        99.0,
+        message="ORTH written ({0} intervals, {1} word-level, {2} refined)".format(
+            len(new_intervals), len(merged_words), len(refined_additions)
+        ),
+    )
 
     return {
         "speaker": speaker,
         "filled": len(new_intervals),
+        "ortho_words": len(merged_words),
+        "refined_lexemes": len(refined_additions),
+        "refine_lexemes_enabled": refine_lexemes,
         "skipped": False,
         "replaced_existing": has_existing_text,
         "audio_path": str(audio_path),

--- a/python/server.py
+++ b/python/server.py
@@ -4069,7 +4069,7 @@ def _short_clip_refine_lexemes(
     """Re-transcribe a ±``pad_sec`` window per concept whose ortho_words
     match is missing or weak, using a Whisper ``initial_prompt`` built from
     the concept labels themselves. Returns new ``ortho_words``-shaped
-    entries with ``source="short_clip_whisper"`` that the caller should
+    entries with ``source="short_clip_fallback"`` that the caller should
     merge (upsert) into the main list.
     """
     if not concept_intervals:
@@ -4183,14 +4183,25 @@ def _short_clip_refine_lexemes(
             "end": c_end,
             "text": text,
             "confidence": float(conf or 0.0),
-            "source": "short_clip_whisper",
+            "source": "short_clip_fallback",
         })
 
-        if job_id and idx and idx % 50 == 0:
+        # Per-concept stderr log keeps long runs legible in the server log.
+        # The UI progress bar is throttled to every 10 concepts so the
+        # websocket/poll channel doesn't drown in updates.
+        print(
+            "[ORTH] refine_lexemes {0}/{1} concept='{2}' → '{3}' (conf {4:.2f})".format(
+                idx + 1, total, str(concept_iv.get("text") or "")[:40], text[:40], float(conf or 0.0),
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
+        if job_id and (idx + 1) % 10 == 0:
+            pct = 97.0 + 2.0 * (idx + 1) / max(total, 1)
             _set_job_progress(
                 job_id,
-                98.0,
-                message="ORTH refine_lexemes ({0}/{1})".format(idx, total),
+                pct,
+                message="Refining lexeme {0}/{1}".format(idx + 1, total),
             )
 
     return additions
@@ -4550,14 +4561,18 @@ def _compute_full_pipeline(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
                 steps_run.append(step)
 
             elif step == "ortho":
-                sub_result = _compute_speaker_ortho(
-                    job_id,
-                    {
-                        "speaker": speaker,
-                        "overwrite": overwrites.get("ortho", False),
-                        "language": language_str,
-                    },
-                )
+                ortho_sub_payload: Dict[str, Any] = {
+                    "speaker": speaker,
+                    "overwrite": overwrites.get("ortho", False),
+                    "language": language_str,
+                }
+                # Forward the batch-level refine_lexemes flag so the ORTH
+                # runner's provider-config default can be overridden by the
+                # compute dialog. Omit when unset so _compute_speaker_ortho
+                # falls back to the provider's ai_config default.
+                if payload.get("refine_lexemes") is not None:
+                    ortho_sub_payload["refine_lexemes"] = bool(payload.get("refine_lexemes"))
+                sub_result = _compute_speaker_ortho(job_id, ortho_sub_payload)
                 # _compute_speaker_ortho returns {"skipped": True/False, ...} —
                 # translate to status vocabulary shared across steps.
                 if sub_result.get("skipped"):

--- a/python/test_compute_speaker_ortho.py
+++ b/python/test_compute_speaker_ortho.py
@@ -72,6 +72,7 @@ def test_ortho_writes_razhan_segments_to_empty_tier(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
     stub = _StubOrthoProvider()
     monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
 
     _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
     _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
@@ -88,6 +89,10 @@ def test_ortho_writes_razhan_segments_to_empty_tier(tmp_path, monkeypatch):
     assert [iv["text"] for iv in intervals] == ["بەش", "سەرە"]
     assert intervals[0]["start"] == pytest.approx(0.5)
     assert intervals[1]["end"] == pytest.approx(2.0)
+    # ortho_words tier is always written, even when segments carry no word spans
+    assert "ortho_words" in ann["tiers"]
+    assert isinstance(ann["tiers"]["ortho_words"]["intervals"], list)
+
 
 
 def test_ortho_skips_if_tier_populated_without_overwrite(tmp_path, monkeypatch):
@@ -181,6 +186,107 @@ def test_run_compute_job_dispatches_ortho(tmp_path, monkeypatch):
 # --------------------------------------------------------------------------
 # Pipeline state probe
 # --------------------------------------------------------------------------
+
+
+def test_ortho_writes_ortho_words_from_forced_alignment(tmp_path, monkeypatch):
+    """When Whisper produces word-level timestamps, Tier-2 forced alignment
+    flattens them into tiers.ortho_words — coarse ortho tier stays intact."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    segments_with_words = [
+        {
+            "start": 0.0,
+            "end": 1.5,
+            "text": "بەش سەرە",
+            "words": [
+                {"word": "بەش", "start": 0.05, "end": 0.55, "prob": 0.95},
+                {"word": "سەرە", "start": 0.60, "end": 1.20, "prob": 0.90},
+            ],
+        },
+    ]
+    stub = _StubOrthoProvider(segments=segments_with_words)
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+
+    # Stub the wav2vec2 aligner so the test doesn't pull the 1.2 GB model.
+    # Input shape matches align_segments: List[Segment] → List[List[AlignedWord]].
+    fake_aligned = [[
+        {"word": "بەش", "start": 0.08, "end": 0.52, "confidence": 0.97,
+         "method": "wav2vec2"},
+        {"word": "سەرە", "start": 0.62, "end": 1.18, "confidence": 0.93,
+         "method": "wav2vec2"},
+    ]]
+
+    def _fake_align_segments(audio_path, segments, **kwargs):
+        assert len(segments) == 1 and segments[0]["words"]
+        return fake_aligned
+
+    import ai.forced_align as fa
+    monkeypatch.setattr(fa, "align_segments", _fake_align_segments)
+
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho("j1", {"speaker": "Fail02"})
+
+    assert result["filled"] == 1  # one coarse segment
+    assert result["ortho_words"] == 2  # two word-level entries
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    coarse = ann["tiers"]["ortho"]["intervals"]
+    assert [iv["text"] for iv in coarse] == ["بەش سەرە"]
+
+    words = ann["tiers"]["ortho_words"]["intervals"]
+    assert [iv["text"] for iv in words] == ["بەش", "سەرە"]
+    assert words[0]["start"] == pytest.approx(0.08)
+    assert words[0]["end"] == pytest.approx(0.52)
+    assert words[0]["source"] == "forced_align"
+    assert words[0]["confidence"] == pytest.approx(0.97)
+
+
+def test_ortho_words_empty_when_segments_have_no_word_level_data(tmp_path, monkeypatch):
+    """Tier-2 is a no-op (empty ortho_words) when segments lack words[]."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    stub = _StubOrthoProvider()  # default: no words[]
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho("j1", {"speaker": "Fail02"})
+    assert result["ortho_words"] == 0
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    assert ann["tiers"]["ortho_words"]["intervals"] == []
+
+
+def test_ortho_words_survives_alignment_exception(tmp_path, monkeypatch):
+    """align_segments raising shouldn't fail the ortho job — fall through
+    with an empty ortho_words tier so the coarse pass still lands."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    segments_with_words = [
+        {
+            "start": 0.0, "end": 1.0, "text": "hi",
+            "words": [{"word": "hi", "start": 0.0, "end": 1.0, "prob": 0.9}],
+        },
+    ]
+    stub = _StubOrthoProvider(segments=segments_with_words)
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+
+    import ai.forced_align as fa
+    def _boom(*a, **kw):
+        raise RuntimeError("wav2vec2 unavailable")
+    monkeypatch.setattr(fa, "align_segments", _boom)
+
+    _seed_annotation(tmp_path, "Fail02", source_audio="raw/Fail02.wav")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho("j1", {"speaker": "Fail02"})
+    assert result["filled"] == 1
+    assert result["ortho_words"] == 0
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    assert ann["tiers"]["ortho_words"]["intervals"] == []
 
 
 def test_pipeline_state_reports_all_steps_empty_for_fresh_speaker(tmp_path, monkeypatch):

--- a/python/test_compute_speaker_ortho_refine_lexemes.py
+++ b/python/test_compute_speaker_ortho_refine_lexemes.py
@@ -144,7 +144,7 @@ def test_refine_lexemes_payload_override_enables_fallback(tmp_path, monkeypatch)
 
     ann = _load(tmp_path, "Fail02")
     words = ann["tiers"]["ortho_words"]["intervals"]
-    refined = [w for w in words if w.get("source") == "short_clip_whisper"]
+    refined = [w for w in words if w.get("source") == "short_clip_fallback"]
     assert len(refined) == 1
     assert refined[0]["text"] == "هیر"
     assert refined[0]["start"] == pytest.approx(1.0)

--- a/python/test_compute_speaker_ortho_refine_lexemes.py
+++ b/python/test_compute_speaker_ortho_refine_lexemes.py
@@ -1,0 +1,180 @@
+"""Tests for the ORTH short-clip fallback gated behind refine_lexemes."""
+import json
+import pathlib
+import sys
+
+import pytest
+
+pytest.importorskip("numpy")  # short-clip fallback loads audio via numpy
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server  # noqa: E402
+
+
+class _StubOrthoProvider:
+    """Stub provider that also implements transcribe_clip for the fallback."""
+
+    def __init__(self, segments, clip_text: str = "هیر", clip_conf: float = 0.88):
+        self._segments = segments
+        self._clip_text = clip_text
+        self._clip_conf = clip_conf
+        self.clip_calls: list[dict] = []
+        self.refine_lexemes = False  # provider-level default; job can override
+
+    def transcribe(self, audio_path, language=None, progress_callback=None):
+        return list(self._segments)
+
+    def transcribe_clip(self, audio_array, *, initial_prompt=None, language=None):
+        self.clip_calls.append({
+            "len": int(getattr(audio_array, "shape", [0])[0] or 0),
+            "initial_prompt": initial_prompt,
+            "language": language,
+        })
+        return (self._clip_text, self._clip_conf)
+
+
+def _seed(tmp_path, speaker="Fail02", concept_intervals=None, source_audio="raw/Fail02.wav"):
+    ann_dir = tmp_path / "annotations"
+    ann_dir.mkdir(exist_ok=True)
+    annotation = {
+        "version": 1,
+        "project_id": "t",
+        "speaker": speaker,
+        "source_audio": source_audio,
+        "source_audio_duration_sec": 3.0,
+        "tiers": {
+            "ipa":     {"type": "interval", "display_order": 1, "intervals": []},
+            "ortho":   {"type": "interval", "display_order": 2, "intervals": []},
+            "concept": {"type": "interval", "display_order": 3, "intervals": concept_intervals or []},
+            "speaker": {"type": "interval", "display_order": 4, "intervals": []},
+        },
+        "metadata": {"language_code": "sdh"},
+    }
+    (ann_dir / f"{speaker}.parse.json").write_text(json.dumps(annotation), encoding="utf-8")
+
+
+def _fake_wav(tmp_path, rel):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfake")
+    return p
+
+
+def _load(tmp_path, speaker):
+    return json.loads((tmp_path / "annotations" / f"{speaker}.parse.json").read_text("utf-8"))
+
+
+def _patch_audio_loader(monkeypatch, duration_sec: float = 3.0):
+    """Replace _load_audio_mono_16k with a synthetic tensor of N samples."""
+    import numpy as np
+    samples = int(duration_sec * 16000)
+    fake_audio = np.zeros(samples, dtype="float32")
+
+    class _FakeTensor:
+        def __init__(self, arr):
+            self._arr = arr
+            self.shape = arr.shape
+        def squeeze(self):
+            return self
+        def numpy(self):
+            return self._arr
+
+    import ai.forced_align as fa
+    monkeypatch.setattr(fa, "_load_audio_mono_16k", lambda p: _FakeTensor(fake_audio))
+
+
+def _patch_align(monkeypatch, aligned):
+    import ai.forced_align as fa
+    monkeypatch.setattr(fa, "align_segments", lambda audio_path, segments, **kw: aligned)
+
+
+def test_refine_lexemes_disabled_skips_short_clip(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    segments = [{
+        "start": 0.0, "end": 2.0, "text": "whole narrative",
+        "words": [{"word": "whole", "start": 0.1, "end": 0.9, "prob": 0.8}],
+    }]
+    stub = _StubOrthoProvider(segments=segments)
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+    _patch_align(monkeypatch, [[
+        {"word": "whole", "start": 0.1, "end": 0.9, "confidence": 0.8},
+    ]])
+    _patch_audio_loader(monkeypatch)
+
+    concepts = [{"start": 1.0, "end": 1.2, "text": "hair"}]
+    _seed(tmp_path, concept_intervals=concepts)
+    _fake_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho("j", {"speaker": "Fail02"})
+
+    assert result["refine_lexemes_enabled"] is False
+    assert result["refined_lexemes"] == 0
+    assert stub.clip_calls == []
+
+
+def test_refine_lexemes_payload_override_enables_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    segments = [{
+        "start": 0.0, "end": 2.0, "text": "whole narrative",
+        "words": [{"word": "unrelated", "start": 0.0, "end": 0.2, "prob": 0.9}],
+    }]
+    stub = _StubOrthoProvider(segments=segments)
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+    # Aligned word is outside the concept anchor window → weak/no match →
+    # fallback should fire for the "hair" concept at 1.0–1.2s.
+    _patch_align(monkeypatch, [[
+        {"word": "unrelated", "start": 0.0, "end": 0.2, "confidence": 0.9},
+    ]])
+    _patch_audio_loader(monkeypatch)
+
+    concepts = [{"start": 1.0, "end": 1.2, "text": "hair"}]
+    _seed(tmp_path, concept_intervals=concepts)
+    _fake_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho(
+        "j", {"speaker": "Fail02", "refine_lexemes": True},
+    )
+
+    assert result["refine_lexemes_enabled"] is True
+    assert result["refined_lexemes"] == 1
+    assert len(stub.clip_calls) == 1
+    assert "hair" in (stub.clip_calls[0]["initial_prompt"] or "")
+
+    ann = _load(tmp_path, "Fail02")
+    words = ann["tiers"]["ortho_words"]["intervals"]
+    refined = [w for w in words if w.get("source") == "short_clip_whisper"]
+    assert len(refined) == 1
+    assert refined[0]["text"] == "هیر"
+    assert refined[0]["start"] == pytest.approx(1.0)
+    assert refined[0]["end"] == pytest.approx(1.2)
+
+
+def test_refine_lexemes_strong_match_skipped(tmp_path, monkeypatch):
+    """When forced-alignment confidence is already high on a concept span,
+    the short-clip fallback must not re-transcribe — it's wasted compute."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    segments = [{
+        "start": 0.0, "end": 2.0, "text": "hair",
+        "words": [{"word": "hair", "start": 1.0, "end": 1.2, "prob": 0.99}],
+    }]
+    stub = _StubOrthoProvider(segments=segments)
+    monkeypatch.setattr(server, "get_ortho_provider", lambda: stub)
+    _patch_align(monkeypatch, [[
+        {"word": "hair", "start": 1.0, "end": 1.2, "confidence": 0.95},
+    ]])
+    _patch_audio_loader(monkeypatch)
+
+    concepts = [{"start": 1.0, "end": 1.2, "text": "hair"}]
+    _seed(tmp_path, concept_intervals=concepts)
+    _fake_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_ortho(
+        "j", {"speaker": "Fail02", "refine_lexemes": True},
+    )
+
+    assert result["refine_lexemes_enabled"] is True
+    assert result["refined_lexemes"] == 0
+    assert stub.clip_calls == []

--- a/python/textgrid_io.py
+++ b/python/textgrid_io.py
@@ -34,6 +34,7 @@ _CANONICAL_TEXTGRID_NAMES = {
     "ipa_phone": "Phones",
     "ipa": "IPA",
     "ortho": "Ortho",
+    "ortho_words": "Ortho words",
     "stt": "STT",
     "concept": "Concept",
     "sentence": "Sentence",
@@ -46,10 +47,11 @@ _CANONICAL_DISPLAY_ORDERS = {
     "ipa_phone": 1,
     "ipa": 2,
     "ortho": 3,
-    "stt": 4,
-    "concept": 5,
-    "sentence": 6,
-    "speaker": 7,
+    "ortho_words": 4,
+    "stt": 5,
+    "concept": 6,
+    "sentence": 7,
+    "speaker": 8,
 }
 
 _LONG_ITEM_HEADER_RE = re.compile(r"^item\s*\[\s*(\d+)\s*\]\s*:$")

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -691,4 +691,53 @@ describe("Actions menu — transcription run flow", () => {
 
     confirmSpy.mockRestore();
   });
+
+  it("prefills Orthographic (Kurdish) from ortho_words word when coarse ortho is a monolithic segment", async () => {
+    // Simulates the Fail102 regression: razhan produces one giant coarse
+    // ortho interval covering minutes of narrative. Without ortho_words, the
+    // whole paragraph text would land in the lexeme field. With ortho_words
+    // (from Tier-2 forced alignment), the single-word entry wins.
+    const COARSE_TEXT = "زور جوان بووین ئاو دەگڕێ";  // monolithic paragraph
+    const WORD_TEXT = "ئاو";  // expected: just the Kurdish word for water
+
+    mockConfig = {
+      project_name: "PARSE",
+      language_code: "ku",
+      speakers: ["Fail01", "Kalh01"],
+      concepts: [{ id: "1", label: "water" }, { id: "2", label: "fire" }],
+      audio_dir: "audio",
+      annotations_dir: "annotations",
+    };
+
+    const base = makeRecord("Fail01", [
+      { conceptText: "water", ortho: COARSE_TEXT, start: 0.0, end: 5.0 },
+    ]);
+    mockRecords = {
+      Fail01: {
+        ...base,
+        tiers: {
+          ...base.tiers,
+          // Word-level tier: single word fully inside the concept anchor
+          ortho_words: {
+            name: "ortho_words",
+            display_order: 4,
+            intervals: [
+              { start: 1.1, end: 1.4, text: WORD_TEXT },
+            ],
+          },
+        },
+      },
+    };
+
+    render(<ParseUI />);
+    await switchToAnnotateMode();
+
+    // After mode switch the annotate view renders and findAnnotationForConcept
+    // preferring ortho_words populates the ortho input with the single word.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(WORD_TEXT)).toBeTruthy();
+    });
+    // The coarse paragraph must NOT appear as the pre-filled value.
+    expect(screen.queryByDisplayValue(COARSE_TEXT)).toBeNull();
+  });
 });

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2000,6 +2000,7 @@ export function ParseUI() {
       steps: confirm.steps,
       overwrites: confirm.overwrites,
       language: sttLanguageRef.current || undefined,
+      refineLexemes: confirm.refineLexemes,
     });
   };
 

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -134,6 +134,37 @@ function getConceptStatus(tags: StoreTag[]): ConceptTag {
   return 'untagged';
 }
 
+// Prefer word-level ortho_words (from Tier-2 forced alignment) over the
+// coarse ortho tier. When the coarse tier is one monolithic segment — as
+// razhan often produces on long elicited word-list recordings — picking
+// the whole-paragraph interval by overlap dumps the entire narrative into
+// a single lexeme field. The word-level tier yields a single clean word.
+export function pickOrthoIntervalForConcept(
+  record: AnnotationRecord,
+  conceptInterval: AnnotationInterval,
+): AnnotationInterval | null {
+  const words = record.tiers.ortho_words?.intervals ?? [];
+  if (words.length) {
+    const contained = words.find(
+      (iv) => iv.start >= conceptInterval.start && iv.end <= conceptInterval.end,
+    );
+    if (contained) return contained;
+
+    let bestOverlap = 0;
+    let bestWord: AnnotationInterval | null = null;
+    for (const iv of words) {
+      if (iv.end <= conceptInterval.start || iv.start >= conceptInterval.end) continue;
+      const ov = Math.min(iv.end, conceptInterval.end) - Math.max(iv.start, conceptInterval.start);
+      if (ov > bestOverlap) {
+        bestOverlap = ov;
+        bestWord = iv;
+      }
+    }
+    if (bestWord) return bestWord;
+  }
+  return (record.tiers.ortho?.intervals ?? []).find((iv) => overlaps(iv, conceptInterval)) ?? null;
+}
+
 function findAnnotationForConcept(record: AnnotationRecord | null | undefined, concept: Concept) {
   if (!record) {
     return { conceptInterval: null, ipaInterval: null, orthoInterval: null };
@@ -147,7 +178,7 @@ function findAnnotationForConcept(record: AnnotationRecord | null | undefined, c
   }
 
   const ipaInterval = (record.tiers.ipa?.intervals ?? []).find((interval) => overlaps(interval, conceptInterval)) ?? null;
-  const orthoInterval = (record.tiers.ortho?.intervals ?? []).find((interval) => overlaps(interval, conceptInterval)) ?? null;
+  const orthoInterval = pickOrthoIntervalForConcept(record, conceptInterval);
 
   return { conceptInterval, ipaInterval, orthoInterval };
 }
@@ -196,15 +227,16 @@ function buildSpeakerForm(
   const speakerFlagged = !!(conceptFlags && conceptFlags[speaker]);
 
   const primaryConceptInterval = conceptIntervals[0] ?? null;
-  const orthoIntervals = record?.tiers.ortho?.intervals ?? [];
-  const matchingOrthoIntervals = orthoIntervals.filter((orthoInterval) =>
-    conceptIntervals.some((conceptInterval) => overlaps(orthoInterval, conceptInterval)),
-  );
+  // Prefer word-level ortho_words over the coarse ortho tier — see the
+  // rationale on pickOrthoIntervalForConcept above.
+  const orthoText = record && primaryConceptInterval
+    ? pickOrthoIntervalForConcept(record, primaryConceptInterval)?.text ?? ''
+    : '';
 
   return {
     speaker,
     ipa: matchingIpaIntervals[0]?.text ?? '',
-    ortho: matchingOrthoIntervals[0]?.text ?? '',
+    ortho: orthoText,
     utterances: matchingIpaIntervals.length,
     arabicSim,
     persianSim,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -10,7 +10,7 @@ export interface AnnotationInterval {
 
 export interface OrthoWordInterval extends AnnotationInterval {
   confidence?: number;
-  source?: "forced_align" | "short_clip_whisper";
+  source?: "forced_align" | "short_clip_fallback";
 }
 
 export interface AnnotationTier {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -8,6 +8,11 @@ export interface AnnotationInterval {
   text: string;
 }
 
+export interface OrthoWordInterval extends AnnotationInterval {
+  confidence?: number;
+  source?: "forced_align" | "short_clip_whisper";
+}
+
 export interface AnnotationTier {
   name: string;
   display_order: number;
@@ -16,7 +21,7 @@ export interface AnnotationTier {
 
 export interface AnnotationRecord {
   speaker: string;
-  tiers: Record<string, AnnotationTier>; // keys: ipa_phone, ipa, ortho, stt, concept, sentence, speaker
+  tiers: Record<string, AnnotationTier>; // keys: ipa_phone, ipa, ortho, ortho_words, stt, concept, sentence, speaker
   created_at?: string;
   modified_at?: string;
   source_wav?: string;

--- a/src/components/shared/TranscriptionRunModal.tsx
+++ b/src/components/shared/TranscriptionRunModal.tsx
@@ -425,7 +425,7 @@ export function TranscriptionRunModal({
             <span className="text-xs font-semibold text-slate-700">ORTH</span>
             <label
               className="flex items-center gap-1.5 text-xs text-slate-700 cursor-pointer"
-              title="Enables ~1–2 min extra compute for perfectly clean lexemes (recommended for new speakers)."
+              title="Re-transcribes each concept whose forced-alignment confidence is below 0.5 using a ±0.8 s audio clip. Adds ~1–2 min on thesis-scale recordings — leave off unless forced-alignment quality is poor."
             >
               <input
                 type="checkbox"

--- a/src/components/shared/TranscriptionRunModal.tsx
+++ b/src/components/shared/TranscriptionRunModal.tsx
@@ -46,6 +46,9 @@ export interface TranscriptionRunConfirm {
   speakers: string[];
   steps: PipelineStepId[];
   overwrites: Partial<Record<PipelineStepId, boolean>>;
+  /** Opt-in short-clip Whisper fallback for the ORTH step. Only meaningful
+   *  when `steps` includes `"ortho"`; the backend ignores it otherwise. */
+  refineLexemes?: boolean;
 }
 
 export interface TranscriptionRunModalProps {
@@ -175,11 +178,15 @@ export function TranscriptionRunModal({
   const [selectedSteps, setSelectedSteps] = useState<Set<PipelineStepId>>(
     () => new Set(),
   );
+  // Off by default — opt-in per run. Adds ~1-2 min to each ORTH run on
+  // thesis-scale audio, so surfacing it as unchecked is the safer default.
+  const [refineLexemes, setRefineLexemes] = useState(false);
 
   // Reset state when the modal opens.
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
+    setRefineLexemes(false);
 
     // Seed per-speaker load entries as "loading".
     const initial: Record<string, SpeakerLoadEntry> = {};
@@ -353,7 +360,15 @@ export function TranscriptionRunModal({
       }
     }
 
-    onConfirm({ speakers: speakersArr, steps: stepsArr, overwrites });
+    // refine_lexemes only matters when ORTH is actually scheduled; drop it
+    // otherwise so the backend falls back to its ai_config default.
+    const includesOrtho = stepsArr.includes("ortho");
+    onConfirm({
+      speakers: speakersArr,
+      steps: stepsArr,
+      overwrites,
+      refineLexemes: includesOrtho && refineLexemes ? true : undefined,
+    });
   };
 
   if (!open) return null;
@@ -398,6 +413,29 @@ export function TranscriptionRunModal({
                 </label>
               );
             })}
+          </div>
+        )}
+
+        {/* ORTH options — only relevant when ortho is scheduled. */}
+        {stepsToRender.includes("ortho") && (
+          <div
+            className="flex flex-wrap items-center gap-3 rounded-md border border-slate-200 bg-white px-3 py-2"
+            data-testid="transcription-run-ortho-options"
+          >
+            <span className="text-xs font-semibold text-slate-700">ORTH</span>
+            <label
+              className="flex items-center gap-1.5 text-xs text-slate-700 cursor-pointer"
+              title="Enables ~1–2 min extra compute for perfectly clean lexemes (recommended for new speakers)."
+            >
+              <input
+                type="checkbox"
+                data-testid="transcription-run-refine-lexemes"
+                className="h-3.5 w-3.5 rounded border-slate-300"
+                checked={refineLexemes}
+                onChange={(e) => setRefineLexemes(e.target.checked)}
+              />
+              <span>Refine lexemes (short-clip fallback)</span>
+            </label>
           </div>
         )}
 

--- a/src/hooks/useBatchPipelineJob.ts
+++ b/src/hooks/useBatchPipelineJob.ts
@@ -15,6 +15,11 @@ export interface BatchRunRequest {
    *  steps that actually failed last time — prevents re-running (and
    *  overwriting) steps that succeeded for that speaker. */
   stepsBySpeaker?: Partial<Record<string, PipelineStepId[]>>;
+  /** Opt-in short-clip Whisper fallback for the ORTH step. When true the
+   *  backend re-transcribes a ±0.8s window per concept whose forced-
+   *  alignment match is weak/missing — adds ~1-2 min to a thesis-scale
+   *  speaker. Omit to defer to the provider's ai_config default. */
+  refineLexemes?: boolean;
 }
 
 export interface BatchSpeakerOutcome {
@@ -263,6 +268,9 @@ export function useBatchPipelineJob(): UseBatchPipelineJobResult {
             };
             if (request.language) {
               body.language = request.language;
+            }
+            if (request.refineLexemes) {
+              body.refine_lexemes = true;
             }
             const job = await startCompute("full_pipeline", body);
             if (!isActive()) return;

--- a/src/pickOrthoIntervalForConcept.test.ts
+++ b/src/pickOrthoIntervalForConcept.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import type { AnnotationRecord, AnnotationInterval } from "./api/types";
+import { pickOrthoIntervalForConcept } from "./ParseUI";
+
+function makeRecord(partial: {
+  ortho?: AnnotationInterval[];
+  ortho_words?: AnnotationInterval[];
+}): AnnotationRecord {
+  return {
+    speaker: "Fail02",
+    tiers: {
+      ipa_phone: { name: "ipa_phone", display_order: 1, intervals: [] },
+      ipa:       { name: "ipa",       display_order: 2, intervals: [] },
+      ortho:     { name: "ortho",     display_order: 3, intervals: partial.ortho ?? [] },
+      ortho_words: { name: "ortho_words", display_order: 4, intervals: partial.ortho_words ?? [] },
+      stt:       { name: "stt",       display_order: 5, intervals: [] },
+      concept:   { name: "concept",   display_order: 6, intervals: [] },
+      sentence:  { name: "sentence",  display_order: 7, intervals: [] },
+      speaker:   { name: "speaker",   display_order: 8, intervals: [] },
+    },
+    source_wav: "",
+  };
+}
+
+describe("pickOrthoIntervalForConcept", () => {
+  const conceptInterval: AnnotationInterval = { start: 10.0, end: 10.4, text: "hair" };
+
+  it("prefers the word-level tier over the coarse ortho tier", () => {
+    const record = makeRecord({
+      ortho: [{ start: 0, end: 300, text: "whole narrative dumped here" }],
+      ortho_words: [
+        { start: 5.0, end: 5.3, text: "other" },
+        { start: 10.1, end: 10.3, text: "مووی" },
+      ],
+    });
+
+    const picked = pickOrthoIntervalForConcept(record, conceptInterval);
+    expect(picked?.text).toBe("مووی");
+  });
+
+  it("falls back to the coarse ortho tier when ortho_words is empty", () => {
+    const record = makeRecord({
+      ortho: [{ start: 10.0, end: 10.4, text: "مووی" }],
+      ortho_words: [],
+    });
+    expect(pickOrthoIntervalForConcept(record, conceptInterval)?.text).toBe("مووی");
+  });
+
+  it("picks the word with the greatest overlap when none is strictly contained", () => {
+    const record = makeRecord({
+      ortho_words: [
+        { start: 9.8, end: 10.15, text: "left" },   // 0.15s overlap
+        { start: 10.25, end: 10.6, text: "right" }, // 0.15s overlap — same, first wins
+        { start: 10.0, end: 10.3, text: "center" }, // 0.30s overlap — best
+      ],
+    });
+    expect(pickOrthoIntervalForConcept(record, conceptInterval)?.text).toBe("center");
+  });
+
+  it("returns null when no tier has a matching interval", () => {
+    const record = makeRecord({});
+    expect(pickOrthoIntervalForConcept(record, conceptInterval)).toBeNull();
+  });
+});

--- a/src/stores/annotationStore.ts
+++ b/src/stores/annotationStore.ts
@@ -11,13 +11,14 @@ import { getAnnotation, saveAnnotation } from "../api/client";
 // Adding a new tier? Update _CANONICAL_DISPLAY_ORDERS in python/textgrid_io.py
 // to match, or Praat exports will fall back to default_order=9999.
 const CANONICAL_TIER_ORDER: Record<string, number> = {
-  ipa_phone: 1, // phone-level IPA (wav2vec2 output, lane-visible)
-  ipa: 2,       // word/lexeme-level IPA (lane-visible)
-  ortho: 3,     // orthographic transcription (lane-visible)
-  stt: 4,       // speech-to-text reference (lane-visible)
-  concept: 5,   // concept tags
-  sentence: 6,  // sentence-level grouping (starts empty)
-  speaker: 7,   // speaker turn
+  ipa_phone: 1,   // phone-level IPA (wav2vec2 output, lane-visible)
+  ipa: 2,         // word/lexeme-level IPA (lane-visible)
+  ortho: 3,       // orthographic transcription, coarse Whisper segments (lane-visible)
+  ortho_words: 4, // word-level ortho from Tier-2 forced alignment (data-only, no lane)
+  stt: 5,         // speech-to-text reference (lane-visible)
+  concept: 6,     // concept tags
+  sentence: 7,    // sentence-level grouping (starts empty)
+  speaker: 8,     // speaker turn
 };
 
 function nowIsoUtc(): string {
@@ -28,13 +29,14 @@ function blankRecord(speaker: string): AnnotationRecord {
   return {
     speaker,
     tiers: {
-      ipa_phone: { name: "ipa_phone", display_order: 1, intervals: [] },
-      ipa:       { name: "ipa",       display_order: 2, intervals: [] },
-      ortho:     { name: "ortho",     display_order: 3, intervals: [] },
-      stt:       { name: "stt",       display_order: 4, intervals: [] },
-      concept:   { name: "concept",   display_order: 5, intervals: [] },
-      sentence:  { name: "sentence",  display_order: 6, intervals: [] },
-      speaker:   { name: "speaker",   display_order: 7, intervals: [] },
+      ipa_phone:   { name: "ipa_phone",   display_order: 1, intervals: [] },
+      ipa:         { name: "ipa",         display_order: 2, intervals: [] },
+      ortho:       { name: "ortho",       display_order: 3, intervals: [] },
+      ortho_words: { name: "ortho_words", display_order: 4, intervals: [] },
+      stt:         { name: "stt",         display_order: 5, intervals: [] },
+      concept:     { name: "concept",     display_order: 6, intervals: [] },
+      sentence:    { name: "sentence",    display_order: 7, intervals: [] },
+      speaker:     { name: "speaker",     display_order: 8, intervals: [] },
     },
     created_at: nowIsoUtc(),
     modified_at: nowIsoUtc(),


### PR DESCRIPTION
## Summary

- Long elicited word-list recordings (e.g. **Fail102.wav**) collapse into one coarse ortho segment covering minutes of narrative. Lexeme fields on the concept card are populated client-side by simple interval overlap against the ortho tier, so concepts anchored inside that giant segment get the whole paragraph dumped into their ORTHOGRAPHIC field — the exact \"hair\" corruption you showed me.
- This adds a Tier-2 forced-alignment pass after the ORTH compute job, persists the refined word-level data in a new canonical tier `tiers.ortho_words`, and updates the lexeme lookup to prefer it. An opt-in short-clip Whisper fallback (gated by `refine_lexemes`) cleans up concepts whose forced-alignment match is missing or weak by re-transcribing a ±0.8s window with the concept list fed in as `initial_prompt`.
- Backward-compatible by design: the coarse `ortho` tier stays intact; old annotations get `ortho_words` backfilled on load via `ensureCanonicalTiers`; the four-tier viewer from #177 is untouched (ortho_words is data-only, no lane).

## What changed

- **New canonical tier `tiers.ortho_words`** — added to `CANONICAL_TIER_ORDER` (frontend, [src/stores/annotationStore.ts](src/stores/annotationStore.ts)) and `_CANONICAL_DISPLAY_ORDERS` (python, [python/textgrid_io.py](python/textgrid_io.py)), both renumbered to keep integer ordering.
- **Tier-2 alignment in the ORTH job** — [python/server.py](python/server.py) `_compute_speaker_ortho` now calls `align_segments` on the fresh segments (reusing the existing production-grade aligner from [python/ai/forced_align.py](python/ai/forced_align.py); no changes to alignment itself). Failures log a warning and fall through; the coarse tier is unaffected.
- **Config + provider plumbing** — `LocalWhisperProvider` gains `initial_prompt` (piped into full-file Whisper) and `refine_lexemes` section config, plus a `transcribe_clip(numpy_audio, …)` helper for the fallback path. Defaults documented in [config/ai_config.example.json](config/ai_config.example.json).
- **Short-clip fallback** — gated behind `refine_lexemes: true` (default **off** so thesis-scale ORTH runs aren't surprised by an extra ~1–2 min). Iterates concept-tier intervals, finds the best `ortho_words` overlap, and only re-transcribes a ±0.8s slice if that match is missing or has confidence < 0.5. The `initial_prompt` is the concept list joined with commas, truncated to 400 chars.
- **Frontend lookup** — `findAnnotationForConcept` + `buildSpeakerForm` in [src/ParseUI.tsx](src/ParseUI.tsx) now prefer `ortho_words` (by strict containment, then best overlap), falling back to the coarse ortho tier when the word-level tier is empty.

## Out of scope — follow-up PR

- \"Confirm & Bulk Align Remaining\" button + diff modal + `computeType=bulk-align`
- Enhanced `detect_timestamp_offset` keyed off `ortho_words`
- Levenshtein / phonetic post-matching (current fallback trusts the short-clip Whisper output directly)
- Cross-speaker propagation

## Test plan

- [x] `npm run check` — TS typecheck passes clean
- [x] `npm run test` — 36 files / 221 tests pass (new: `src/pickOrthoIntervalForConcept.test.ts` × 4)
- [x] `pytest python/test_compute_speaker_ortho.py python/test_compute_speaker_ortho_refine_lexemes.py` — 29 passed (3 new ortho_words tests + 3 new refine_lexemes tests)
- [ ] Validate on Fail102.wav end-to-end:
  - [ ] Run ORTH compute on `Fail102.wav` (`refine_lexemes=false` first). Confirm `annotations/Fail102.parse.json` has `tiers.ortho_words.intervals` populated with short word-level entries and the coarse `tiers.ortho` is unchanged.
  - [ ] Open the UI, navigate to the \"hair\" concept. Confirm the ORTHOGRAPHIC (KURDISH) field shows just the Kurdish word, not the whole paragraph.
  - [ ] Set `refine_lexemes=true` (per-job payload or `ai_config.json`), re-run ORTH. Confirm low-confidence concepts are refined via short-clip (`source: \"short_clip_whisper\"` on the interval).
  - [ ] Sanity-check one other speaker (Fail101 / Khan01 — whichever is in `annotations/`) to ensure no regression on cleaner recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)