### PR TITLE
fix(parse-run): preflight bind probe races pm2 stop (Errno 98)

### DIFF
--- a/scripts/parse-run.sh
+++ b/scripts/parse-run.sh
@@ -181,11 +181,27 @@ stop_servers() {
 # the actionable fix (wsl --shutdown) before start_api wastes time.
 
 preflight_api_port() {
-  local probe_out
-  probe_out=$(
-    "${PARSE_PY}" - <<PY 2>&1
+  # Enable SO_REUSEADDR on the probe so a TIME_WAIT / CLOSING socket left
+  # over from the PM2 stop we just ran doesn't report as a phantom
+  # reservation. The real server's socketserver.TCPServer sets
+  # allow_reuse_address=True, so the probe must match — otherwise the
+  # probe is stricter than the actual bind and emits false positives.
+  #
+  # Even with REUSEADDR there's a short window (~100 ms) where the
+  # kernel hasn't finished flushing the old listener. Retry up to 5
+  # times at 300 ms each (~1.5 s total) before giving up, so an
+  # immediate re-run after ``stop_servers`` doesn't bail out on
+  # Errno 98 every time. A true phantom reservation will still fail
+  # on every retry and hit the WinError branches below with the
+  # actionable ``wsl --shutdown`` hint.
+  local probe_out=""
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    probe_out=$(
+      "${PARSE_PY}" - <<PY 2>&1
 import socket, sys
 s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 try:
     s.bind(("127.0.0.1", ${PARSE_API_PORT}))
 except OSError as exc:
@@ -198,7 +214,14 @@ finally:
         pass
 print("BIND_OK")
 PY
-  ) || true
+    ) || true
+    case "${probe_out}" in
+      BIND_OK*) break ;;
+    esac
+    if [ "${attempt}" -lt 5 ]; then
+      sleep 0.3
+    fi
+  done
 
   case "${probe_out}" in
     BIND_OK*)


### PR DESCRIPTION
## Summary

- `parse-run` sometimes aborts immediately after a successful `pm2 stop parse-api` with `[Errno 98] Address already in use` on 127.0.0.1:8766 — observed today after the PR #178 merge while trying to restart the dev server on the PC.
- Root cause isn't a phantom Windows reservation (the existing preflight already handles those with the `wsl --shutdown` hint). It's a plain Linux race: `pm2 stop` returns as soon as SIGTERM is sent, but the Python server's listen socket is still in TCP close sequence for ~100 ms. The preflight's bind probe hits that window, trips `EADDRINUSE`, and the script exits before the kernel finishes the close.
- Two changes on the probe in [scripts/parse-run.sh](scripts/parse-run.sh):
  - Set `SO_REUSEADDR`. The real server's `http.server.HTTPServer` sets `allow_reuse_address=True` (see [python/server.py:6973](python/server.py:6973)), so the probe must match — otherwise it's stricter than the actual bind and emits false positives.
  - Retry up to 5 × 300ms (~1.5s total) before giving up. A genuine phantom reservation still fails every retry and falls through to the existing `WinError 10013/10048` branches with the actionable `wsl --shutdown` hint.

## Test plan

- [x] `bash -n scripts/parse-run.sh` — syntax OK
- [x] Verified today on the PC: after an initial failure with `[Errno 98]`, the same port became free in <1s (confirmed via `ss -tlnp`, `lsof -i :8766`, and a manual python bind from WSL) and a subsequent `parse-run` came up clean (`pm2` online, `GET /api/config` 200, Vite 200). The retry loop matches that observed close-timeout.
- [ ] On next `parse-run` restart, confirm the preflight no longer bails with `[Errno 98]` on back-to-back invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)