### PR TITLE
feat: expose all PARSE chat tools via MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
     - `POST /api/compute/contact-lexemes`
     - `GET /api/contact-lexemes/coverage`
 
+## MCP adapter note
+
+- `python/adapters/mcp_adapter.py` now supports `config/mcp_config.json` with `{ "expose_all_tools": true }`.
+- Default remains the legacy 29-tool MCP surface; enabling the flag exposes all 47 `ParseChatTools` wrappers for external MCP clients.
+- For backward compatibility, root-level `mcp_config.json` is also accepted when `config/mcp_config.json` is absent.
+
 ## Client/Server Contract Surface
 
 All `src/api/client.ts` helpers have matching routes in `python/server.py`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
 ## MCP adapter note
 
 - `python/adapters/mcp_adapter.py` now supports `config/mcp_config.json` with `{ "expose_all_tools": true }`.
-- Default remains the legacy 29-tool MCP surface; enabling the flag exposes all 47 `ParseChatTools` wrappers for external MCP clients.
+- Default MCP surface is **30 tools**: the legacy 29 `ParseChatTools` wrappers plus read-only `mcp_get_exposure_mode` for self-inspection.
+- Enabling `expose_all_tools` expands the MCP surface to **48 tools**: all 47 `ParseChatTools` plus `mcp_get_exposure_mode`.
 - For backward compatibility, root-level `mcp_config.json` is also accepted when `config/mcp_config.json` is absent.
 
 ## Client/Server Contract Surface

--- a/config/mcp_config.json
+++ b/config/mcp_config.json
@@ -1,0 +1,3 @@
+{
+  "expose_all_tools": false
+}

--- a/docs/mcp_agent_roadmap.md
+++ b/docs/mcp_agent_roadmap.md
@@ -6,21 +6,20 @@ Future improvements to make PARSE a first-class citizen in agent-driven workflow
 
 ## 1. Expose all 47 ParseChatTools via MCP
 
-**Currently:** 47 internal tools power the chat dock; only 29 are exposed to external agents.
+**Status:** ✅ Complete
 
-**What to do:** Make the remaining ~18 tools available through the MCP server — priority: write/edit/pipeline tools.
-
-**Why it matters:** Agents (Claude, Cursor, custom Grok agents) are artificially limited today. Full exposure unlocks autonomous end-to-end workflows:
-
-```
-STT → alignment → IPA → Compare mode → LingPy export
-```
-
-**Bonus:** Add an opt-in flag in `mcp_config.json`:
+**Shipped:**
+- `python/adapters/mcp_adapter.py` now exposes the legacy **29-tool** surface by default.
+- Opt-in config at `config/mcp_config.json` (or fallback root `mcp_config.json`) enables the full **47-tool** `ParseChatTools` surface:
 
 ```json
 { "expose_all_tools": true }
 ```
+
+**Notes:**
+- Default behavior is unchanged for existing MCP clients.
+- The internal chat dock still uses `ParseChatTools` directly; this task only changes MCP exposure.
+- Newly exposed tools include the missing write/export/pipeline helpers such as normalize, enrichments, lexeme notes, exports, peaks, source-index validation, and transcript reformatting.
 
 ---
 

--- a/docs/mcp_agent_roadmap.md
+++ b/docs/mcp_agent_roadmap.md
@@ -9,17 +9,19 @@ Future improvements to make PARSE a first-class citizen in agent-driven workflow
 **Status:** ✅ Complete
 
 **Shipped:**
-- `python/adapters/mcp_adapter.py` now exposes the legacy **29-tool** surface by default.
-- Opt-in config at `config/mcp_config.json` (or fallback root `mcp_config.json`) enables the full **47-tool** `ParseChatTools` surface:
+- `python/adapters/mcp_adapter.py` still exposes the legacy **29 `ParseChatTools`** surface by default.
+- MCP now also includes read-only `mcp_get_exposure_mode`, so the total adapter surface is **30 tools by default**.
+- Opt-in config at `config/mcp_config.json` (or fallback root `mcp_config.json`) enables the full **47-tool** `ParseChatTools` surface, for **48 MCP tools total** including `mcp_get_exposure_mode`:
 
 ```json
 { "expose_all_tools": true }
 ```
 
 **Notes:**
-- Default behavior is unchanged for existing MCP clients.
+- Default behavior is unchanged for existing callers that rely on the legacy 29 PARSE tool wrappers.
 - The internal chat dock still uses `ParseChatTools` directly; this task only changes MCP exposure.
 - Newly exposed tools include the missing write/export/pipeline helpers such as normalize, enrichments, lexeme notes, exports, peaks, source-index validation, and transcript reformatting.
+- `mcp_get_exposure_mode` lets external agents self-inspect whether the active MCP server is running in the default or full-exposure mode.
 
 ---
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -62,37 +62,6 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger("parse.mcp_adapter")
 
 MCP_CONFIG_FILENAME = "mcp_config.json"
-DEFAULT_MCP_TOOL_NAMES = (
-    "project_context_read",
-    "annotation_read",
-    "read_csv_preview",
-    "cognate_compute_preview",
-    "cross_speaker_match_preview",
-    "spectrogram_preview",
-    "contact_lexeme_lookup",
-    "stt_start",
-    "stt_status",
-    "stt_word_level_start",
-    "stt_word_level_status",
-    "forced_align_start",
-    "forced_align_status",
-    "ipa_transcribe_acoustic_start",
-    "ipa_transcribe_acoustic_status",
-    "detect_timestamp_offset",
-    "detect_timestamp_offset_from_pair",
-    "apply_timestamp_offset",
-    "import_tag_csv",
-    "prepare_tag_import",
-    "onboard_speaker_import",
-    "import_processed_speaker",
-    "parse_memory_read",
-    "parse_memory_upsert_section",
-    "speakers_list",
-    "pipeline_state_read",
-    "pipeline_state_batch",
-    "pipeline_run",
-    "compute_status",
-)
 
 # ---------------------------------------------------------------------------
 # Ensure the python/ package is importable
@@ -102,6 +71,8 @@ _ADAPTER_DIR = Path(__file__).resolve().parent
 _PYTHON_DIR = _ADAPTER_DIR.parent
 if str(_PYTHON_DIR) not in sys.path:
     sys.path.insert(0, str(_PYTHON_DIR))
+
+from ai.chat_tools import DEFAULT_MCP_TOOL_NAMES
 
 # ---------------------------------------------------------------------------
 # Lazy MCP SDK import
@@ -180,6 +151,30 @@ def _selected_mcp_tool_names(all_tool_names: List[str], expose_all_tools: bool) 
         return list(all_tool_names)
     available_names = set(all_tool_names)
     return [name for name in DEFAULT_MCP_TOOL_NAMES if name in available_names]
+
+
+def _mcp_exposure_payload(
+    *,
+    expose_all_tools: bool,
+    config_source: Optional[str],
+    parse_chat_tool_count: int,
+    mcp_tool_count: int,
+) -> Dict[str, Any]:
+    """Build a read-only MCP payload describing the active exposure mode."""
+    return {
+        "tool": "mcp_get_exposure_mode",
+        "ok": True,
+        "result": {
+            "readOnly": True,
+            "previewOnly": True,
+            "mode": "read-only",
+            "exposeAllTools": expose_all_tools,
+            "configSource": config_source,
+            "parseChatToolCount": parse_chat_tool_count,
+            "mcpToolCount": mcp_tool_count,
+            "defaultParseMcpToolCount": len(DEFAULT_MCP_TOOL_NAMES),
+        },
+    }
 
 
 def _load_repo_parse_env(project_root_path: Path) -> Dict[str, str]:
@@ -750,6 +745,17 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
     def _json_tool_result(tool_name: str, args: Dict[str, Any]) -> str:
         result = tools.execute(tool_name, args)
         return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool(name="mcp_get_exposure_mode")
+    def mcp_get_exposure_mode() -> str:
+        """Read the active MCP exposure mode, config source, and tool counts."""
+        payload = _mcp_exposure_payload(
+            expose_all_tools=expose_all_tools,
+            config_source=mcp_config.get("config_path"),
+            parse_chat_tool_count=len(all_mcp_tool_names),
+            mcp_tool_count=len(selected_mcp_tool_names) + 1,
+        )
+        return json.dumps(payload, indent=2, ensure_ascii=False)
 
     # -- Register each ParseChatTools tool as an MCP tool --------------------
     # The cross-check test in python/adapters/test_mcp_adapter.py enforces
@@ -1570,7 +1576,7 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             return _json_tool_result("audio_normalize_status", {"jobId": jobId})
         mcp.tool(name="audio_normalize_status")(mcp_audio_normalize_status)
 
-        def mcp_enrichments_read(keys: Optional[list] = None) -> str:
+        def mcp_enrichments_read(keys: Optional[List[str]] = None) -> str:
             """Read parse-enrichments.json, optionally filtered to top-level keys."""
             args: Dict[str, Any] = {}
             if keys is not None:
@@ -1578,7 +1584,7 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             return _json_tool_result("enrichments_read", args)
         mcp.tool(name="enrichments_read")(mcp_enrichments_read)
 
-        def mcp_enrichments_write(enrichments: dict, merge: Optional[bool] = None) -> str:
+        def mcp_enrichments_write(enrichments: Dict[str, Any], merge: Optional[bool] = None) -> str:
             """Write or merge enrichments into parse-enrichments.json."""
             args: Dict[str, Any] = {"enrichments": enrichments}
             if merge is not None:
@@ -1709,7 +1715,7 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             form: str,
             mode: Optional[str] = None,
             form2: Optional[str] = None,
-            rules: Optional[list] = None,
+            rules: Optional[List[Dict[str, Any]]] = None,
         ) -> str:
             """Normalize/apply/compare IPA forms using project phonetic rules."""
             args: Dict[str, Any] = {"form": form}
@@ -1747,8 +1753,8 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         def mcp_source_index_validate(
             mode: Optional[str] = None,
             speakerId: Optional[str] = None,
-            speakerData: Optional[dict] = None,
-            manifest: Optional[dict] = None,
+            speakerData: Optional[Dict[str, Any]] = None,
+            manifest: Optional[Dict[str, Any]] = None,
             outputPath: Optional[str] = None,
         ) -> str:
             """Validate one source-index entry or a full source-index manifest."""

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -61,6 +61,39 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("parse.mcp_adapter")
 
+MCP_CONFIG_FILENAME = "mcp_config.json"
+DEFAULT_MCP_TOOL_NAMES = (
+    "project_context_read",
+    "annotation_read",
+    "read_csv_preview",
+    "cognate_compute_preview",
+    "cross_speaker_match_preview",
+    "spectrogram_preview",
+    "contact_lexeme_lookup",
+    "stt_start",
+    "stt_status",
+    "stt_word_level_start",
+    "stt_word_level_status",
+    "forced_align_start",
+    "forced_align_status",
+    "ipa_transcribe_acoustic_start",
+    "ipa_transcribe_acoustic_status",
+    "detect_timestamp_offset",
+    "detect_timestamp_offset_from_pair",
+    "apply_timestamp_offset",
+    "import_tag_csv",
+    "prepare_tag_import",
+    "onboard_speaker_import",
+    "import_processed_speaker",
+    "parse_memory_read",
+    "parse_memory_upsert_section",
+    "speakers_list",
+    "pipeline_state_read",
+    "pipeline_state_batch",
+    "pipeline_run",
+    "compute_status",
+)
+
 # ---------------------------------------------------------------------------
 # Ensure the python/ package is importable
 # ---------------------------------------------------------------------------
@@ -98,6 +131,55 @@ def _resolve_project_root(cli_root: Optional[str] = None) -> Path:
     if (candidate / "python" / "ai" / "chat_tools.py").exists():
         return candidate
     return Path.cwd()
+
+
+def _resolve_mcp_config_path(project_root_path: Path) -> Optional[Path]:
+    """Return the preferred mcp_config.json path if one exists.
+
+    Preferred location is config/mcp_config.json for consistency with the
+    other PARSE config files. For backward compatibility, also accept a
+    project-root mcp_config.json fallback.
+    """
+    candidates = [
+        project_root_path / "config" / MCP_CONFIG_FILENAME,
+        project_root_path / MCP_CONFIG_FILENAME,
+    ]
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_mcp_config(project_root_path: Path) -> Dict[str, Any]:
+    """Load MCP adapter config, defaulting to the legacy 29-tool surface."""
+    config_path = _resolve_mcp_config_path(project_root_path)
+    if config_path is None:
+        return {"expose_all_tools": False}
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read %s: %s. Falling back to expose_all_tools=false.", config_path, exc)
+        return {"expose_all_tools": False}
+    if not isinstance(payload, dict):
+        logger.warning("Ignoring non-object MCP config at %s. Falling back to expose_all_tools=false.", config_path)
+        return {"expose_all_tools": False}
+    expose_all_tools_raw = payload.get("expose_all_tools", False)
+    if not isinstance(expose_all_tools_raw, bool):
+        logger.warning(
+            "Ignoring non-boolean expose_all_tools=%r at %s. Falling back to expose_all_tools=false.",
+            expose_all_tools_raw,
+            config_path,
+        )
+        expose_all_tools_raw = False
+    return {"expose_all_tools": expose_all_tools_raw, "config_path": str(config_path)}
+
+
+def _selected_mcp_tool_names(all_tool_names: List[str], expose_all_tools: bool) -> List[str]:
+    """Return the MCP tool surface for this server instance."""
+    if expose_all_tools:
+        return list(all_tool_names)
+    available_names = set(all_tool_names)
+    return [name for name in DEFAULT_MCP_TOOL_NAMES if name in available_names]
 
 
 def _load_repo_parse_env(project_root_path: Path) -> Dict[str, str]:
@@ -651,6 +733,10 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         start_normalize_job=normalize_cb,
         list_active_jobs=jobs_cb,
     )
+    mcp_config = _load_mcp_config(root)
+    expose_all_tools = bool(mcp_config.get("expose_all_tools", False))
+    all_mcp_tool_names = ParseChatTools.get_all_tool_names()
+    selected_mcp_tool_names = _selected_mcp_tool_names(all_mcp_tool_names, expose_all_tools)
 
     mcp = FastMCP(
         "parse",
@@ -660,6 +746,10 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             "cognate analysis, STT pipeline control, and contact-language lookup."
         ),
     )
+
+    def _json_tool_result(tool_name: str, args: Dict[str, Any]) -> str:
+        result = tools.execute(tool_name, args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     # -- Register each ParseChatTools tool as an MCP tool --------------------
     # The cross-check test in python/adapters/test_mcp_adapter.py enforces
@@ -1462,6 +1552,248 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             args["computeType"] = computeType
         result = tools.execute("compute_status", args)
         return json.dumps(result, indent=2, ensure_ascii=False)
+
+    if expose_all_tools:
+        # These wrappers intentionally stay explicit, even in the "all tools"
+        # mode, so the MCP surface remains readable/auditable in code rather
+        # than being generated by reflection magic.
+        def mcp_audio_normalize_start(speaker: str, sourceWav: Optional[str] = None) -> str:
+            """Start speaker audio normalization. Returns a jobId for audio_normalize_status."""
+            args: Dict[str, Any] = {"speaker": speaker}
+            if sourceWav is not None:
+                args["sourceWav"] = sourceWav
+            return _json_tool_result("audio_normalize_start", args)
+        mcp.tool(name="audio_normalize_start")(mcp_audio_normalize_start)
+
+        def mcp_audio_normalize_status(jobId: str) -> str:
+            """Poll a normalize job started with audio_normalize_start."""
+            return _json_tool_result("audio_normalize_status", {"jobId": jobId})
+        mcp.tool(name="audio_normalize_status")(mcp_audio_normalize_status)
+
+        def mcp_enrichments_read(keys: Optional[list] = None) -> str:
+            """Read parse-enrichments.json, optionally filtered to top-level keys."""
+            args: Dict[str, Any] = {}
+            if keys is not None:
+                args["keys"] = keys
+            return _json_tool_result("enrichments_read", args)
+        mcp.tool(name="enrichments_read")(mcp_enrichments_read)
+
+        def mcp_enrichments_write(enrichments: dict, merge: Optional[bool] = None) -> str:
+            """Write or merge enrichments into parse-enrichments.json."""
+            args: Dict[str, Any] = {"enrichments": enrichments}
+            if merge is not None:
+                args["merge"] = merge
+            return _json_tool_result("enrichments_write", args)
+        mcp.tool(name="enrichments_write")(mcp_enrichments_write)
+
+        def mcp_export_annotations_csv(
+            speaker: Optional[str] = None,
+            outputPath: Optional[str] = None,
+            dryRun: Optional[bool] = None,
+        ) -> str:
+            """Export annotations to CSV, or preview when outputPath is omitted."""
+            args: Dict[str, Any] = {}
+            if speaker is not None:
+                args["speaker"] = speaker
+            if outputPath is not None:
+                args["outputPath"] = outputPath
+            if dryRun is not None:
+                args["dryRun"] = dryRun
+            return _json_tool_result("export_annotations_csv", args)
+        mcp.tool(name="export_annotations_csv")(mcp_export_annotations_csv)
+
+        def mcp_export_annotations_elan(
+            speaker: str,
+            outputPath: Optional[str] = None,
+            dryRun: Optional[bool] = None,
+        ) -> str:
+            """Export one speaker's annotations to ELAN .eaf XML."""
+            args: Dict[str, Any] = {"speaker": speaker}
+            if outputPath is not None:
+                args["outputPath"] = outputPath
+            if dryRun is not None:
+                args["dryRun"] = dryRun
+            return _json_tool_result("export_annotations_elan", args)
+        mcp.tool(name="export_annotations_elan")(mcp_export_annotations_elan)
+
+        def mcp_export_annotations_textgrid(
+            speaker: str,
+            outputPath: Optional[str] = None,
+            dryRun: Optional[bool] = None,
+        ) -> str:
+            """Export one speaker's annotations to Praat TextGrid."""
+            args: Dict[str, Any] = {"speaker": speaker}
+            if outputPath is not None:
+                args["outputPath"] = outputPath
+            if dryRun is not None:
+                args["dryRun"] = dryRun
+            return _json_tool_result("export_annotations_textgrid", args)
+        mcp.tool(name="export_annotations_textgrid")(mcp_export_annotations_textgrid)
+
+        def mcp_export_lingpy_tsv(outputPath: Optional[str] = None, dryRun: Optional[bool] = None) -> str:
+            """Export a LingPy TSV preview or write it inside the project."""
+            args: Dict[str, Any] = {}
+            if outputPath is not None:
+                args["outputPath"] = outputPath
+            if dryRun is not None:
+                args["dryRun"] = dryRun
+            return _json_tool_result("export_lingpy_tsv", args)
+        mcp.tool(name="export_lingpy_tsv")(mcp_export_lingpy_tsv)
+
+        def mcp_export_nexus(outputPath: Optional[str] = None, dryRun: Optional[bool] = None) -> str:
+            """Export a NEXUS preview or write it inside the project."""
+            args: Dict[str, Any] = {}
+            if outputPath is not None:
+                args["outputPath"] = outputPath
+            if dryRun is not None:
+                args["dryRun"] = dryRun
+            return _json_tool_result("export_nexus", args)
+        mcp.tool(name="export_nexus")(mcp_export_nexus)
+
+        def mcp_jobs_list_active() -> str:
+            """List active jobs in the shared PARSE job registry."""
+            return _json_tool_result("jobs_list_active", {})
+        mcp.tool(name="jobs_list_active")(mcp_jobs_list_active)
+
+        def mcp_lexeme_notes_read(speaker: Optional[str] = None, conceptId: Optional[str] = None) -> str:
+            """Read lexeme notes, optionally narrowed by speaker and/or concept."""
+            args: Dict[str, Any] = {}
+            if speaker is not None:
+                args["speaker"] = speaker
+            if conceptId is not None:
+                args["conceptId"] = conceptId
+            return _json_tool_result("lexeme_notes_read", args)
+        mcp.tool(name="lexeme_notes_read")(mcp_lexeme_notes_read)
+
+        def mcp_lexeme_notes_write(
+            speaker: str,
+            conceptId: str,
+            userNote: Optional[str] = None,
+            importNote: Optional[str] = None,
+            delete: Optional[bool] = None,
+        ) -> str:
+            """Write or delete one lexeme note entry."""
+            args: Dict[str, Any] = {"speaker": speaker, "conceptId": conceptId}
+            if userNote is not None:
+                args["userNote"] = userNote
+            if importNote is not None:
+                args["importNote"] = importNote
+            if delete is not None:
+                args["delete"] = delete
+            return _json_tool_result("lexeme_notes_write", args)
+        mcp.tool(name="lexeme_notes_write")(mcp_lexeme_notes_write)
+
+        def mcp_peaks_generate(
+            speaker: Optional[str] = None,
+            audioPath: Optional[str] = None,
+            outputPath: Optional[str] = None,
+            samplesPerPixel: Optional[int] = None,
+            dryRun: Optional[bool] = None,
+        ) -> str:
+            """Generate waveform peaks for a speaker or explicit audio file."""
+            args: Dict[str, Any] = {}
+            if speaker is not None:
+                args["speaker"] = speaker
+            if audioPath is not None:
+                args["audioPath"] = audioPath
+            if outputPath is not None:
+                args["outputPath"] = outputPath
+            if samplesPerPixel is not None:
+                args["samplesPerPixel"] = samplesPerPixel
+            if dryRun is not None:
+                args["dryRun"] = dryRun
+            return _json_tool_result("peaks_generate", args)
+        mcp.tool(name="peaks_generate")(mcp_peaks_generate)
+
+        def mcp_phonetic_rules_apply(
+            form: str,
+            mode: Optional[str] = None,
+            form2: Optional[str] = None,
+            rules: Optional[list] = None,
+        ) -> str:
+            """Normalize/apply/compare IPA forms using project phonetic rules."""
+            args: Dict[str, Any] = {"form": form}
+            if mode is not None:
+                args["mode"] = mode
+            if form2 is not None:
+                args["form2"] = form2
+            if rules is not None:
+                args["rules"] = rules
+            return _json_tool_result("phonetic_rules_apply", args)
+        mcp.tool(name="phonetic_rules_apply")(mcp_phonetic_rules_apply)
+
+        def mcp_read_audio_info(sourceWav: str) -> str:
+            """Read WAV metadata without loading audio samples."""
+            return _json_tool_result("read_audio_info", {"sourceWav": sourceWav})
+        mcp.tool(name="read_audio_info")(mcp_read_audio_info)
+
+        def mcp_read_text_preview(
+            path: str,
+            startLine: Optional[int] = None,
+            maxLines: Optional[int] = None,
+            maxChars: Optional[int] = None,
+        ) -> str:
+            """Read a bounded preview of a markdown/text file."""
+            args: Dict[str, Any] = {"path": path}
+            if startLine is not None:
+                args["startLine"] = startLine
+            if maxLines is not None:
+                args["maxLines"] = maxLines
+            if maxChars is not None:
+                args["maxChars"] = maxChars
+            return _json_tool_result("read_text_preview", args)
+        mcp.tool(name="read_text_preview")(mcp_read_text_preview)
+
+        def mcp_source_index_validate(
+            mode: Optional[str] = None,
+            speakerId: Optional[str] = None,
+            speakerData: Optional[dict] = None,
+            manifest: Optional[dict] = None,
+            outputPath: Optional[str] = None,
+        ) -> str:
+            """Validate one source-index entry or a full source-index manifest."""
+            args: Dict[str, Any] = {}
+            if mode is not None:
+                args["mode"] = mode
+            if speakerId is not None:
+                args["speakerId"] = speakerId
+            if speakerData is not None:
+                args["speakerData"] = speakerData
+            if manifest is not None:
+                args["manifest"] = manifest
+            if outputPath is not None:
+                args["outputPath"] = outputPath
+            return _json_tool_result("source_index_validate", args)
+        mcp.tool(name="source_index_validate")(mcp_source_index_validate)
+
+        def mcp_transcript_reformat(
+            inputPath: str,
+            outputPath: Optional[str] = None,
+            speaker: Optional[str] = None,
+            sourceWav: Optional[str] = None,
+            durationSec: Optional[float] = None,
+            dryRun: Optional[bool] = None,
+        ) -> str:
+            """Reformat a *_coarse.json file into PARSE coarse-transcript schema."""
+            args: Dict[str, Any] = {"inputPath": inputPath}
+            if outputPath is not None:
+                args["outputPath"] = outputPath
+            if speaker is not None:
+                args["speaker"] = speaker
+            if sourceWav is not None:
+                args["sourceWav"] = sourceWav
+            if durationSec is not None:
+                args["durationSec"] = durationSec
+            if dryRun is not None:
+                args["dryRun"] = dryRun
+            return _json_tool_result("transcript_reformat", args)
+        mcp.tool(name="transcript_reformat")(mcp_transcript_reformat)
+
+    logger.warning(
+        "MCP exposing %s tools (%s)",
+        len(selected_mcp_tool_names),
+        "expose_all_tools=true" if expose_all_tools else "default",
+    )
 
     return mcp
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -734,7 +734,7 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         list_active_jobs=jobs_cb,
     )
     mcp_config = _load_mcp_config(root)
-    expose_all_tools = bool(mcp_config.get("expose_all_tools", False))
+    expose_all_tools = mcp_config.get("expose_all_tools", False)
     all_mcp_tool_names = ParseChatTools.get_all_tool_names()
     selected_mcp_tool_names = _selected_mcp_tool_names(all_mcp_tool_names, expose_all_tools)
 
@@ -1789,10 +1789,10 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             return _json_tool_result("transcript_reformat", args)
         mcp.tool(name="transcript_reformat")(mcp_transcript_reformat)
 
-    logger.warning(
-        "MCP exposing %s tools (%s)",
+    logger.info(
+        "MCP exposing %s tools (expose_all_tools=%s)",
         len(selected_mcp_tool_names),
-        "expose_all_tools=true" if expose_all_tools else "default",
+        str(expose_all_tools).lower(),
     )
 
     return mcp

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -99,6 +99,76 @@ def test_every_mcp_tool_is_allowlisted_in_parse_chat_tools(tmp_path) -> None:
     )
 
 
+def test_parse_chat_tools_get_all_tool_names_matches_instance(tmp_path) -> None:
+    instance_names = ParseChatTools(project_root=tmp_path).tool_names()
+    assert ParseChatTools.get_all_tool_names() == instance_names
+
+
+@pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
+def test_create_mcp_server_defaults_to_29_tools_without_config(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from adapters.mcp_adapter import create_mcp_server
+
+    monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
+    server = create_mcp_server(str(tmp_path))
+    mcp_tools = asyncio.run(server.list_tools())
+
+    assert len(mcp_tools) == 29
+
+
+@pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
+def test_create_mcp_server_exposes_all_47_tools_when_enabled_in_config_dir(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from adapters.mcp_adapter import create_mcp_server
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "mcp_config.json").write_text(
+        '{"expose_all_tools": true}\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
+    server = create_mcp_server(str(tmp_path))
+    mcp_tools = asyncio.run(server.list_tools())
+
+    assert len(mcp_tools) == 47
+
+
+@pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
+def test_create_mcp_server_exposes_all_47_tools_when_enabled_in_root_config(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from adapters.mcp_adapter import create_mcp_server
+
+    (tmp_path / "mcp_config.json").write_text(
+        '{"expose_all_tools": true}\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
+    server = create_mcp_server(str(tmp_path))
+    mcp_tools = asyncio.run(server.list_tools())
+
+    assert len(mcp_tools) == 47
+
+
+def test_load_mcp_config_rejects_non_boolean_expose_all_tools(tmp_path) -> None:
+    from adapters import mcp_adapter
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "mcp_config.json").write_text(
+        '{"expose_all_tools": "false"}\n',
+        encoding="utf-8",
+    )
+
+    config = mcp_adapter._load_mcp_config(tmp_path)
+    assert config["expose_all_tools"] is False
+
+
 def test_resolve_onboard_http_timeout_scales_for_large_files(monkeypatch) -> None:
     from adapters import mcp_adapter
 

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -93,9 +93,11 @@ def test_every_mcp_tool_is_allowlisted_in_parse_chat_tools(tmp_path) -> None:
     chat_names = set(ParseChatTools(project_root=tmp_path).tool_names())
 
     phantom = mcp_names - chat_names
-    assert not phantom, (
+    adapter_only = {"mcp_get_exposure_mode"}
+    assert phantom <= adapter_only, (
         "MCP tools that are NOT in ParseChatTools.tool_names() will raise "
-        "ChatToolValidationError at runtime. Phantom tools: {0}".format(sorted(phantom))
+        "ChatToolValidationError at runtime unless they are explicit adapter-only tools. "
+        "Unexpected phantom tools: {0}".format(sorted(phantom - adapter_only))
     )
 
 
@@ -105,21 +107,33 @@ def test_parse_chat_tools_get_all_tool_names_matches_instance(tmp_path) -> None:
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
-def test_create_mcp_server_defaults_to_29_tools_without_config(tmp_path, monkeypatch) -> None:
+def test_create_mcp_server_defaults_to_30_tools_without_config(tmp_path, monkeypatch) -> None:
     import asyncio
+    import json
 
     from adapters.mcp_adapter import create_mcp_server
 
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
+    tool_names = {tool.name for tool in mcp_tools}
 
-    assert len(mcp_tools) == 29
+    assert len(mcp_tools) == 30
+    assert "mcp_get_exposure_mode" in tool_names
+
+    _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
+    payload = json.loads(meta["result"])
+    assert payload["ok"] is True
+    assert payload["result"]["exposeAllTools"] is False
+    assert payload["result"]["configSource"] is None
+    assert payload["result"]["mcpToolCount"] == 30
+    assert payload["result"]["parseChatToolCount"] == 47
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
-def test_create_mcp_server_exposes_all_47_tools_when_enabled_in_config_dir(tmp_path, monkeypatch) -> None:
+def test_create_mcp_server_exposes_all_48_tools_when_enabled_in_config_dir(tmp_path, monkeypatch) -> None:
     import asyncio
+    import json
 
     from adapters.mcp_adapter import create_mcp_server
 
@@ -133,13 +147,20 @@ def test_create_mcp_server_exposes_all_47_tools_when_enabled_in_config_dir(tmp_p
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
+    assert len(mcp_tools) == 48
 
-    assert len(mcp_tools) == 47
+    _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
+    payload = json.loads(meta["result"])
+    assert payload["ok"] is True
+    assert payload["result"]["exposeAllTools"] is True
+    assert payload["result"]["mcpToolCount"] == 48
+    assert payload["result"]["parseChatToolCount"] == 47
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
-def test_create_mcp_server_exposes_all_47_tools_when_enabled_in_root_config(tmp_path, monkeypatch) -> None:
+def test_create_mcp_server_exposes_all_48_tools_when_enabled_in_root_config(tmp_path, monkeypatch) -> None:
     import asyncio
+    import json
 
     from adapters.mcp_adapter import create_mcp_server
 
@@ -151,8 +172,12 @@ def test_create_mcp_server_exposes_all_47_tools_when_enabled_in_root_config(tmp_
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
+    assert len(mcp_tools) == 48
 
-    assert len(mcp_tools) == 47
+    _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
+    payload = json.loads(meta["result"])
+    assert payload["result"]["configSource"] == str(tmp_path / "mcp_config.json")
+    assert payload["result"]["exposeAllTools"] is True
 
 
 def test_load_mcp_config_rejects_non_boolean_expose_all_tools(tmp_path) -> None:

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -41,6 +41,37 @@ READ_ONLY_NOTICE = (
     "only specific allowlisted tools may write dedicated support files such as contact lexeme config or parse-tags, "
     "not annotations or enrichments."
 )
+DEFAULT_MCP_TOOL_NAMES = (
+    "project_context_read",
+    "annotation_read",
+    "read_csv_preview",
+    "cognate_compute_preview",
+    "cross_speaker_match_preview",
+    "spectrogram_preview",
+    "contact_lexeme_lookup",
+    "stt_start",
+    "stt_status",
+    "stt_word_level_start",
+    "stt_word_level_status",
+    "forced_align_start",
+    "forced_align_status",
+    "ipa_transcribe_acoustic_start",
+    "ipa_transcribe_acoustic_status",
+    "detect_timestamp_offset",
+    "detect_timestamp_offset_from_pair",
+    "apply_timestamp_offset",
+    "import_tag_csv",
+    "prepare_tag_import",
+    "onboard_speaker_import",
+    "import_processed_speaker",
+    "parse_memory_read",
+    "parse_memory_upsert_section",
+    "speakers_list",
+    "pipeline_state_read",
+    "pipeline_state_batch",
+    "pipeline_run",
+    "compute_status",
+)
 WRITE_ALLOWED_TOOL_NAMES = frozenset({
     "audio_normalize_start",
     "contact_lexeme_lookup",
@@ -5553,5 +5584,6 @@ __all__ = [
     "ChatToolValidationError",
     "ChatToolExecutionError",
     "ChatToolSpec",
+    "DEFAULT_MCP_TOOL_NAMES",
     "ParseChatTools",
 ]

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -1618,6 +1618,11 @@ class ParseChatTools:
         """Return sorted tool names in allowlist."""
         return sorted(self._tool_specs.keys())
 
+    @classmethod
+    def get_all_tool_names(cls) -> List[str]:
+        """Return the full built-in ParseChatTools surface without caller setup."""
+        return cls(project_root=Path.cwd()).tool_names()
+
     def _finalize_read_only_result(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         result = _deepcopy_jsonable(payload)
         result["mode"] = "read-only"


### PR DESCRIPTION
## Summary
- add `config/mcp_config.json` support for MCP exposure with default-safe `expose_all_tools=false`
- keep the legacy 29 `ParseChatTools` wrappers by default, with a new read-only `mcp_get_exposure_mode` adapter tool for self-inspection
- expose all 47 `ParseChatTools` when opted in, for 48 total MCP tools including `mcp_get_exposure_mode`
- move `DEFAULT_MCP_TOOL_NAMES` into `python/ai/chat_tools.py` as the single source of truth
- tighten wrapper type hints and extend MCP adapter tests/docs

## Validation
- `pytest python/adapters/test_mcp_adapter.py -q` ✅ (12 passed)
- `python -m py_compile python/adapters/mcp_adapter.py python/ai/chat_tools.py` ✅
- `git diff --check` ✅
- manual MCP verification:
  - default mode => 30 MCP tools total (`29 ParseChatTools` + `mcp_get_exposure_mode`) ✅
  - full mode => 48 MCP tools total (`47 ParseChatTools` + `mcp_get_exposure_mode`) ✅
  - verified `mcp_get_exposure_mode`, `read_text_preview`, `enrichments_write`, `transcript_reformat`, `source_index_validate`, and `jobs_list_active` ✅

## Notes
- config parsing is fail-closed: non-boolean `expose_all_tools` values fall back to `false`
- full repo test run still has 2 unrelated pre-existing failures outside this change:
  - `python/ai/test_acoustic_alignment_mcp_tools.py::test_forced_align_start_live_dispatches_forced_align_compute`
  - `python/ai/test_ortho_provider_fallback.py::test_ortho_section_defaults_vad_filter_off`
