### PR TITLE
Persist active mode + root ErrorBoundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
 import { BrowserRouter } from "react-router-dom";
 import { ParseUI } from "./ParseUI";
+import { ErrorBoundary } from "./components/shared/ErrorBoundary";
 
 export function App() {
   return (
-    <BrowserRouter>
-      <ParseUI />
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <ParseUI />
+      </BrowserRouter>
+    </ErrorBoundary>
   );
 }

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -1901,7 +1901,20 @@ export function ParseUI() {
       setSpeakerPicker(rawSpeakers.find(s => !rawSpeakers.includes(s)) ?? rawSpeakers[0] ?? null);
     }
   }, [rawSpeakers]); // eslint-disable-line react-hooks/exhaustive-deps
-  const [currentMode, setCurrentMode] = useState<AppMode>('compare');
+  // Persist the active mode so an accidental unmount (HMR, error boundary
+  // reset, or a root-level remount) doesn't snap the user back to Compare
+  // and away from an in-flight Annotate session.
+  const [currentMode, setCurrentMode] = useState<AppMode>(() => {
+    try {
+      const raw = localStorage.getItem('parse.currentMode');
+      if (raw === 'annotate' || raw === 'compare' || raw === 'tags') return raw;
+    } catch { /* localStorage disabled — fall through */ }
+    return 'compare';
+  });
+  useEffect(() => {
+    try { localStorage.setItem('parse.currentMode', currentMode); }
+    catch { /* non-fatal */ }
+  }, [currentMode]);
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
   const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
   const [sttLanguage, setSttLanguage] = useState<string>(() => {

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+}
+
+/**
+ * Root-level error boundary. Without one, an uncaught render error (e.g. a
+ * crash in the post-STT reload flow) unmounts the entire tree and Vite HMR
+ * presents it as a page refresh — losing in-flight process output and
+ * snapping local component state (like the current mode) back to defaults.
+ *
+ * This boundary catches the error, shows the stack, and lets the user retry
+ * without a full reload — so the next time the "phantom refresh" happens
+ * we actually see what triggered it.
+ */
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null, errorInfo: null };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error("[ErrorBoundary] caught:", error, errorInfo);
+    this.setState({ errorInfo });
+  }
+
+  handleReset = (): void => {
+    this.setState({ error: null, errorInfo: null });
+  };
+
+  render(): React.ReactNode {
+    const { error, errorInfo } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div
+        style={{
+          minHeight: "100vh",
+          padding: "1.5rem",
+          fontFamily: "monospace",
+          fontSize: "0.875rem",
+          background: "#fff5f5",
+          color: "#7f1d1d",
+          overflow: "auto",
+        }}
+        role="alert"
+      >
+        <div style={{ fontWeight: 700, fontSize: "1rem", marginBottom: "0.75rem" }}>
+          PARSE hit an unhandled error
+        </div>
+        <div style={{ marginBottom: "0.5rem", color: "#991b1b" }}>
+          The app kept running instead of reloading, so the process output you
+          were looking at in the other panels is still intact. Copy the trace
+          below and share it — that's what we need to chase the root cause.
+        </div>
+        <div style={{ marginBottom: "0.5rem" }}>
+          <button
+            type="button"
+            onClick={this.handleReset}
+            style={{
+              padding: "0.375rem 0.75rem",
+              border: "1px solid #991b1b",
+              borderRadius: "0.25rem",
+              background: "#fee2e2",
+              color: "#7f1d1d",
+              cursor: "pointer",
+              fontFamily: "monospace",
+              fontSize: "0.75rem",
+            }}
+          >
+            Try to recover (clears the error, re-renders the tree)
+          </button>
+        </div>
+        <pre
+          style={{
+            whiteSpace: "pre-wrap",
+            background: "#fee2e2",
+            border: "1px solid #fca5a5",
+            borderRadius: "0.25rem",
+            padding: "0.75rem",
+            marginTop: "0.5rem",
+            maxHeight: "60vh",
+            overflow: "auto",
+          }}
+        >
+          {error.message}
+          {"\n\n"}
+          {error.stack}
+          {errorInfo?.componentStack ? "\n\n--- React component stack ---" + errorInfo.componentStack : ""}
+        </pre>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Two small, scoped changes so the next post-STT "phantom refresh" is both rarer and diagnosable.

1. **Persist `currentMode`** — was a bare `useState('compare')` at [ParseUI.tsx:1904](src/ParseUI.tsx). Any root remount (HMR, dev-server blip, error-boundary reset) snapped you out of Annotate mid-task. Now read/written to `localStorage['parse.currentMode']`, matching the pattern already used for `parse.stt.language`.
2. **Root `ErrorBoundary`** — `<App/>` previously had none, so any uncaught render error (suspected culprit: the post-STT `reloadSpeakerAnnotation` flow at [ParseUI.tsx:1972](src/ParseUI.tsx)) bubbled up and Vite HMR presented it as a page reload, nuking in-flight console output. New boundary catches it, logs to console, and shows the error + component stack on-screen so the next occurrence captures its own traceback.

## Why this instead of chasing the root cause first

No repro in hand, and without an error boundary every occurrence erases the evidence. This turns the next occurrence into a copy-paste diagnostic instead of "page just reloaded, dunno what happened." If nothing ever triggers it again, great — the mode-persistence is still worth it on its own.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 222/222 pass
- [ ] Manual: switch to Annotate, hard-reload the page, confirm it comes back in Annotate (was snapping back to Compare before)
- [ ] Manual: temporarily throw from a component (e.g. stick `throw new Error('test')` in a render) to confirm the boundary renders the red panel instead of white-screen / reload
- [ ] Next time STT triggers the phantom refresh: screenshot the boundary panel, paste the stack here

## Scope notes

- No app logic changed on the happy path.
- Boundary is non-recoverable-per-error (sub-tree reset requires clicking "Try to recover") — good enough as a diagnostic net; can refine later if the error is frequent and benign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)