### PR TITLE
docs: restructure README and split focused docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,670 +1,163 @@
-# PARSE
+# PARSE — Phonetic Analysis & Review Source Explorer
 
-**P**honetic **A**nalysis & **R**eview **S**ource **E**xplorer  
-Browser-based dual-mode workstation for linguistic fieldwork and cross-speaker comparison.  
-Repository: [ArdeleanLucas/PARSE](https://github.com/ArdeleanLucas/PARSE)
+**Browser-based dual-mode workstation for linguistic fieldwork.**
+Annotate per-speaker recordings with tiered IPA/orthography, then compare across speakers for cognate adjudication, borrowing detection, and export-ready historical-linguistic datasets.
 
-> **Project status:** PARSE is in active development and is **not yet in beta**. Interfaces, workflows, and file contracts are still moving quickly as thesis-critical fieldwork and comparison features land on `main`.
+<!-- TODO: Add a hero GIF here showing the unified React shell: Annotate waveform + tiers, Compare concept matrix + CLEF panel, and the AI chat dock. A wide GitHub-friendly GIF or screenshot strip would work well. -->
+<!-- TODO: Add 2-3 static screenshots below the hero once the current UI settles: Annotate mode, Compare mode, and Lexeme Search / CLEF panels. -->
 
-## What is PARSE
+> **Status**: Active development. Thesis-critical features are landing frequently, interfaces and file contracts are still evolving, and PARSE should currently be treated as research software rather than beta software.
 
-PARSE is a browser-based research tool for linguists working with long field recordings, concept-based wordlists, and multi-speaker datasets. It combines audio navigation, annotation, onboarding/import, and comparative analysis in one workspace, so researchers can move from raw recordings or processed thesis artifacts to analysis-ready linguistic data without switching between disconnected tools.
+## ✨ What Makes PARSE Different
 
-PARSE has a dual-mode architecture: **Annotate** for per-speaker segmentation and transcription, and **Compare** for cross-speaker cognate review and borrowing adjudication. Both modes are hosted in a **unified React shell** (`ParseUI.tsx`) alongside the tag system, action menu, and AI chat dock, with precise time-aligned annotations and a shared tag system across workflows.
+- **Dual-mode unified React shell** for annotation and comparison in one workspace
+- **Fieldwork-first design** for long recordings, uneven metadata, and iterative review
+- **AI-native workflow surface** with a built-in chat assistant powered by **47 PARSE-specific tools**
+- **Full MCP server mode** exposing a curated **29-tool** subset for external agents and automation
+- **CLEF — Contact Lexeme Explorer Feature** for borrowing adjudication via a 10-provider contact-language lookup stack
+- **Lexical Anchor Alignment System** for locating repeated lexical items across long recordings and across speakers
+- **Export pipeline** for LingPy TSV and NEXUS outputs used in downstream comparative workflows
 
-The active frontend architecture is **React + Vite** (`index.html` + `src/`), with the preferred development routes at `http://localhost:5173/` (Annotate) and `http://localhost:5173/compare` (Compare). The legacy HTML entrypoints, old review page, and root vanilla-JS tree have been removed. For non-dev/local-server usage, run `npm run build` and the Python backend will serve the built frontend from `http://localhost:8766/` and `http://localhost:8766/compare`. LingPy export verification and full browser regression remain on a deferred to-test list until onboarding/import and end-to-end testing are ready.
-
-The Python backend continues to power AI/API routes for both architectures. PARSE is designed for real fieldwork constraints — large recordings, mixed metadata quality, iterative review — and should be treated as **research software** rather than production software.
-
----
-
-## Modes
-
-### Annotate mode (React route `/`)
-
-Per-speaker segmentation and transcription workstation.
-
-- Waveform review with WaveSurfer 7 for long recordings
-- Four annotation tiers: **IPA**, **orthography**, **concept**, and **speaker**
-- Stacked **transcription lanes** under the waveform for **STT**, **IPA**, and **ORTH**, with waveform-aligned timestamps and synchronized horizontal scrolling
-- Audio normalization job (`/api/normalize`) with in-place working-audio support
-- Speaker-level STT job (`/api/stt`) with progress/error reporting, automatic language detection from project metadata when available, tunable VAD / task / beam-size settings, and nested word-level timestamps (`segments[].words[]`)
-- Tier 2 acoustic forced alignment refines Tier 1 word windows with `torchaudio.functional.forced_align` against wav2vec2, yielding tighter per-word boundaries and optional phoneme spans
-- Speaker-level ORTH job (`computeType='ortho'`) backed by Razhan (`razhan/whisper-base-sdh`) for full-waveform Kurdish orthographic transcription; current defaults keep VAD off so the whole recording is covered unless you explicitly retune it
-- Speaker-level IPA fill job (`computeType='ipa_only'`) now runs **acoustic wav2vec2-only IPA** through the full forced-alignment path when word-level STT cache is available, yielding word-level IPA intervals; it falls back to coarse ORTH-interval slices only when no STT word cache exists
-- Batch transcription runner for one or many speakers, with preflight pipeline-state checks, overwrite cues, step-level failure isolation, rerun-failed support, and a walk-away batch report with expandable tracebacks, "empty" step detection, skip-breakdown counters, and exception samples for steps that ran but wrote no intervals
-- Preflight now distinguishes **"tier has intervals"** from **"the full WAV has been processed"** via coverage-aware fields (`duration_sec`, `coverage_start_sec`, `coverage_end_sec`, `coverage_fraction`, `full_coverage`)
-- Full pipeline execution now runs explicit ordered steps — **normalize → STT → ORTH → IPA** — with per-step skip/error reporting instead of treating the run as a single opaque job
-- Draggable lexeme timestamp editing and manual boundary correction
-- Timestamp-offset detect/apply workflow for constant CSV↔audio misalignment, now with monotonic alignment, quantile anchor sampling, and manual single-pair fallback
-- Clip-bounded playback for the selected region plus global **Space** play/pause hotkey
-- Concept display modes and sorting controls (ID order, A–Z, survey-order when present)
-- Keyboard shortcuts for mode switching and concept navigation
-- AI chat dock for in-session analysis assistance
-- Tag and filter concepts for selective annotation
-
-### Compare mode (React route `/compare`)
-
-Cross-speaker analysis workspace for cognates and phylogenetic data preparation.
-
-- Concept × speaker matrix for side-by-side lexical review
-- Cognate controls: **accept**, **split**, **merge**, and **cycle**
-- Per-row cognate-group editing, speaker flags, and long-press / secondary-action controls
-- Borrowing adjudication aided by contact-language similarity signals
-- Enrichments overlay for computed analysis metadata
-- **CLEF** (Contact Lexeme Explorer Feature) — multi-source contact-language similarity panel powered by a provider registry (see below)
-- Unified tag system (shared with Annotate mode) for scoped filtering
-- Export to LingPy-compatible TSV and NEXUS (placeholder) for downstream pipelines (LexStat, BEAST 2)
-
-### CLEF — Contact Lexeme Explorer Feature
-
-CLEF provides contact-language similarity data for borrowing adjudication in Compare mode. It fetches lexical data from multiple third-party and local sources via a **provider registry** (`python/compare/providers/`), then surfaces similarity signals in the `ContactLexemePanel` UI component.
-
-**Providers (10):**
-
-| Provider | Source type |
-|---|---|
-| `asjp` | ASJP database |
-| `cldf` | CLDF datasets |
-| `csv_override` | Local CSV overrides |
-| `grokipedia` | LLM-assisted lookup (xAI/Grok) |
-| `lingpy_wordlist` | LingPy wordlist data |
-| `literature` | Published literature references |
-| `pycldf_provider` | pycldf library |
-| `pylexibank_provider` | pylexibank library |
-| `wikidata` | Wikidata lexemes |
-| `wiktionary` | Wiktionary entries |
-
-**Endpoints:**
-- `POST /api/compute/contact-lexemes` — trigger contact-lexeme fetch job
-- `GET /api/contact-lexemes/coverage` — check coverage status across providers
-
-### Current entrypoint status
-
-- **Preferred development UI:** `http://localhost:5173/` and `http://localhost:5173/compare`
-- **Python-served built UI:** `http://localhost:8766/` and `http://localhost:8766/compare` after `npm run build`
-- **Cleanup status:** legacy vanilla-JS entrypoints have been removed from the repo; broader validation still lives on the deferred testing backlog
-
----
-
-## AI Provider System
-
-PARSE supports multiple AI backends, routed per task type:
-
-| Task | Supported providers |
-|---|---|
-| STT (speech-to-text) | faster-whisper (local, GPU-first with CPU/int8 fallback; word-level timestamps enabled), OpenAI Whisper API |
-| IPA transcription | acoustic wav2vec2 via `ipa_only` compute on audio slices (no text-to-IPA endpoint or Epitran fallback) |
-| LLM / chat | xAI (Grok), OpenAI |
-
-Provider selection is feature-specific — STT, IPA, and LLM tasks can each route to a different backend in the same project. Configuration lives in `config/ai_config.json`, which is gitignored because it contains machine-specific paths (e.g. a local Razhan CT2 model path). Copy `config/ai_config.example.json` to `config/ai_config.json` on a fresh clone and edit for your machine. If the file is missing entirely, the backend falls back to built-in defaults with a `[WARN]` on stderr.
-
-**Runtime note:** GPU STT remains the intended path, but the current faster-whisper provider now includes explicit CUDA-runtime detection, an emergency `PARSE_STT_FORCE_CPU=1` override, and a CPU/int8 fallback path when the local cuDNN / cuBLAS stack is unavailable. STT can auto-detect language from project metadata (falling back to configured defaults), STT and ORTH expose tunable decoding parameters such as `beam_size`, `task`, and VAD settings in `config/ai_config.json`, and mid-run CUDA failures rebuild the Whisper model on CPU instead of leaving the job wedged.
-
-### Models
-
-| Model | Task | Source |
-|---|---|---|
-| [`razhan/whisper-base-sdh`](https://huggingface.co/razhan/whisper-base-sdh) | ORTH transcription / Southern Kurdish speech recognition | HuggingFace (local CT2) |
-| [`facebook/wav2vec2-xlsr-53-espeak-cv-ft`](https://huggingface.co/facebook/wav2vec2-xlsr-53-espeak-cv-ft) | Acoustic IPA transcription + forced alignment head | HuggingFace (local) |
-| Silero VAD | Voice activity detection — segment boundary detection in long recordings | bundled with faster-whisper |
-
-**Razhan** is the key model for the Southern Kurdish thesis project. It is a Whisper variant fine-tuned directly on Southern Kurdish (`sdh`) speech data, converted to CTranslate2 format for GPU-accelerated inference (`device=cuda, compute_type=float16`). It produces **Kurdish Arabic-script orthographic transcriptions with word-level timestamps** — not IPA. IPA is a separate stage handled by wav2vec2.
-
-Silero VAD segments each full-length recording before Razhan processes it. VAD parameters are tuned specifically for the elicitation recording format: activation threshold 0.35 (lower than default, to catch soft-spoken consultants at variable microphone distances) and minimum silence of 300 ms between segments (to prevent interviewer-prompt and speaker-response pairs from being collapsed into single units).
-
-The wav2vec2 model (`facebook/wav2vec2-xlsr-53-espeak-cv-ft`) now serves Tier 2 forced alignment and Tier 3 acoustic IPA. By default, `ipa_only` prefers the word-level STT cache (`coarse_transcripts/<speaker>.json`) and runs the full forced-align path word-by-word; if no word cache exists, PARSE falls back to coarse ORTH-interval slices. The older Epitran / text-IPA / LLM IPA paths are gone, and the synchronous `POST /api/ipa` endpoint has been removed. On WSL, the aligner now resolves to **CPU by default** to avoid GPU-driver crashes under long CTC workloads; `config/ai_config.json` also exposes `wav2vec2.force_cpu` and `wav2vec2.chunk_size` so long runs can be tuned without code changes. Recent fixes also cache `EspeakBackend` instances per language and report progress during Tier 2 forced alignment, so long CPU runs no longer sit at a misleading 0% while G2P / alignment work is underway.
-
-### Citation and external dependency links
-
-For academic integrity, the following table lists the **core external models and repositories directly referenced by the current PARSE code/config**. If PARSE results are reported in a thesis, paper, talk, or dataset release, these are the first external components that should be cited or acknowledged alongside PARSE itself.
-
-| Component | Type | Used in PARSE for | Link |
-|---|---|---|---|
-| `razhan/whisper-base-sdh` | Model | ORTH transcription of Southern Kurdish speech | https://huggingface.co/razhan/whisper-base-sdh |
-| `facebook/wav2vec2-xlsr-53-espeak-cv-ft` | Model | Acoustic IPA transcription + forced alignment | https://huggingface.co/facebook/wav2vec2-xlsr-53-espeak-cv-ft |
-| Silero VAD | Model / repo | Voice activity detection during Whisper-style decoding | https://github.com/snakers4/silero-vad |
-| faster-whisper | Repository / library | Local STT + ORTH inference backend | https://github.com/SYSTRAN/faster-whisper |
-| CTranslate2 | Repository / library | Optimized local inference runtime for Whisper-family models | https://github.com/OpenNMT/CTranslate2 |
-| WaveSurfer.js | Repository / library | Long-recording waveform UI, regions, and timeline | https://github.com/katspaugh/wavesurfer.js |
-| React | Repository / library | Frontend application framework | https://github.com/facebook/react |
-| Vite | Repository / library | Frontend dev/build toolchain | https://github.com/vitejs/vite |
-| Tailwind CSS | Repository / library | Frontend styling system | https://github.com/tailwindlabs/tailwindcss |
-| Lucide | Repository / library | UI icon set (`lucide-react`) | https://github.com/lucide-icons/lucide |
-
-**Scope note:** this table intentionally covers the major external models and repositories that PARSE calls out in source/config and that materially shape runtime behaviour or outputs. Proprietary API providers used by configuration (for example OpenAI or xAI) are services rather than citeable source repositories, so they should be acknowledged separately in method sections when they are actually enabled in a given run.
-
-### Lexical Anchor Alignment System
-
-The core unique feature of PARSE. Long elicitation recordings (2.5–5 hours each) contain target lexical items embedded in conversational frames, metalinguistic commentary, and ambient noise. Manually scanning recordings to locate each concept across eleven speakers is prohibitively slow and inconsistent. PARSE solves this through a two-signal candidate scoring pipeline (thesis §4.4).
-
-**Signal A — Within-speaker repetition detection.** Each elicited item is typically produced two to four times in succession. Clusters of phonetically similar forms within a 30-second window are strong candidates for a repeated target item. Phonetic similarity is measured by normalised Levenshtein distance on IPA strings.
-
-**Signal B — Cross-speaker concept matching.** Unassigned segments are compared against verified annotations from other speakers for the same concept using a four-strategy cascade: exact orthographic → fuzzy orthographic → phonetic rule-based → positional prior. Phonetic variation rules encode documented Southern Kurdish alternations — onset voicing (k/g, t/d, p/b), nucleus variation (e/a), coda deletion — so that legitimate dialectal variants are not rejected as mismatches.
-
-**Confidence formula:**
-
-```
-confidence = 0.50 × phonetic + 0.25 × repetition + 0.15 × positional + 0.10 × cluster
-```
-
-The positional component applies a 45-second tolerance window (linear decay) around the expected timestamp derived from the cross-speaker median for each concept.
-
-The system presents ranked candidates. The annotator verifies, adjusts boundaries, and confirms. Nothing is saved without an explicit action. Candidate quality improves as the dataset grows — each verified annotation adds to the reference pool that cross-speaker matching draws on, making later speakers progressively faster to annotate than the first.
-
-**User-facing tool — "Search &amp; anchor lexeme" (Annotate mode).** The Annotation panel exposes the full two-signal pipeline directly. Enter the known orthographic variants of the target concept (e.g. `yek, yak, jek`), and PARSE ranks time ranges across the `ortho_words`, `ortho`, `stt`, and `ipa` tiers via `GET /api/lexeme/search`, which combines:
-
-- **Within-speaker phonetic similarity** — normalized Levenshtein on both the orthographic form and the IPA sequence (the interval text is phonemized on the fly via `phonemizer`/espeak-ng). The match's `confidence_weight` carries through any `ortho_words` per-interval forced-alignment confidence from PR #178.
-- **Cross-speaker concept matching** — for the same `concept_id`, the endpoint scans every other speaker's `confirmed_anchors` sidecar and adds a small bonus when a candidate is close to an already-verified variant elsewhere.
-- **Contact-language variant augmentation** — the user-supplied variants are auto-expanded from `config/sil_contact_languages.json` so the annotator doesn't need to know every documented form.
-
-"Confirm &amp; Use" writes the chosen candidate to `AnnotationRecord.confirmed_anchors[concept_id]` (sidecar — survives Praat/TextGrid round-trips cleanly). Each confirmation strengthens the cross-speaker signal for the remaining speakers — the reference pool compounds exactly as §4.4 describes. The Annotate control bar also shows a numeric playhead readout (`m:ss.sss / m:ss.sss`) so anchor decisions don't require eyeballing the scrub position. The bulk-align CTA stays stubbed until PR C, which will use the confirmed anchors as scaffolding to align the remaining concepts for a speaker in one pass.
-
----
-
-## AI Workflow Assistant
-
-Both Annotate and Compare modes include a built-in AI chat dock powered by the configured LLM provider (xAI/Grok or OpenAI). This is not a general-purpose chatbot — it is a domain-specific assistant designed to guide users through the entire PARSE workflow from start to finish.
-
-The assistant has full access to project state via the `ParseChatTools` interface (`python/ai/chat_tools.py`) and can:
-
-**Audio setup and file management**
-- Help locate and load `.wav` source files into the workspace
-- Check audio health (LUFS, format, sample rate, duration)
-- Guide the normalization pipeline for new speakers
-
-**Annotation workflow**
-- Walk through the segment annotation process tier by tier (IPA, orthography, concept, speaker)
-- Run the STT pipeline on a full recording to locate candidate segments
-- Assist with boundary correction and iterative refinement
-
-**Cross-speaker analysis**
-- Prepare and guide a Compare mode session
-- Explain cognate controls and borrowing adjudication decisions
-- Help interpret enrichment overlays and similarity scores
-
-**Export and downstream pipeline**
-- Guide LingPy-compatible TSV export
-- Explain column structure for LexStat and BEAST 2 input
-
-**Troubleshooting**
-- Diagnose pipeline failures (STT, IPA, normalization)
-- Identify missing files, mismatched metadata, or annotation gaps
-- Explain error messages from the server log
-
-Recent post-README improvements also expanded the assistant's operational surface in two practical areas: server-backed tags now sync on UI bootstrap (so imported tags appear after reload), and existing tags can be renamed directly inside PARSE's Tags mode instead of being recreate-only.
-
-The assistant operates with read and write access to the project. It can stage files, update metadata, trigger jobs, and report back — without requiring the user to leave the interface.
-
----
-
-## Speaker import and workspace hydration
-
-Recent PRs expanded PARSE beyond raw upload-only onboarding. In addition to `POST /api/onboard/speaker`, the current workstation and MCP adapter support **processed-speaker imports**: copying a timestamp-aligned working WAV plus annotation/peaks/transcript artifacts into the active workspace and registering the speaker in `project.json` and `source_index.json`.
-
-This matters for thesis workflows where the richest aligned source is not a fresh raw WAV pipeline run but an existing processed artifact set. In practice, PARSE can now be hydrated from:
-
-- a working WAV under `audio/working/<Speaker>/`
-- `annotations/<Speaker>.json` / `annotations/<Speaker>.parse.json`
-- `peaks/<Speaker>.json`
-- optional `coarse_transcripts/<Speaker>.json`
-- optional legacy transcript CSV under `imports/legacy/<Speaker>/`
-
-The active frontend speaker list comes from the live workspace behind `/api/config`, not necessarily from the bare repo checkout. When running PARSE with `PARSE_WORKSPACE_ROOT` set, imports and runtime writes must land in that workspace for the UI to see them.
-
-> **API schema version contract:** Every `/api/config` response carries `schema_version: 1`. The React client validates this on boot; a mismatch (old server code running against a new frontend) surfaces as a banner instead of a silent empty workspace. When a breaking change to the config payload shape is needed, bump `CONFIG_SCHEMA_VERSION` in `python/server.py` **and** `EXPECTED_CONFIG_SCHEMA_VERSION` in `src/api/client.ts` together in the same PR.
-
----
-
-## Quick Start
-
-### One-command launch (recommended)
-
-The `scripts/parse-run.sh` launcher (tracked in this repo) starts both servers, pulls the latest code, cleans up stale processes on both WSL and Windows sides, probes the API port before launch, and health-checks the API before printing URLs. A shell alias (`parse-run`) is typically wired to call this script.
+## 🚀 Quick Start
 
 ```bash
-scripts/parse-run.sh    # same as `parse-run` alias; run directly from repo root
+git clone https://github.com/ArdeleanLucas/PARSE.git
+cd PARSE
+./scripts/parse-run.sh
 ```
 
-The alias version lives in `~/.bash_aliases`:
+On a fresh clone, you will usually also want to:
 
-```bash
-alias parse-run='/path/to/parse/scripts/parse-run.sh'
-alias parse-stop='/path/to/parse/scripts/parse-stop.sh'
-```
+- run `npm install` once
+- copy `config/ai_config.example.json` to `config/ai_config.json`
+- review your local model/provider settings before serious speech work
 
-On success you will see:
+Open:
 
-```
-[parse-run] ════════════════════════════════════════
-[parse-run]   PARSE is running
-[parse-run]   React UI:  http://localhost:5173/
-[parse-run]   Compare:   http://localhost:5173/compare
-[parse-run]   API:       http://localhost:8766/api/config
-[parse-run] ════════════════════════════════════════
-```
+- **Annotate**: http://localhost:5173/
+- **Compare**: http://localhost:5173/compare
 
-Open **http://localhost:5173/** in your browser for the React UI.
+For full requirements, workspace setup, GPU/model configuration, and troubleshooting, see [Getting Started](docs/getting-started.md).
 
-### Runtime and deployment notes
+## 🛠️ Core Concepts
 
-- The HTTP server now runs behind a **bounded 4-worker request pool** rather than one ad-hoc OS thread per request, which keeps long polling runs stable during batch STT / ORTH / IPA jobs.
-- Compute jobs support three launcher modes: the default in-process `thread` mode, an opt-in `subprocess` mode (`python python/server.py --compute-mode=subprocess` or `PARSE_COMPUTE_MODE=subprocess`), and a **persistent** worker mode (`python python/server.py --compute-mode=persistent` or `PARSE_USE_PERSISTENT_WORKER=true`) that preloads wav2vec2 once and reuses it across compute jobs.
-- If you supervise the backend with PM2, use the tracked `deploy/pm2-ecosystem.config.cjs` file and keep `cwd` pointed at the **live workspace**, not the git checkout, so annotations and derived artifacts land in the runtime workspace rather than in the repo tree.
-- The PM2 config now also documents the current WSL safety defaults: `PARSE_STT_FORCE_CPU=1` and `CUDA_VISIBLE_DEVICES=""`, so STT / ORTH / IPA can fall back to all-CPU operation on unstable WSL GPU stacks.
-- For persistent-worker deployments, `GET /api/worker/status` provides a health check suitable for PM2 or external monitors; non-persistent modes return mode information but no worker liveness probe.
+### Annotate Mode (`/`)
 
-### Workspace-first bootstrap (recommended on a fresh machine)
+**Annotate** is the per-speaker segmentation and transcription workstation.
 
-For real fieldwork use, keep generated runtime state outside the git checkout. `scripts/parse-init-workspace.sh` scaffolds a standalone workspace for copied source audio, annotations, peaks, chat memory, and config-local runtime files.
+It combines:
 
-```bash
-# scaffold once
-scripts/parse-init-workspace.sh /path/to/parse-workspace
+- **WaveSurfer 7** waveform review for long recordings
+- **Four annotation tiers**: IPA, orthography, concept, and speaker
+- **Stacked transcription lanes** for STT, IPA, and ORTH with synchronized horizontal scrolling
+- **Audio normalization**, **speaker-level STT**, **ORTH transcription**, and **acoustic IPA fill** jobs
+- **Tier 2 forced alignment** with wav2vec2 for tighter word-level boundaries
+- **Draggable timestamp correction** and clip-bounded playback for manual review
+- **Batch transcription** with preflight checks and rerun-failed support
+- **Timestamp-offset detection/apply workflows** for constant CSV↔audio misalignment
+- **Search & anchor lexeme** tooling built on the Lexical Anchor Alignment System
+- **Shared tags** and the in-session **AI chat dock**
 
-# then launch PARSE against that workspace
-PARSE_WORKSPACE_ROOT="/path/to/parse-workspace" \
-  PARSE_CHAT_MEMORY_PATH="/path/to/parse-workspace/parse-memory.md" \
-  PARSE_EXTERNAL_READ_ROOTS="/mnt/c/Users/Lucas/Thesis" \
-  scripts/parse-run.sh
-```
+Annotate mode is where PARSE turns long, messy field recordings into time-aligned annotation data without forcing the user into disconnected tools.
 
-This keeps original WAV/CSV sources untouched. Chat-assisted onboarding copies selected source files into `audio/original/<speaker>/` inside the workspace rather than mutating the source tree.
+### Compare Mode (`/compare`)
 
-Environment overrides:
+**Compare** is the cross-speaker review workspace.
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `PARSE_PY` | `python3` | Python interpreter. Set to a Windows `python.exe` (e.g. `/mnt/c/Users/Lucas/anaconda3/envs/kurdish_asr/python.exe`) when running from WSL against a Windows conda env. |
-| `PARSE_ROOT` | auto-detected | Repo root. |
-| `PARSE_WORKSPACE_ROOT` | `PARSE_ROOT` | Workspace/data root used by backend chat tools and runtime files. Point this outside the repo for fieldwork use. |
-| `PARSE_CHAT_DOCS_ROOT` | `PARSE_WORKSPACE_ROOT` | Optional docs/text root used by `read_text_preview`. |
-| `PARSE_CHAT_MEMORY_PATH` | `PARSE_WORKSPACE_ROOT/parse-memory.md` | Persistent markdown memory file used by the chat assistant. |
-| `PARSE_EXTERNAL_READ_ROOTS` | empty | Absolute roots the chat assistant may read outside the workspace for onboarding and file previews. Use OS path separators for multiple roots, or `*` to disable the sandbox entirely. |
-| `PARSE_CHAT_READ_ONLY` | empty | Override chat mutability: `1` forces read-only; `0` forces write-enabled. Otherwise PARSE defers to `config/ai_config.json`. |
-| `PARSE_API_PORT` | `8766` | API server port. |
-| `PARSE_VITE_PORT` | `5173` | Vite dev server port. |
-| `PARSE_SKIP_PULL` | `0` | Set to `1` to skip the `git pull` step. |
-| `PARSE_PULL_MODE` | `auto` | Git integration strategy: `auto`, `ff`, `rebase`, or `reset`. |
-
-For machine-local overrides without editing tracked files, create a gitignored `.parse-env` file in the repo root. `parse-run.sh` sources it before applying defaults, and the standalone MCP adapter now mirrors that convention when launched directly, so settings like `PARSE_PY`, `PARSE_EXTERNAL_READ_ROOTS`, or `PARSE_CHAT_MEMORY_PATH` can live there permanently. Explicit process environment variables still win over `.parse-env`.
-
-Two companion commands are also available:
-
-```bash
-scripts/parse-stop.sh   # kill both servers (WSL + Windows-side zombies)
-parse-logs api          # tail Python API stderr
-parse-logs vite         # tail Vite dev server output
-```
-
-#### WSL + Windows python.exe note
-
-When `PARSE_PY` points at a Windows `python.exe` (a conda env on `C:`), the actual server process runs on the Windows side. WSL's `pkill`/`fuser` cannot signal Windows processes, so `parse-run.sh` detects this case and additionally calls `taskkill.exe` via `/mnt/c/Windows/System32/` to clean up zombie `python.exe` instances holding port 8766. This prevents the "empty reply from server" failure mode where a broken prior process blocks the port.
-
-If `parse-run.sh` reports that it **cannot bind** `127.0.0.1:8766` with `WinError 10013` or `10048`, this is usually a Windows/WSL phantom port reservation. The launcher now detects that case before startup and prints the fix: run `wsl --shutdown` from Windows Command Prompt or PowerShell, then relaunch PARSE. You can also temporarily override the port with `PARSE_API_PORT=<other>`.
-
-#### What `scripts/parse-run.sh` does
-
-1. Integrates latest `origin/main` according to `PARSE_PULL_MODE` (skipped if `PARSE_SKIP_PULL=1`)
-2. Kills any stale Python or Vite processes on ports 8766 / 5173
-3. Probes whether the API port is actually bindable before launch
-4. Starts the **Python API server** (`python/server.py`) on `:8766`
-5. Waits for `/api/config` to return 200 (up to 12 s)
-6. Starts the **Vite dev server** (`npx vite --host`) on `:5173`
-7. Waits for Vite to respond, then prints URLs
-
-Both servers must be running. The Python backend serves the API routes;
-the Vite dev server serves the React/TypeScript frontend with Tailwind CSS
-and hot module replacement.
-
-#### Requirements
-
-- **WSL / Linux** — the alias uses Bash and `pkill`/`fuser`
-- **`kurdish_asr` conda env** — Python interpreter path is hardcoded in the
-  alias (`/mnt/c/Users/Lucas/anaconda3/envs/kurdish_asr/python.exe`)
-- **Node.js 18+** and `npm install` run once per clone
-
-### Manual launch (alternative)
-
-If you prefer to start each server individually:
-
-```bash
-# One-time per clone: create your local AI config from the template
-cp config/ai_config.example.json config/ai_config.json
-# then edit config/ai_config.json — especially stt.model_path (local Razhan CT2 path)
-
-# Terminal 1 — Python API backend
-cd /path/to/parse
-/path/to/anaconda3/envs/kurdish_asr/python.exe python/server.py
-
-# Terminal 2 — Vite frontend
-cd /path/to/parse
-npm install   # once per clone
-npm run dev
-```
-
-The backend runs on port `8766`; Vite runs on port `5173`.
-
-### Open in browser
-
-#### React UI (active dev workflow)
-
-- Annotate mode: `http://localhost:5173/`
-- Compare mode: `http://localhost:5173/compare`
-
-#### Python-served built UI (after `npm run build`)
-
-- Annotate mode: `http://localhost:8766/`
-- Compare mode: `http://localhost:8766/compare`
-
----
-
-## Project Structure
-
-```text
-index.html              -- React/Vite entry HTML
-src/
-  App.tsx               -- BrowserRouter shell → <ParseUI />
-  ParseUI.tsx           -- Unified UI shell (Annotate + Compare + Tags + AI Chat)
-  api/
-    client.ts           -- Typed API client (all fetch calls go through here)
-    types.ts            -- Shared TypeScript types
-  components/
-    annotate/           -- Annotate mode components
-    compare/            -- Compare mode (CompareMode, ConceptTable, CognateControls,
-                           BorrowingPanel, EnrichmentsPanel, ContactLexemePanel,
-                           SpeakerImport, TagManager)
-    shared/             -- Cross-mode shared components
-  hooks/                -- React hooks (useWaveSurfer, useChatSession,
-                           useAnnotationSync, useSpectrogram, useActionJob,
-                           useComputeJob, useExport, useImportExport, useSuggestions)
-  stores/               -- Zustand stores (annotationStore, configStore,
-                           enrichmentStore, playbackStore, tagStore, uiStore)
-python/
-  server.py             -- Backend API server + built-frontend static serving (port 8766)
-  adapters/
-    mcp_adapter.py      -- MCP server adapter (exposes ParseChatTools over stdio MCP)
-  ai/                   -- AI provider layer
-    chat_tools.py       -- ParseChatTools — AI assistant tool interface (47 tools)
-    chat_orchestrator.py-- Chat session management
-    stt_pipeline.py     -- Tier 1 word-level STT (faster-whisper + `word_timestamps=True`)
-    forced_align.py     -- Tier 2 acoustic forced alignment (torchaudio + wav2vec2-xlsr)
-    ipa_transcribe.py   -- Tier 3 acoustic IPA (wav2vec2 CTC on audio slices, wav2vec2-only)
-  compare/              -- Compare pipeline (cognates, offsets, matching)
-    providers/          -- CLEF provider registry and provider adapters
-  shared/               -- Shared Python utilities
-config/
-  ai_config.example.json -- Template for AI provider configuration (tracked)
-  ai_config.json          -- AI provider configuration (gitignored — copy from example)
-annotations/            -- Per-speaker annotation JSON files (runtime, untracked)
-parse-enrichments.json  -- Computed comparative overlays (runtime, untracked)
-desktop/                -- Electron shell scaffold
-docs/                   -- Documentation and plans
-dist/                   -- Vite build output (generated, gitignored)
-```
-
----
-
-## AI Chat Tools
-
-The AI chat assistant uses `ParseChatTools` (`python/ai/chat_tools.py`) as its programmatic tool layer. The built-in PARSE chat currently exposes **47 tools** in total. These tools are invoked by the LLM during chat sessions and stay bounded to PARSE-specific workflows.
-
-### Tools (47)
-
-**Read-only / preview**
-
-| Tool | Description |
-|---|---|
-| `project_context_read` | Full project metadata and speaker status |
-| `speakers_list` | Enumerate annotated speakers for batch/preflight workflows |
-| `annotation_read` | Read annotation data for a speaker (with optional tier/concept filtering) |
-| `pipeline_state_read` | Preflight one speaker's pipeline state with per-step `done` / `can_run`, coverage fields, counts, and reasons; agents should prefer `full_coverage` over bare `done` when deciding whether a rerun is needed |
-| `pipeline_state_batch` | Preflight multiple speakers and summarize blocked / partial-coverage speakers before a batch run |
-| `cognate_compute_preview` | Preview cognate computation results |
-| `cross_speaker_match_preview` | Preview cross-speaker matching candidates |
-| `spectrogram_preview` | Generate spectrogram preview for a segment |
-| `read_audio_info` | Read WAV metadata (duration, sample rate, channels, sample width, file size) |
-| `read_csv_preview` | Preview a CSV file (e.g. `concepts.csv`) |
-| `read_text_preview` | Preview Markdown/text files from the workspace or docs root |
-| `parse_memory_read` | Read persistent chat memory from `parse-memory.md` |
-| `enrichments_read` | Read computed enrichments with optional top-level key filtering |
-| `lexeme_notes_read` | Read stored lexeme notes with optional speaker / concept filtering |
-| `phonetic_rules_apply` | Apply or inspect phonetic-rule normalization / equivalence logic |
-| `jobs_list_active` | List active background jobs so agents can recover state after restarts |
-
-**Job-triggering**
-
-| Tool | Description |
-|---|---|
-| `stt_start` | Start STT pipeline on a recording. Returns job ID |
-| `stt_status` | Poll status of a running STT job |
-| `compute_status` | Generic poller for compute jobs, including full-pipeline runs and step-level results |
-| `audio_normalize_start` | Start audio normalization for one speaker |
-| `audio_normalize_status` | Poll status of a normalization job |
-| `stt_word_level_start` | Start Tier 1 word-level STT (`word_timestamps=True`, nested `segments[].words[]`) |
-| `stt_word_level_status` | Poll status/result of a Tier 1 word-level STT job |
-| `forced_align_start` | Start Tier 2 acoustic forced alignment for one speaker |
-| `forced_align_status` | Poll status/result of a Tier 2 forced-alignment job |
-| `pipeline_run` | Start a one-speaker pipeline or ORTH-only run with explicit steps/overwrites |
-| `ipa_transcribe_acoustic_start` | Start Tier 3 acoustic IPA transcription for one speaker |
-| `ipa_transcribe_acoustic_status` | Poll status/result of a Tier 3 acoustic IPA job |
-
-**Alignment / correction**
-
-| Tool | Description |
-|---|---|
-| `detect_timestamp_offset` | Detect a constant timestamp offset between annotation data and audio/STT evidence |
-| `detect_timestamp_offset_from_pair` | Compute an offset from one or more manually known CSV↔audio anchor pairs when automated STT-based matching is weak or unavailable |
-| `apply_timestamp_offset` | Apply a constant offset to lexeme timestamps for one speaker (`dryRun=true` first) |
-
-**Tag operations**
-
-| Tool | Description |
-|---|---|
-| `prepare_tag_import` | Validate and preview a tag CSV before import |
-| `import_tag_csv` | Import tags from a prepared CSV file |
-
-**Write / export / merge operations**
-
-| Tool | Description |
-|---|---|
-| `contact_lexeme_lookup` | Fetch and optionally merge contact-language reference forms via the CLEF provider chain (`dryRun=true` first) |
-| `onboard_speaker_import` | Copy external audio/CSV into the workspace, scaffold speaker state, and register it in `source_index.json` (`dryRun=true` first) |
-| `import_processed_speaker` | Hydrate one speaker from existing processed artifacts (working WAV, annotations, peaks, optional transcript files) into the active workspace (`dryRun=true` first) |
-| `parse_memory_upsert_section` | Create or replace a `## Section` block in `parse-memory.md` (`dryRun=true` first) |
-| `enrichments_write` | Shallow-merge or replace computed enrichments |
-| `lexeme_notes_write` | Write or delete lexeme notes for a speaker/concept pair |
-| `export_annotations_csv` | Export annotations as CSV (`speaker="all"` supported) |
-| `export_lingpy_tsv` | Export a LingPy-compatible TSV wordlist |
-| `export_nexus` | Export a NEXUS matrix for downstream phylogenetics |
-| `export_annotations_elan` | Export annotations as ELAN XML |
-| `export_annotations_textgrid` | Export annotations as Praat TextGrid |
-| `transcript_reformat` | Reformat transcript files into PARSE-friendly structure |
-| `peaks_generate` | Generate waveform peaks for one speaker/audio source |
-| `source_index_validate` | Validate or build `source_index.json` entries / manifests |
-
-The built-in assistant operates with both read and write access to the project, but the write-capable tools are intentionally gated. In particular, onboarding is **one speaker at a time**, and multi-source speakers are flagged as requiring manual / virtual-timeline coordination because PARSE does not yet auto-align multiple WAVs into a shared annotation timeline.
-
----
-
-## MCP Server Mode
-
-### Agent Tools (MCP)
-
-PARSE can run as an **MCP (Model Context Protocol) server**, exposing a curated subset of **29 MCP tools** from its broader **47-tool** `ParseChatTools` surface. This is the agent-facing entrypoint for Claude Code, Cursor, Cline, Hermes, Windsurf, Codex, and other MCP-compatible clients: they can call PARSE's project-aware tools programmatically without going through the browser UI. The MCP surface is intentionally narrower than the in-app chat surface; not every chat tool is exported over MCP.
-
-```bash
-python python/adapters/mcp_adapter.py                          # auto-detect project root
-python python/adapters/mcp_adapter.py --project-root /path/to  # explicit root
-python python/adapters/mcp_adapter.py --verbose                # debug logging
-```
-
-### Client Configuration
-
-Add PARSE as an MCP server in your client config. Example for Claude Desktop (`claude_desktop_config.json`):
-
-```json
-{
-    "mcpServers": {
-        "parse": {
-            "command": "python",
-            "args": ["/path/to/parse/python/adapters/mcp_adapter.py"],
-            "env": {
-                "PARSE_PROJECT_ROOT": "/path/to/your/parse/project",
-                "PARSE_EXTERNAL_READ_ROOTS": "/mnt/c/Users/Lucas/Thesis",
-                "PARSE_CHAT_MEMORY_PATH": "/path/to/parse-memory.md"
-            }
-        }
-    }
-}
-```
-
-If you launch the adapter without an explicit `env` block, it also reads repo-local overrides from `<project-root>/.parse-env` (same convention as `scripts/parse-run.sh`). Use that for machine-specific `PARSE_EXTERNAL_READ_ROOTS`, `PARSE_CHAT_MEMORY_PATH`, or `PARSE_PROJECT_ROOT`; explicit client-provided env vars still take precedence.
-
-### Exposed Tools
-
-The MCP adapter currently registers **29 tools** from `ParseChatTools` in `python/adapters/mcp_adapter.py`:
-
-For pipeline-preflight tools, note that PARSE now exposes **coverage-aware state**, not just interval presence. At the top level this includes `duration_sec`; per step (STT / ORTH / IPA) it includes `coverage_start_sec`, `coverage_end_sec`, `coverage_fraction`, and `full_coverage`. For automation, `full_coverage` is the field that answers "has the entire WAV really been processed?".
-
-| Tool | Description |
-|---|---|
-| `project_context_read` | Project metadata, source index, annotation inventory, enrichments summary |
-| `annotation_read` | Read speaker annotation data with optional concept/tier filtering |
-| `read_csv_preview` | Preview CSV files (columns, row count, sample rows) |
-| `cognate_compute_preview` | Compute cognate/similarity preview from annotations (read-only) |
-| `cross_speaker_match_preview` | Cross-speaker match candidates from STT output |
-| `spectrogram_preview` | Spectrogram preview for a time-bounded segment |
-| `contact_lexeme_lookup` | Fetch reference forms from third-party sources (CLDF, ASJP, Wikidata, etc.); **dryRun required** — pass dryRun=true to preview, dryRun=false to merge into sil_contact_languages.json |
-| `stt_start` | Start STT background job on an audio file (proxied to the running PARSE HTTP server on PARSE_API_PORT, default 8766, so job state is shared with the browser UI) |
-| `stt_status` | Poll status/progress of an STT job (same HTTP proxy) |
-| `stt_word_level_start` | Start Tier 1 word-level STT; segments include nested `words[]` spans from `word_timestamps=True` |
-| `stt_word_level_status` | Poll status/progress of a Tier 1 word-level STT job |
-| `forced_align_start` | Start Tier 2 forced alignment with torchaudio + wav2vec2 on Tier 1 word windows |
-| `forced_align_status` | Poll status/progress of a Tier 2 forced-alignment job |
-| `ipa_transcribe_acoustic_start` | Start Tier 3 acoustic IPA transcription (`ipa_only`) on one speaker |
-| `ipa_transcribe_acoustic_status` | Poll status/progress of a Tier 3 acoustic IPA job |
-| `detect_timestamp_offset` | Detect a constant timestamp offset between transcript/annotation timestamps and audio evidence, with monotonic alignment and quantile anchor selection |
-| `detect_timestamp_offset_from_pair` | Detect an offset from manually supplied audio↔CSV anchor pair(s) when automated alignment is unreliable |
-| `apply_timestamp_offset` | Apply a constant offset to speaker lexeme timestamps; dry-run first |
-| `import_tag_csv` | Import a CSV file as a custom tag list (dry-run first) |
-| `prepare_tag_import` | Create/update a tag with concept IDs (dry-run first) |
-| `onboard_speaker_import` | Import one speaker from on-disk audio (and optional CSV) into the workspace; dry-run first; multi-source speakers may require manual virtual-timeline coordination |
-| `import_processed_speaker` | Import one speaker from existing processed artifacts (working WAV, annotations, peaks, optional transcript JSON/CSV) into the active workspace; dry-run first |
-| `parse_memory_read` | Read persistent PARSE chat memory from `parse-memory.md` |
-| `parse_memory_upsert_section` | Upsert a `## Section` block in `parse-memory.md`; dry-run first |
-| `speakers_list` | Enumerate annotated speakers for batch/preflight tooling |
-| `pipeline_state_read` | Preflight one speaker's pipeline state with per-step `done` / `can_run`, coverage fields, counts, and reasons; use `full_coverage` rather than bare `done` when deciding whether a tier truly covers the whole recording |
-| `pipeline_state_batch` | Preflight multiple speakers at once and summarize blocked / partial-coverage speakers before a batch run |
-| `pipeline_run` | Start a one-speaker `full_pipeline` run or an ORTH-only/step-subset run with explicit overwrites |
-| `compute_status` | Poll any compute job, including full-pipeline runs, and return the backend snapshot/result |
-
-> **Requires:** `pip install 'mcp[cli]'`
-
----
-
-## HTTP API
-
-The Python backend (`python/server.py`, port `8766`) exposes the following endpoints. The React frontend communicates exclusively through the typed client in `src/api/client.ts`.
-
-### GET
-
-| Endpoint | Description |
-|---|---|
-| `/api/config` | Project configuration |
-| `/api/enrichments` | Computed comparative enrichments |
-| `/api/auth/status` | Auth provider status |
-| `/api/export/lingpy` | LingPy-compatible TSV export |
-| `/api/export/nexus` | NEXUS export *(placeholder — not yet implemented)* |
-| `/api/contact-lexemes/coverage` | CLEF provider coverage status |
-| `/api/worker/status` | Persistent compute-worker health check (`alive`, `pid`, `jobs_in_flight`) |
-| `/api/tags` | Tag definitions and assignments |
-
-### POST
-
-| Endpoint | Description |
-|---|---|
-| `/api/onboard/speaker` | Speaker onboarding (multipart upload, background job) |
-| `/api/onboard/speaker/status` | Poll onboarding job status |
-| `/api/normalize` | Start audio normalization (ffmpeg loudnorm) |
-| `/api/normalize/status` | Poll normalization job status |
-| `/api/stt` | Start STT pipeline |
-| `/api/stt/status` | Poll STT job status |
-| `/api/suggest` | Request annotation suggestions |
-| `/api/chat/session` | Create or resume a chat session |
-| `/api/chat/run` | Send a message to the chat assistant |
-| `/api/chat/run/status` | Poll chat run status |
-| `/api/enrichments` | Save enrichments (POST overwrites) |
-| `/api/config` | Update project configuration (partial) |
-| `/api/auth/key` | Save API key for a provider |
-| `/api/auth/start` | Start OAuth flow |
-| `/api/auth/poll` | Poll OAuth status |
-| `/api/auth/logout` | Clear auth credentials |
-| `/api/tags/merge` | Merge tag definitions |
-
-### PUT
-
-| Endpoint | Description |
-|---|---|
-| `/api/config` | Full project configuration update |
-
----
-
-## Data Architecture
-
-PARSE uses a hybrid data model:
-
-- **Live annotations** — per-speaker JSON files in `annotations/<Speaker>.json` (primary source of truth; timestamps are never modified by AI)
-- **Computed enrichments** — `parse-enrichments.json`, generated by the compare pipeline for cognate sets, similarity scores, and borrowing decisions
-- **Tag store** — Zustand `tagStore` persists tag definitions to localStorage, shared across both Annotate and Compare modes under a single project-scoped key
-
-The enrichments layer stores computed structures while preserving manual adjudications. Annotations and enrichments are both excluded from version control as runtime data.
-
----
-
-## Technology
-
-- React 18 + TypeScript + Vite (current frontend architecture)
-- Zustand (state management)
-- Tailwind CSS v3 (styling)
-- Python 3.10–3.12 backend serving API routes and the built frontend (`dist/`) for non-dev usage (3.13+ is blocked by `cgi.FieldStorage` removal until `python/server.py` migrates off it)
-- WaveSurfer 7
-- faster-whisper + CTranslate2 (local STT / ORTH, with CPU fallback)
-- wav2vec2 via HuggingFace transformers (local forced alignment + IPA; CPU-first on WSL)
-- PyTorch runtime for local ML, with GPU where the host/runtime stack is stable
-
----
-
-## Context
-
-PARSE was built for a Southern Kurdish dialect phylogenetics thesis at the University of Bamberg. The working dataset covers multiple speakers of Southern Kurdish varieties with an 85-item Oxford Iranian wordlist, targeting downstream Bayesian phylogenetic analysis in BEAST 2.
-
----
-
-## Citation
-
-If you use PARSE in academic work, please cite it as research software. A machine-readable `CITATION.cff` is included in the repository root, so GitHub's **"Cite this repository"** sidebar button will produce APA/BibTeX entries automatically.
+It provides:
+
+- A **concept × speaker matrix** for side-by-side lexical comparison
+- Cognate controls for **accept**, **split**, **merge**, and **cycle**
+- Per-row editing, speaker flags, and secondary actions for review work
+- **Borrowing adjudication** aided by contact-language similarity evidence
+- **Enrichment overlays** for computed comparative metadata
+- The **CLEF** panel for multi-source contact-language lookup
+- The same shared **tag system** used in Annotate mode
+- Export to **LingPy-compatible TSV** and **NEXUS** for downstream phylogenetic analysis
+
+Together, Annotate and Compare cover the full movement from speaker-specific audio review to cross-speaker historical analysis.
+
+### AI Workflow Assistant
+
+PARSE includes a built-in **domain-specific chat dock** powered by the configured LLM provider.
+
+This assistant is not a generic chatbot. It operates through `ParseChatTools` and can inspect project state, guide annotation workflows, trigger jobs, help interpret comparative results, and support onboarding, export, and troubleshooting inside the same workstation.
+
+Supported LLM backends currently include **xAI (Grok)** and **OpenAI**. Local speech and alignment work is handled separately through faster-whisper, Razhan, Silero VAD, and wav2vec2.
+
+### MCP Server Mode
+
+PARSE can also run as an **MCP (Model Context Protocol) server**.
+
+That means external agent clients such as Claude Code, Cursor, Cline, Hermes, Windsurf, Codex, or other MCP-capable tools can call a curated subset of PARSE functions programmatically, without going through the browser UI.
+
+The MCP adapter currently exposes **29 tools** drawn from the broader in-app PARSE tool surface.
+
+## 📚 Documentation
+
+- [Getting Started](docs/getting-started.md) — installation, launch paths, requirements, environment variables, `ai_config.json`, GPU notes, and troubleshooting
+- [User Guide](docs/user-guide.md) — detailed Annotate/Compare workflows, CLEF usage, Lexical Anchor Alignment, and workspace hydration
+- [AI Integration](docs/ai-integration.md) — provider routing, model roles, configuration, external dependencies, and the full 47-tool chat surface
+- [API Reference](docs/api-reference.md) — HTTP endpoints, compute routes, examples, and the full 29-tool MCP surface
+- [Architecture](docs/architecture.md) — unified shell, backend/data design, Lexical Anchor Alignment scoring, and CLEF provider registry
+- [Developer Guide](docs/developer-guide.md) — project structure, tech stack, local development flow, and extension points for chat tools, MCP tools, and endpoints
+- [Research Context](docs/research-context.md) — thesis background, citation guidance, and research-software framing
+
+If you are new to PARSE, start with **[Getting Started](docs/getting-started.md)** and then move to the **[User Guide](docs/user-guide.md)**.
+
+## Research Workflow in One Pass
+
+PARSE is designed around a real fieldwork sequence rather than a toy demo sequence:
+
+1. **Load or import one speaker** into the active workspace
+2. **Normalize audio** and inspect the waveform
+3. **Run STT / ORTH / IPA support jobs** to seed time-aligned review
+4. **Correct timestamps and confirm segments** in Annotate mode
+5. **Search and anchor difficult lexemes** across long recordings
+6. **Compare the concept set across speakers** in the matrix view
+7. **Use CLEF evidence** when a borrowing analysis needs external lexical context
+8. **Export LingPy TSV or NEXUS** for downstream comparative and phylogenetic analysis
+
+The guiding principle is simple: timestamps are central, human review stays explicit, and automation should make linguistic judgment faster rather than opaque.
+
+## Core Runtime Notes
+
+A few practical details matter up front:
+
+- The active frontend is **React + Vite** in `src/`
+- The Python backend in `python/server.py` powers AI routes and can also serve the built frontend
+- The preferred development URLs are:
+  - `http://localhost:5173/`
+  - `http://localhost:5173/compare`
+- After `npm run build`, the Python server can serve the built UI at:
+  - `http://localhost:8766/`
+  - `http://localhost:8766/compare`
+- `config/ai_config.json` is machine-local and gitignored; start from `config/ai_config.example.json`
+- For real fieldwork usage, PARSE is intended to run against a **workspace root outside the git checkout**
+- PARSE is still in active development; the repository has explicitly treated full browser regression and export verification as ongoing validation work rather than fully settled release guarantees
+
+Those details are expanded in [Getting Started](docs/getting-started.md) and [Developer Guide](docs/developer-guide.md).
+
+## 🔬 Research & Citation
+
+PARSE was developed for a **Southern Kurdish dialect phylogenetics thesis** at the **University of Bamberg**.
+
+The working dataset and workflow are oriented toward:
+
+- long elicitation recordings
+- concept-based wordlists
+- multiple speakers of closely related varieties
+- cognate review and borrowing adjudication
+- downstream comparative analysis in **LingPy**, **LexStat**, and **BEAST 2**
+
+If you use PARSE in academic work, please cite it as **research software** and use the repository's [`CITATION.cff`](CITATION.cff) file or GitHub's **Cite this repository** UI.
 
 Suggested citation:
 
 > Ardelean, L. M. (2026). *PARSE: Phonetic Analysis & Review Source Explorer* [Computer software]. University of Bamberg. https://github.com/ArdeleanLucas/PARSE
 
-BibTeX:
-
-```bibtex
-@software{ardelean_parse_2026,
-  author  = {Ardelean, Lucas M.},
-  title   = {{PARSE}: Phonetic Analysis \& Review Source Explorer},
-  year    = {2026},
-  url     = {https://github.com/ArdeleanLucas/PARSE},
-  note    = {Research software for Southern Kurdish dialect phylogenetics}
-}
-```
-
-PARSE is research software developed alongside a Southern Kurdish dialect phylogenetics thesis at the University of Bamberg; please also cite the associated thesis if/when it is published.
-
----
+See [Research Context](docs/research-context.md) for full citation guidance and research framing.
 
 ## License
 
-MIT
+MIT License

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -1,0 +1,312 @@
+# AI Integration
+
+> Last updated: 2026-04-24
+>
+> This document consolidates the AI provider system, model roles, configuration expectations, and the full built-in PARSE chat tool surface currently described in the repository README and code.
+
+PARSE is AI-native, but not in the sense of a generic chatbot pasted onto a UI. Different tasks route to different providers and model families, and the in-app assistant operates through a bounded PARSE-specific tool layer.
+
+## Provider system at a glance
+
+PARSE routes AI work by task type rather than forcing one model/provider to do everything.
+
+| Task | Supported providers |
+|---|---|
+| STT (speech-to-text) | faster-whisper (local), OpenAI Whisper API |
+| IPA transcription | acoustic wav2vec2 via `ipa_only` compute |
+| LLM / chat | xAI (Grok), OpenAI |
+
+A single project can therefore mix providers across tasks:
+
+- local STT / ORTH for speech work
+- wav2vec2 for alignment and acoustic IPA
+- OpenAI or xAI for workflow chat
+
+Configuration lives in `config/ai_config.json`.
+
+## Configuration model
+
+PARSE expects a machine-local config file:
+
+```bash
+cp config/ai_config.example.json config/ai_config.json
+```
+
+The file is gitignored because it includes machine-specific paths and secrets.
+
+If the file is missing, the backend can still start with built-in defaults, but runtime behavior will not necessarily match a thesis-ready setup.
+
+### Key config sections
+
+#### `stt`
+
+This block controls the main speech-to-text provider.
+
+Current template:
+
+```json
+"stt": {
+  "provider": "faster-whisper",
+  "model_path": "",
+  "language": "ku",
+  "device": "cuda",
+  "compute_type": "float16",
+  "beam_size": 5
+}
+```
+
+Operational notes from the current README and template:
+
+- faster-whisper is the main local STT backend
+- word-level timestamps are enabled in the pipeline
+- language can be auto-detected from project metadata when available
+- the intended workflow is GPU-backed local inference
+- the current README notes explicit CUDA-runtime detection, an emergency `PARSE_STT_FORCE_CPU=1` override, and a CPU/int8 fallback if the local CUDA stack is unavailable
+- mid-run CUDA failures rebuild the Whisper model on CPU instead of leaving the job wedged
+
+#### `ortho`
+
+This block configures the orthographic transcription path.
+
+Current template:
+
+```json
+"ortho": {
+  "provider": "faster-whisper",
+  "model_path": "razhan/whisper-base-sdh",
+  "language": "sd",
+  "device": "cuda",
+  "compute_type": "float16",
+  "beam_size": 5,
+  "vad_filter": false,
+  "initial_prompt": "",
+  "refine_lexemes": false
+}
+```
+
+Key behavior:
+
+- **Razhan** is the canonical Southern Kurdish orthographic model
+- `vad_filter` defaults to **false** for full-waveform coverage in ORTH mode
+- `initial_prompt` can prime the Whisper decoder for elicitation-style recordings
+- `refine_lexemes=true` adds a short-clip lexeme refinement pass after forced alignment
+
+#### `ipa` + `wav2vec2`
+
+The current PARSE architecture makes acoustic IPA a dedicated wav2vec2 stage rather than a text-derived fallback.
+
+```json
+"ipa": {
+  "engine": "wav2vec2",
+  "model": "facebook/wav2vec2-xlsr-53-espeak-cv-ft",
+  "model_only": true
+},
+"wav2vec2": {
+  "provider": "wav2vec2-ipa",
+  "model": "facebook/wav2vec2-xlsr-53-espeak-cv-ft",
+  "device": "cuda",
+  "force_cpu": false,
+  "chunk_size": 150
+}
+```
+
+Important design point: the older Epitran / text-to-IPA / LLM IPA paths are gone from the main workflow described in the current README.
+
+#### `llm` and `chat`
+
+These blocks configure the workflow assistant.
+
+```json
+"llm": {
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "api_key_env": "OPENAI_API_KEY"
+},
+"chat": {
+  "enabled": true,
+  "read_only": false,
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "api_key_env": "OPENAI_API_KEY",
+  "temperature": 0.1,
+  "max_tool_rounds": 4,
+  "max_history_messages": 24,
+  "max_output_tokens": 1400
+}
+```
+
+Supported provider families for chat are currently:
+
+- **OpenAI**
+- **xAI / Grok**
+
+## Current model roles
+
+### `razhan/whisper-base-sdh`
+
+| Field | Value |
+|---|---|
+| Task | ORTH transcription / Southern Kurdish speech recognition |
+| Source | HuggingFace (local CT2 path or repo id) |
+| Role in PARSE | Speaker-level orthographic transcription for Southern Kurdish recordings |
+
+The current README emphasizes that Razhan produces **Kurdish Arabic-script orthographic transcription with word-level timestamps**. It is **not** the IPA engine.
+
+### `facebook/wav2vec2-xlsr-53-espeak-cv-ft`
+
+| Field | Value |
+|---|---|
+| Task | Tier 2 forced alignment + Tier 3 acoustic IPA |
+| Source | HuggingFace (local) |
+| Role in PARSE | Tightens word boundaries and generates phoneme output from audio slices |
+
+Current behavior described in the README:
+
+- Tier 2 forced alignment refines Tier 1 word windows
+- Tier 3 IPA prefers the word-level STT cache when available
+- If no STT word cache exists, PARSE falls back to coarse ORTH-interval slices
+- On WSL, the aligner now resolves to **CPU by default** for long wav2vec2 CTC workloads
+- `config/ai_config.json` exposes `wav2vec2.force_cpu` and `wav2vec2.chunk_size` so long runs can be tuned without code changes
+- recent fixes also cache `EspeakBackend` instances per language and report progress during Tier 2 forced alignment, which matters most on slower CPU-heavy WSL runs
+
+### Silero VAD
+
+| Field | Value |
+|---|---|
+| Task | Voice activity detection |
+| Source | Bundled with faster-whisper |
+| Role in PARSE | Segment boundary detection for long recordings in Whisper-style decoding |
+
+The current README notes that Silero VAD parameters are tuned for elicitation recordings with soft-spoken consultants and variable microphone distance.
+
+### faster-whisper + CTranslate2
+
+| Component | Role |
+|---|---|
+| `faster-whisper` | Local STT / ORTH inference backend |
+| `CTranslate2` | Optimized runtime for Whisper-family models |
+
+These components underpin local inference for the speech-heavy parts of PARSE.
+
+## External dependency links worth citing
+
+The current README includes a citation-oriented table for core external models and repositories directly referenced by PARSE.
+
+| Component | Type | Used in PARSE for | Link |
+|---|---|---|---|
+| `razhan/whisper-base-sdh` | Model | ORTH transcription of Southern Kurdish speech | https://huggingface.co/razhan/whisper-base-sdh |
+| `facebook/wav2vec2-xlsr-53-espeak-cv-ft` | Model | Acoustic IPA transcription + forced alignment | https://huggingface.co/facebook/wav2vec2-xlsr-53-espeak-cv-ft |
+| Silero VAD | Model / repo | Voice activity detection during Whisper-style decoding | https://github.com/snakers4/silero-vad |
+| faster-whisper | Repository / library | Local STT + ORTH inference backend | https://github.com/SYSTRAN/faster-whisper |
+| CTranslate2 | Repository / library | Optimized local inference runtime for Whisper-family models | https://github.com/OpenNMT/CTranslate2 |
+| WaveSurfer.js | Repository / library | Long-recording waveform UI | https://github.com/katspaugh/wavesurfer.js |
+| React | Repository / library | Frontend application framework | https://github.com/facebook/react |
+| Vite | Repository / library | Frontend dev/build toolchain | https://github.com/vitejs/vite |
+| Tailwind CSS | Repository / library | Frontend styling system | https://github.com/tailwindlabs/tailwindcss |
+| Lucide | Repository / library | UI icon set | https://github.com/lucide-icons/lucide |
+
+## The AI workflow assistant
+
+Both Annotate and Compare modes include a built-in assistant powered by the configured LLM provider.
+
+The current README describes it as a **domain-specific assistant**, not a general-purpose chatbot. It operates through `ParseChatTools` in `python/ai/chat_tools.py` and can currently support:
+
+- audio setup and file management
+- annotation workflow guidance
+- cross-speaker analysis support
+- export and downstream-pipeline assistance
+- troubleshooting across the PARSE workflow
+
+## Full built-in chat tool surface (47 tools)
+
+The in-app assistant currently exposes **47 PARSE-specific tools**.
+
+### Read-only / preview tools (16)
+
+| Tool | Description |
+|---|---|
+| `project_context_read` | Full project metadata and speaker status |
+| `speakers_list` | Enumerate annotated speakers for batch/preflight workflows |
+| `annotation_read` | Read annotation data for a speaker, with optional tier/concept filtering |
+| `pipeline_state_read` | Preflight one speaker's pipeline state with per-step `done` / `can_run`, coverage fields, counts, and reasons |
+| `pipeline_state_batch` | Preflight multiple speakers and summarize blocked / partial-coverage speakers before a batch run |
+| `cognate_compute_preview` | Preview cognate computation results |
+| `cross_speaker_match_preview` | Preview cross-speaker matching candidates |
+| `spectrogram_preview` | Generate a spectrogram preview for a segment |
+| `read_audio_info` | Read WAV metadata such as duration, sample rate, channels, sample width, and file size |
+| `read_csv_preview` | Preview a CSV file such as `concepts.csv` |
+| `read_text_preview` | Preview Markdown/text files from the workspace or docs root |
+| `parse_memory_read` | Read persistent chat memory from `parse-memory.md` |
+| `enrichments_read` | Read computed enrichments with optional top-level filtering |
+| `lexeme_notes_read` | Read stored lexeme notes with optional speaker/concept filtering |
+| `phonetic_rules_apply` | Apply or inspect phonetic-rule normalization / equivalence logic |
+| `jobs_list_active` | List active background jobs so agents can recover state after restarts |
+
+### Job-triggering tools (12)
+
+| Tool | Description |
+|---|---|
+| `stt_start` | Start STT pipeline on a recording and return a job ID |
+| `stt_status` | Poll the status of a running STT job |
+| `compute_status` | Generic poller for compute jobs, including full-pipeline runs and step-level results |
+| `audio_normalize_start` | Start audio normalization for one speaker |
+| `audio_normalize_status` | Poll the status of a normalization job |
+| `stt_word_level_start` | Start Tier 1 word-level STT with nested `segments[].words[]` spans |
+| `stt_word_level_status` | Poll status/result of a Tier 1 word-level STT job |
+| `forced_align_start` | Start Tier 2 acoustic forced alignment for one speaker |
+| `forced_align_status` | Poll status/result of a Tier 2 forced-alignment job |
+| `pipeline_run` | Start a one-speaker pipeline or ORTH-only run with explicit steps and overwrites |
+| `ipa_transcribe_acoustic_start` | Start Tier 3 acoustic IPA transcription for one speaker |
+| `ipa_transcribe_acoustic_status` | Poll status/result of a Tier 3 acoustic IPA job |
+
+### Alignment / correction tools (3)
+
+| Tool | Description |
+|---|---|
+| `detect_timestamp_offset` | Detect a constant timestamp offset between annotation data and audio/STT evidence |
+| `detect_timestamp_offset_from_pair` | Compute an offset from one or more manually trusted CSV↔audio anchor pairs |
+| `apply_timestamp_offset` | Apply a constant offset to lexeme timestamps for one speaker (`dryRun=true` first) |
+
+### Tag operations (2)
+
+| Tool | Description |
+|---|---|
+| `prepare_tag_import` | Validate and preview a tag CSV before import |
+| `import_tag_csv` | Import tags from a prepared CSV file |
+
+### Write / export / merge tools (14)
+
+| Tool | Description |
+|---|---|
+| `contact_lexeme_lookup` | Fetch and optionally merge contact-language reference forms via the CLEF provider chain (`dryRun=true` first) |
+| `onboard_speaker_import` | Copy external audio/CSV into the workspace, scaffold speaker state, and register it in `source_index.json` (`dryRun=true` first) |
+| `import_processed_speaker` | Hydrate one speaker from existing processed artifacts into the active workspace (`dryRun=true` first) |
+| `parse_memory_upsert_section` | Create or replace a `## Section` block in `parse-memory.md` (`dryRun=true` first) |
+| `enrichments_write` | Shallow-merge or replace computed enrichments |
+| `lexeme_notes_write` | Write or delete lexeme notes for a speaker/concept pair |
+| `export_annotations_csv` | Export annotations as CSV (`speaker="all"` supported) |
+| `export_lingpy_tsv` | Export a LingPy-compatible TSV wordlist |
+| `export_nexus` | Export a NEXUS matrix for downstream phylogenetics |
+| `export_annotations_elan` | Export annotations as ELAN XML |
+| `export_annotations_textgrid` | Export annotations as Praat TextGrid |
+| `transcript_reformat` | Reformat transcript files into PARSE-friendly structure |
+| `peaks_generate` | Generate waveform peaks for one speaker/audio source |
+| `source_index_validate` | Validate or build `source_index.json` entries / manifests |
+
+## Tool-surface design constraints
+
+The current README calls out two important operational boundaries:
+
+- write-capable tools are intentionally gated
+- onboarding is **one speaker at a time**
+
+Multi-source speakers may still require manual or virtual-timeline coordination because PARSE does not yet auto-align multiple WAVs into a single shared annotation timeline.
+
+## MCP subset versus in-app tool surface
+
+Not every in-app chat tool is exported over MCP.
+
+- **Built-in chat tools**: 47
+- **MCP-exposed tools**: 29
+
+For the exact MCP subset, startup instructions, and usage examples, see [API Reference](./api-reference.md).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,408 @@
+# API Reference
+
+> Last updated: 2026-04-24
+>
+> This page consolidates the current PARSE HTTP surface and MCP server mode. HTTP routes were cross-checked against `src/api/client.ts` and `python/server.py`; MCP tools were cross-checked against `python/adapters/mcp_adapter.py`.
+
+## API overview
+
+PARSE has two programmatic surfaces:
+
+1. **HTTP API** — used by the browser frontend and any local automation that talks to `python/server.py`
+2. **MCP server mode** — used by external agent clients through the PARSE MCP adapter
+
+### Base URLs
+
+During active development:
+
+- frontend: `http://localhost:5173`
+- API backend: `http://localhost:8766`
+
+In practice, the React app usually calls relative `/api/...` paths through the Vite proxy.
+
+## HTTP API
+
+### Response conventions
+
+A few patterns recur across the API:
+
+- job-start endpoints usually return `{ "jobId": "...", "status": "running" }`
+- status endpoints typically accept either `jobId` or `job_id`
+- binary export/image endpoints return files rather than JSON
+- compute endpoints normalize job handling across multiple background workflows
+- `/api/config` carries a schema-versioned payload; if the config contract changes incompatibly, update the corresponding version constants in both `python/server.py` and `src/api/client.ts`
+
+## GET endpoints
+
+### Core workspace data
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `GET /api/config` | Read project configuration | Current config payload is wrapped and includes `schema_version: 1` |
+| `GET /api/annotations/{speaker}` | Read one speaker annotation record | Resolves the requested speaker to the normalized annotation payload |
+| `GET /api/stt-segments/{speaker}` | Read cached STT segments for a speaker | Returns `segments: []` when cache is missing rather than 404 |
+| `GET /api/enrichments` | Read comparative enrichments | Returns `{ enrichments: ... }` |
+| `GET /api/tags` | Read tag definitions and assignments | Shared across Annotate and Compare |
+| `GET /api/jobs/active` | List active backend jobs | Used to rehydrate progress after reload |
+| `GET /api/pipeline/state/{speaker}` | Read coverage-aware pipeline state | Includes `full_coverage` metadata per step |
+| `GET /api/chat/session/{sessionId}` | Read one chat session | Returns message history and token metadata |
+
+### Search, analysis, and media
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `GET /api/lexeme/search` | Rank candidate time ranges for a lexeme/concept | User-facing endpoint behind Search & anchor lexeme |
+| `GET /api/spectrogram` | Return or generate a PNG spectrogram for a clip | Cached on disk; returns `image/png` |
+| `GET /api/contact-lexemes/coverage` | Inspect CLEF provider coverage | Used by the Compare CLEF workflow |
+
+### Auth, exports, and worker health
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `GET /api/auth/status` | Read auth provider status | Used by provider-auth UI state |
+| `GET /api/export/lingpy` | Download LingPy TSV export | Returns a file/blob, not JSON |
+| `GET /api/export/nexus` | Download NEXUS export | Returns a file/blob, not JSON |
+| `GET /api/worker/status` | Health-check the persistent compute worker | Returns mode info in every case; returns a real liveness probe when persistent-worker mode is active |
+
+## POST endpoints
+
+### Annotation, onboarding, and speaker data
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `POST /api/annotations/{speaker}` | Save one speaker annotation record | Writes normalized annotation JSON |
+| `POST /api/onboard/speaker` | Upload raw audio and optional CSV for one speaker | Multipart upload |
+| `POST /api/onboard/speaker/status` | Poll onboarding job status | Background-job status endpoint |
+| `POST /api/concepts/import` | Import concepts CSV | Multipart form upload |
+| `POST /api/tags/import` | Import tags from CSV | Multipart form upload |
+| `POST /api/lexeme-notes` | Write or delete a lexeme note | Writes into `parse-enrichments.json` |
+| `POST /api/lexeme-notes/import` | Import lexeme notes/comments from CSV | Multipart form upload |
+
+### Audio, STT, and compute jobs
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `POST /api/normalize` | Start audio normalization | ffmpeg loudnorm pipeline |
+| `POST /api/normalize/status` | Poll normalization status | Job polling |
+| `POST /api/stt` | Start STT | Accepts `speaker`, `sourceWav` / `source_wav`, optional `language` |
+| `POST /api/stt/status` | Poll STT status | Accepts `jobId` or `job_id` |
+| `POST /api/compute/{computeType}` | Start a compute job | Main dispatcher for ORTH, IPA, full pipeline, contact lexemes, etc. |
+| `POST /api/compute/{computeType}/status` | Poll a typed compute job | Verifies the job matches the compute type |
+| `POST /api/compute/status` | Poll a compute job without specifying a type | Generic polling alias |
+| `POST /api/{computeType}/status` | Compatibility alias for compute status | Used for compute-style status endpoints other than STT |
+
+### Suggestions, chat, and auth
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `POST /api/suggest` | Request annotation suggestions | Concept-scoped suggestion workflow |
+| `POST /api/chat/session` | Create or resume a chat session | Returns normalized `sessionId` / `session_id` |
+| `POST /api/chat/run` | Start a chat run | Returns a job ID |
+| `POST /api/chat/run/status` | Poll chat run status | Background-job polling |
+| `POST /api/auth/key` | Save an API key for a provider | Provider-scoped credential save |
+| `POST /api/auth/start` | Start OAuth/device auth flow | Provider auth initiation |
+| `POST /api/auth/poll` | Poll OAuth/device auth flow | Normalized status: pending/complete/expired/error |
+| `POST /api/auth/logout` | Clear auth credentials | Logout endpoint |
+
+### Comparative data and workflow correction
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `POST /api/enrichments` | Save enrichments | Accepts either `{ enrichments: ... }` or the raw object |
+| `POST /api/config` | Update project configuration | Current server accepts POST as an update path |
+| `POST /api/tags/merge` | Merge tag definitions | Shared tag persistence |
+| `POST /api/offset/detect` | Detect a constant timestamp offset | Supports STT-based alignment checks |
+| `POST /api/offset/detect-from-pair` | Detect a timestamp offset from trusted manual pairs | STT-free correction path |
+| `POST /api/offset/apply` | Apply a constant timestamp shift | Mutates the speaker annotation file |
+
+## PUT endpoints
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `PUT /api/config` | Update project configuration | Same underlying update handler as POST `/api/config` |
+
+## Compute types
+
+The compute dispatcher normalizes several named background workflows.
+
+| Compute type | Accepted aliases | Purpose |
+|---|---|---|
+| `contact-lexemes` | — | Start a CLEF contact-lexeme fetch/merge job |
+| `ipa_only` | `ipa-only`, `ipa` | Run Tier 3 acoustic IPA fill |
+| `ortho` | `ortho_only`, `ortho-only` | Run speaker-level ORTH transcription |
+| `forced_align` | `forced-align`, `align` | Run Tier 2 forced alignment |
+| `full_pipeline` | `full-pipeline`, `pipeline` | Run the step-resilient full annotation pipeline |
+
+## Example requests and responses
+
+### Start STT
+
+```http
+POST /api/stt
+Content-Type: application/json
+
+{
+  "speaker": "Fail02",
+  "source_wav": "audio/working/Fail02/Fail02.wav",
+  "language": "ku"
+}
+```
+
+Example response:
+
+```json
+{
+  "jobId": "stt-abc123",
+  "status": "running"
+}
+```
+
+### Poll STT status
+
+```http
+POST /api/stt/status
+Content-Type: application/json
+
+{
+  "job_id": "stt-abc123"
+}
+```
+
+Example shape:
+
+```json
+{
+  "status": "running",
+  "progress": 42.0,
+  "message": "Transcribing (18 segments)"
+}
+```
+
+### Read pipeline state
+
+```http
+GET /api/pipeline/state/Fail02
+```
+
+Example shape:
+
+```json
+{
+  "speaker": "Fail02",
+  "duration_sec": 10432.11,
+  "normalize": {
+    "done": true,
+    "can_run": true,
+    "reason": null,
+    "path": "audio/working/Fail02/Fail02.wav"
+  },
+  "stt": {
+    "done": true,
+    "can_run": true,
+    "reason": null,
+    "coverage_fraction": 0.98,
+    "full_coverage": true,
+    "segments": 412
+  }
+}
+```
+
+### Search for lexeme candidates
+
+```http
+GET /api/lexeme/search?speaker=Fail02&variants=yek,yak,jek&concept_id=1&tiers=ortho_words,ortho,stt,ipa&limit=10
+```
+
+Example shape:
+
+```json
+{
+  "speaker": "Fail02",
+  "concept_id": "1",
+  "variants": ["yek", "yak", "jek"],
+  "language": "ku",
+  "candidates": [
+    {
+      "start": 312.41,
+      "end": 313.87,
+      "tier": "ortho_words",
+      "matched_text": "yek",
+      "matched_variant": "yek",
+      "score": 0.92,
+      "phonetic_score": 0.88,
+      "cross_speaker_score": 0.12,
+      "confidence_weight": 0.84,
+      "source_label": "ortho_words"
+    }
+  ],
+  "signals_available": {
+    "phonemizer": true,
+    "cross_speaker_anchors": 6,
+    "contact_variants": ["yak"]
+  }
+}
+```
+
+### Start a full pipeline run
+
+```http
+POST /api/compute/full_pipeline
+Content-Type: application/json
+
+{
+  "speaker": "Fail02"
+}
+```
+
+Example response:
+
+```json
+{
+  "jobId": "compute-full-pipeline-xyz789",
+  "status": "running"
+}
+```
+
+### Poll a compute job
+
+```http
+POST /api/compute/full_pipeline/status
+Content-Type: application/json
+
+{
+  "job_id": "compute-full-pipeline-xyz789"
+}
+```
+
+Example shape:
+
+```json
+{
+  "status": "complete",
+  "progress": 100,
+  "message": "Pipeline finished",
+  "result": {
+    "speaker": "Fail02",
+    "steps_run": ["normalize", "stt", "ortho", "ipa"],
+    "summary": {
+      "ok": 4,
+      "skipped": 0,
+      "error": 0
+    }
+  }
+}
+```
+
+### Download exports
+
+```http
+GET /api/export/lingpy
+GET /api/export/nexus
+```
+
+Both endpoints return downloadable file content rather than JSON.
+
+## MCP server mode
+
+PARSE can run as an MCP server by exposing a curated subset of `ParseChatTools` through `python/adapters/mcp_adapter.py`.
+
+### Start the adapter
+
+```bash
+python python/adapters/mcp_adapter.py
+python python/adapters/mcp_adapter.py --project-root /path/to/project
+python python/adapters/mcp_adapter.py --verbose
+```
+
+### Requirement
+
+```bash
+pip install 'mcp[cli]'
+```
+
+### Example client configuration
+
+```json
+{
+  "mcpServers": {
+    "parse": {
+      "command": "python",
+      "args": ["/path/to/parse/python/adapters/mcp_adapter.py"],
+      "env": {
+        "PARSE_PROJECT_ROOT": "/path/to/your/parse/project",
+        "PARSE_EXTERNAL_READ_ROOTS": "/mnt/c/Users/Lucas/Thesis",
+        "PARSE_CHAT_MEMORY_PATH": "/path/to/parse-memory.md"
+      }
+    }
+  }
+}
+```
+
+If no explicit environment block is passed, the adapter also reads repo-local overrides from `.parse-env`.
+
+## Full MCP tool surface (29 tools)
+
+### Inspection / preview / preflight
+
+| Tool | Description |
+|---|---|
+| `project_context_read` | Project metadata, source index summary, annotation inventory, enrichments summary |
+| `annotation_read` | Read speaker annotation data with optional concept/tier filtering |
+| `read_csv_preview` | Preview CSV files and sample rows |
+| `cognate_compute_preview` | Compute a read-only cognate/similarity preview |
+| `cross_speaker_match_preview` | Read cross-speaker match candidates from STT output |
+| `spectrogram_preview` | Generate a time-bounded spectrogram preview |
+| `parse_memory_read` | Read persistent PARSE chat memory |
+| `speakers_list` | Enumerate speakers for batch/preflight workflows |
+| `pipeline_state_read` | Read one speaker's coverage-aware pipeline state |
+| `pipeline_state_batch` | Read preflight state for multiple speakers |
+
+### Job control
+
+| Tool | Description |
+|---|---|
+| `stt_start` | Start STT on a project audio file |
+| `stt_status` | Poll STT job status |
+| `stt_word_level_start` | Start Tier 1 word-level STT |
+| `stt_word_level_status` | Poll Tier 1 word-level STT status |
+| `forced_align_start` | Start Tier 2 forced alignment |
+| `forced_align_status` | Poll forced-alignment status |
+| `ipa_transcribe_acoustic_start` | Start Tier 3 acoustic IPA |
+| `ipa_transcribe_acoustic_status` | Poll Tier 3 acoustic IPA status |
+| `pipeline_run` | Start a one-speaker full pipeline or step-subset run |
+| `compute_status` | Poll any compute job |
+
+### Alignment / correction
+
+| Tool | Description |
+|---|---|
+| `detect_timestamp_offset` | Detect a constant timestamp offset from annotation↔audio/STT evidence |
+| `detect_timestamp_offset_from_pair` | Detect an offset from trusted manual anchor pairs |
+| `apply_timestamp_offset` | Apply a constant shift to speaker timestamps |
+
+### Write / import / curation
+
+| Tool | Description |
+|---|---|
+| `contact_lexeme_lookup` | Fetch contact-language reference forms; dry-run first |
+| `import_tag_csv` | Import a CSV as a PARSE tag list |
+| `prepare_tag_import` | Preview and validate a tag import |
+| `onboard_speaker_import` | Import one speaker from on-disk audio/CSV into the workspace |
+| `import_processed_speaker` | Import one speaker from existing processed artifacts |
+| `parse_memory_upsert_section` | Upsert a `## Section` block in `parse-memory.md` |
+
+## MCP usage notes
+
+The MCP surface is a **subset** of the full in-app chat tool surface.
+
+A few operational rules remain important:
+
+- use `dryRun=true` first for gated mutating tools such as `contact_lexeme_lookup`, `onboard_speaker_import`, and timestamp/application workflows
+- prefer `full_coverage` rather than bare `done` when making automation decisions about whether a tier really covers the full recording
+- onboarding remains **one speaker at a time**
+
+## Related docs
+
+- Provider and model overview: [AI Integration](./ai-integration.md)
+- User-facing workflow context: [User Guide](./user-guide.md)
+- Data model and system design: [Architecture](./architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,324 @@
+# Architecture & Data Model
+
+> Last updated: 2026-04-24
+>
+> This document summarizes the current PARSE system shape: the unified React shell, Python backend, hybrid data model, Lexical Anchor Alignment System, CLEF provider registry, and export flow.
+
+PARSE is a research workstation rather than a single-purpose annotator. Its architecture is designed to keep per-speaker timing work, cross-speaker comparison, AI-assisted workflows, and export pipelines in one coherent system.
+
+## System overview
+
+```mermaid
+flowchart LR
+    Browser[React + Vite frontend\nAnnotate / Compare / Tags / AI Chat] --> Client[src/api/client.ts]
+    Client --> Server[python/server.py\nHTTP API + built frontend serving]
+    Server --> Annotations[annotations/<Speaker>.json\nper-speaker annotation records]
+    Server --> Enrichments[parse-enrichments.json\ncomparative overlays + notes]
+    Server --> ChatTools[python/ai/chat_tools.py\n47 PARSE-specific tools]
+    Server --> Compare[python/compare/*\ncognates + CLEF providers]
+    Server --> Models[local & remote AI providers\nfaster-whisper / wav2vec2 / OpenAI / xAI]
+    ChatTools --> MCP[python/adapters/mcp_adapter.py\n29-tool MCP server mode]
+    Compare --> Exports[LingPy TSV + NEXUS]
+```
+
+## Unified dual-mode shell
+
+The current frontend architecture is **React + Vite** with a unified shell hosted in `ParseUI.tsx`.
+
+That shell brings together:
+
+- **Annotate mode** for per-speaker segmentation and review
+- **Compare mode** for cross-speaker comparative analysis
+- the shared **tag system**
+- the **action menu** and compute workflows
+- the built-in **AI chat dock**
+
+This is a major architectural choice: PARSE does not treat annotation, comparison, and workflow assistance as separate apps. The same project state is reused across modes.
+
+### Current runtime routes
+
+Preferred development routes:
+
+- `http://localhost:5173/` — Annotate
+- `http://localhost:5173/compare` — Compare
+
+After `npm run build`, the Python backend can also serve the built frontend at:
+
+- `http://localhost:8766/`
+- `http://localhost:8766/compare`
+
+## Frontend structure
+
+The current top-level structure described in the README is:
+
+```text
+index.html              -- React/Vite entry HTML
+src/
+  App.tsx               -- BrowserRouter shell → <ParseUI />
+  ParseUI.tsx           -- Unified UI shell
+  api/
+    client.ts           -- Typed API client
+    types.ts            -- Shared TypeScript types
+  components/
+    annotate/           -- Annotate mode components
+    compare/            -- Compare mode components
+    shared/             -- Cross-mode shared components
+  hooks/                -- React hooks
+  stores/               -- Zustand stores
+python/
+  server.py             -- Backend API server + built-frontend serving
+  adapters/
+    mcp_adapter.py      -- MCP adapter
+  ai/                   -- AI provider layer and chat tools
+  compare/              -- Compare pipeline and CLEF providers
+config/
+  ai_config.example.json
+  ai_config.json
+annotations/            -- Runtime annotation JSON
+parse-enrichments.json  -- Runtime comparative overlays
+desktop/                -- Electron shell scaffold
+docs/                   -- Documentation and planning material
+dist/                   -- Vite build output
+```
+
+## Backend design
+
+The backend is centered on `python/server.py`.
+
+It is responsible for:
+
+- serving workspace configuration
+- reading and writing annotation records
+- managing background jobs
+- coordinating STT / normalization / compute endpoints
+- exposing chat and auth routes
+- generating exports
+- serving the built frontend for non-dev/local-server usage
+
+The backend is not just a thin file server. It is the orchestration layer for PARSE's workflow-specific automation.
+
+## Hybrid data architecture
+
+PARSE uses a layered data model rather than a single monolithic database.
+
+```mermaid
+flowchart TD
+    Audio[Source / working audio] --> Ann[annotations/<Speaker>.json]
+    Ann --> Compare[Comparative computation]
+    Compare --> Enrich[parse-enrichments.json]
+    Ann --> Export[LingPy TSV / NEXUS / ELAN / TextGrid]
+    Enrich --> Export
+    Tags[Zustand tagStore persistence] --> AnnotateUI[Annotate mode]
+    Tags --> CompareUI[Compare mode]
+```
+
+### 1. Live annotations
+
+Primary speaker-level data lives in:
+
+- `annotations/<Speaker>.json`
+- or the canonical `.parse.json` variant where present
+
+These files are the primary source of truth for time-aligned annotation work.
+
+The current README emphasizes an important rule: timestamps are not treated as disposable AI output. Timing remains central to the review workflow.
+
+### 2. Computed enrichments
+
+Comparative overlays live in:
+
+- `parse-enrichments.json`
+
+This layer stores computed comparative structures such as:
+
+- cognate sets
+- similarity signals
+- borrowing-related overlays
+- lexeme notes
+- manual overrides layered onto computed output
+
+The point of the enrichments layer is to preserve comparative structure without collapsing the original annotation record into a purely derived format.
+
+### 3. Tags
+
+The tag system is shared across Annotate and Compare.
+
+The current README describes it as a **Zustand `tagStore` persisted to localStorage**, scoped to the project and reused across workflows.
+
+### 4. Transcript and analysis sidecars
+
+PARSE also depends on supporting artifacts such as:
+
+- `coarse_transcripts/<speaker>.json`
+- `peaks/<Speaker>.json`
+- optional import/legacy transcript CSVs
+- `source_index.json`
+
+These are not the same thing as the main annotation truth, but they materially support search, alignment, import, and visualization.
+
+## Workspace-first design
+
+PARSE can run directly from the repo, but its architecture is explicitly workspace-friendly.
+
+When `PARSE_WORKSPACE_ROOT` is set, runtime writes and imports should land in that workspace rather than the bare repository tree.
+
+This matters because PARSE is designed for:
+
+- copied source audio
+- imported processed artifacts
+- persistent chat memory
+- iterative fieldwork data preparation
+
+In other words, the architecture assumes the active research workspace may be larger and more dynamic than the git checkout itself.
+
+## AI provider architecture
+
+PARSE routes different tasks to different provider families.
+
+```mermaid
+flowchart LR
+    STT[STT request] --> FW[faster-whisper / Whisper API]
+    ORTH[ORTH request] --> Razhan[razhan/whisper-base-sdh]
+    Align[Forced alignment] --> W2V[wav2vec2-xlsr-53-espeak-cv-ft]
+    IPA[Acoustic IPA] --> W2V
+    Chat[AI chat dock] --> LLM[OpenAI or xAI]
+```
+
+This separation is important conceptually:
+
+- speech recognition is not conflated with orthographic transcription
+- orthographic transcription is not conflated with IPA generation
+- workflow chat is not treated as the engine of alignment or export logic
+
+## Lexical Anchor Alignment System
+
+The **Lexical Anchor Alignment System** is the core PARSE feature for locating repeated lexical items in long recordings.
+
+### Problem it solves
+
+Long elicitation recordings often contain:
+
+- conversational framing
+- interviewer prompts
+- repeated productions
+- metalinguistic commentary
+- ambient noise
+
+A purely manual search process does not scale well across many speakers and concepts.
+
+### Two-signal candidate ranking
+
+```mermaid
+flowchart TD
+    Input[Target variants + optional concept_id] --> A[Signal A: within-speaker repetition]
+    Input --> B[Signal B: cross-speaker concept matching]
+    A --> Score[Weighted candidate score]
+    B --> Score
+    Score --> Ranked[Ranked candidate time ranges]
+    Ranked --> Confirm[Human confirmation in Annotate mode]
+    Confirm --> Anchors[confirmed_anchors sidecar]
+    Anchors --> Future[Improved cross-speaker evidence for later speakers]
+```
+
+#### Signal A — within-speaker repetition detection
+
+PARSE looks for repeated phonetically similar forms within a short time window. This is motivated by elicitation behavior where the same target form may be repeated several times in succession.
+
+#### Signal B — cross-speaker concept matching
+
+PARSE compares unassigned material against verified annotations from other speakers for the same concept using exact, fuzzy, phonetic-rule, and positional strategies.
+
+#### Current confidence formula
+
+```text
+confidence = 0.50 × phonetic + 0.25 × repetition + 0.15 × positional + 0.10 × cluster
+```
+
+The positional component uses a 45-second tolerance window around the expected cross-speaker median timestamp.
+
+### Human-in-the-loop design
+
+Architecturally, this system is ranking-and-review, not auto-commit.
+
+The annotator verifies a candidate, adjusts boundaries if needed, and explicitly confirms it. Confirmed anchors are then written to `AnnotationRecord.confirmed_anchors[concept_id]`, strengthening the cross-speaker signal for the remaining speakers.
+
+## CLEF provider registry
+
+**CLEF** (Contact Lexeme Explorer Feature) is the contact-language evidence layer used during borrowing adjudication in Compare mode.
+
+It is implemented as a provider registry under `python/compare/providers/`.
+
+### Registry shape
+
+The current README describes a 10-provider stack:
+
+- `asjp`
+- `cldf`
+- `csv_override`
+- `grokipedia`
+- `lingpy_wordlist`
+- `literature`
+- `pycldf_provider`
+- `pylexibank_provider`
+- `wikidata`
+- `wiktionary`
+
+### Architectural role of CLEF
+
+```mermaid
+flowchart LR
+    CompareRow[Compare row / candidate borrowing case] --> CLEFReq[Contact lexeme request]
+    CLEFReq --> Registry[Provider registry]
+    Registry --> Sources[External and local lexical sources]
+    Sources --> Evidence[Reference forms + coverage]
+    Evidence --> Panel[ContactLexemePanel]
+    Panel --> Decision[Borrowing adjudication]
+```
+
+CLEF is intentionally separated from the main annotation store. It augments comparison with external evidence rather than overwriting the primary annotation record.
+
+## Chat tool architecture
+
+The in-app assistant works through `python/ai/chat_tools.py`.
+
+Current counts:
+
+- **47** built-in PARSE chat tools
+- **29** MCP-exposed tools via `python/adapters/mcp_adapter.py`
+
+This separation matters architecturally:
+
+- the browser assistant can use the broader tool surface
+- external MCP clients get a curated subset
+- the system stays bounded to PARSE-specific workflows rather than arbitrary shell access
+
+## Export architecture
+
+PARSE's export layer exists to carry reviewed annotation and comparative decisions into downstream analysis.
+
+Current export paths mentioned in the README and code include:
+
+- LingPy TSV
+- NEXUS
+- annotations CSV
+- ELAN XML
+- Praat TextGrid
+
+These exports are downstream products of the annotation + enrichment layers rather than independent sources of truth.
+
+## Design principles visible in the current architecture
+
+Several design principles recur across the current implementation:
+
+1. **Timestamps remain central** — PARSE is not a text-only annotation tool
+2. **Human review stays explicit** — automation ranks, pre-fills, or computes, but confirmation remains visible
+3. **Modes share one workspace** — Annotate and Compare are not disconnected applications
+4. **AI is task-routed** — different providers handle different kinds of work
+5. **Research outputs matter** — export is part of the architecture, not an afterthought
+
+## Related docs
+
+- Setup and runtime details: [Getting Started](./getting-started.md)
+- User workflow walkthrough: [User Guide](./user-guide.md)
+- Provider and tool surface details: [AI Integration](./ai-integration.md)
+- Extension points and project layout: [Developer Guide](./developer-guide.md)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,322 @@
+# Developer Guide
+
+> Last updated: 2026-04-24
+>
+> This guide is for contributors working on the active PARSE codebase: the React + Vite frontend in `src/`, the Python backend in `python/`, and the current workflow-specific documentation split under `docs/`.
+
+## Project summary
+
+PARSE is a browser-based dual-mode workstation for linguistic fieldwork and historical-comparative analysis.
+
+Current architectural highlights:
+
+- **Frontend**: React 18 + TypeScript + Vite
+- **Backend**: Python API server in `python/server.py`
+- **Modes**: Annotate (`/`) and Compare (`/compare`) in one unified shell
+- **Data**: per-speaker annotation JSON + `parse-enrichments.json`
+- **AI**: task-routed provider system for STT, ORTH, acoustic IPA, and chat
+- **Automation**: built-in chat tooling plus MCP server mode
+
+## Repository structure
+
+```text
+index.html              -- React/Vite entry HTML
+src/
+  App.tsx               -- BrowserRouter shell → <ParseUI />
+  ParseUI.tsx           -- Unified shell (Annotate + Compare + Tags + AI Chat)
+  api/
+    client.ts           -- Typed API client
+    types.ts            -- Shared TypeScript types
+  components/
+    annotate/           -- Annotate mode components
+    compare/            -- Compare mode components
+    shared/             -- Shared components
+  hooks/                -- React hooks
+  stores/               -- Zustand stores
+python/
+  server.py             -- Backend API server + built frontend serving
+  adapters/
+    mcp_adapter.py      -- MCP adapter
+  ai/
+    chat_tools.py       -- ParseChatTools (47 tools)
+    chat_orchestrator.py
+    stt_pipeline.py
+    forced_align.py
+    ipa_transcribe.py
+  compare/
+    providers/          -- CLEF provider registry and adapters
+  shared/               -- Shared Python utilities
+config/
+  ai_config.example.json -- tracked template
+  ai_config.json         -- machine-local config (gitignored)
+annotations/            -- runtime annotation JSON
+parse-enrichments.json  -- runtime comparative overlays
+desktop/                -- Electron shell scaffold
+docs/                   -- user, developer, research, and planning docs
+dist/                   -- build output
+```
+
+## Tech stack summary
+
+### Frontend
+
+- React 18
+- TypeScript
+- Vite
+- Zustand
+- Tailwind CSS v3
+- WaveSurfer 7
+- Lucide icons
+
+### Backend
+
+- Python 3.10–3.12
+- local HTTP server in `python/server.py`
+- background job orchestration for STT / normalize / compute / chat
+- JSON-file persistence for runtime state
+
+### AI / speech stack
+
+- faster-whisper
+- CTranslate2
+- Razhan (`razhan/whisper-base-sdh`)
+- Silero VAD
+- wav2vec2 (`facebook/wav2vec2-xlsr-53-espeak-cv-ft`)
+- OpenAI and xAI for workflow chat
+
+## Local development flow
+
+### Preferred launcher
+
+Use the tracked launcher from the repo root:
+
+```bash
+./scripts/parse-run.sh
+```
+
+This:
+
+- integrates latest code (unless skipped)
+- clears stale Python/Vite processes
+- starts the backend on `8766`
+- starts Vite on `5173`
+- prints the active URLs
+- preserves the current `parse-run.sh` launcher behavior, including port preflight checks and Windows-process cleanup when `PARSE_PY` points at a Windows `python.exe`
+
+### Manual launch
+
+If you need separate terminals:
+
+```bash
+cp config/ai_config.example.json config/ai_config.json
+
+# Terminal 1
+/path/to/python python/server.py
+
+# Terminal 2
+npm install
+npm run dev
+```
+
+### Built frontend path
+
+For non-dev/local-server usage:
+
+```bash
+npm run build
+/path/to/python python/server.py
+```
+
+The Python backend can then serve the built frontend from `http://localhost:8766/`.
+
+### Compute runtime modes and deployment notes
+
+The current backend runtime is not limited to one execution model.
+
+It supports:
+
+- `thread` mode — the default in-process path
+- `subprocess` mode — useful when isolating compute execution matters more than startup time
+- `persistent` mode — keeps the wav2vec2-heavy worker warm across jobs
+
+Relevant knobs and files:
+
+- `PARSE_COMPUTE_MODE` or `python python/server.py --compute-mode=...`
+- `PARSE_USE_PERSISTENT_WORKER=true` for the persistent-worker path
+- `GET /api/worker/status` for persistent-worker health checks
+- `deploy/pm2-ecosystem.config.cjs` for PM2-supervised deployments
+
+If you use PM2, keep `cwd` pointed at the **live workspace** rather than the bare git checkout so runtime artifacts land where the active UI expects them.
+
+## Workspace model
+
+PARSE can run directly in the repo, but the intended fieldwork architecture is workspace-first.
+
+When `PARSE_WORKSPACE_ROOT` is set:
+
+- runtime files land in that workspace
+- imports hydrate that workspace
+- the UI reflects the live workspace behind `/api/config`
+
+Contributors working on import, annotation, or automation features should always remember that the active project state may be outside the git checkout.
+
+## Frontend development rules that matter in practice
+
+The current PARSE architecture expects:
+
+- API traffic to go through `src/api/client.ts`
+- shared typed contracts to live in `src/api/types.ts`
+- data persistence to flow through the established stores and backend routes
+- the unified shell model to remain the organizing principle rather than splitting Annotate and Compare into isolated apps again
+
+For implementation-level architectural context, see [Architecture](./architecture.md).
+
+## Build and validation
+
+Before pushing PARSE changes, run the current project gates:
+
+```bash
+npm run test -- --run
+./node_modules/.bin/tsc --noEmit
+```
+
+These are the baseline TypeScript and test checks called out in the current PARSE instructions.
+
+Two additional realities are worth documenting explicitly:
+
+- the project is still in active development, so full browser regression and export verification should be treated as ongoing validation work rather than assumed completed release guarantees
+- schema compatibility between frontend and backend is enforced through `/api/config`; if that payload changes incompatibly, update the version constant in both `python/server.py` and `src/api/client.ts` in the same change
+
+For documentation-only work, you should still at minimum:
+
+- read back the changed Markdown files
+- confirm relative links
+- check `git diff` for unintended churn
+
+## Documentation layout after the restructure
+
+The top-level docs now serve distinct audiences more cleanly:
+
+- `docs/getting-started.md` — install, launch, config, troubleshooting
+- `docs/user-guide.md` — end-user workflow
+- `docs/ai-integration.md` — providers, models, chat tool surface
+- `docs/api-reference.md` — HTTP + MCP reference
+- `docs/architecture.md` — system design and data model
+- `docs/developer-guide.md` — contributor-facing implementation guide
+- `docs/research-context.md` — thesis and citation framing
+
+Existing planning and historical material remains available under the existing `docs/`, `docs/plans/`, and `docs/archive/` structure.
+
+## How to add a new HTTP endpoint
+
+When adding an endpoint, keep the client/server contract explicit.
+
+### 1. Add the server route
+
+Implement the route in `python/server.py` by wiring it into the relevant dispatch method:
+
+- `_dispatch_api_get`
+- `_dispatch_api_post`
+- `_dispatch_api_put`
+
+### 2. Add or update the typed client helper
+
+Expose the route from `src/api/client.ts`.
+
+This keeps the frontend on a single typed access layer instead of scattering raw `fetch()` calls.
+
+### 3. Update shared types if needed
+
+If the payload shape changes, update `src/api/types.ts` or the helper-local interfaces.
+
+### 4. Update the docs
+
+At minimum update:
+
+- `docs/api-reference.md`
+- `docs/architecture.md` if the new route changes the data model or workflow surface
+- the root `README.md` if the change is user-visible enough to belong on the landing page
+
+## How to add a new chat tool
+
+The built-in assistant works through `ParseChatTools` in `python/ai/chat_tools.py`.
+
+A new tool should follow this pattern:
+
+1. Add the new `ChatToolSpec` entry in `python/ai/chat_tools.py`
+2. Implement the execution path and validation logic in the same tool layer
+3. Decide whether the tool is:
+   - read-only / preview
+   - job-triggering
+   - alignment / correction
+   - tag-related
+   - write / export / merge
+4. Update `docs/ai-integration.md` to keep the 47-tool list current
+5. If the tool should also be exposed externally, add it to the MCP adapter and update `docs/api-reference.md`
+
+### Why this matters
+
+PARSE's AI layer is designed around **bounded workflow tools**, not arbitrary shell execution. New tools should preserve that design discipline.
+
+## How to expose a tool over MCP
+
+The MCP adapter lives in `python/adapters/mcp_adapter.py`.
+
+To expose a tool over MCP:
+
+1. Ensure the underlying functionality already exists in `ParseChatTools`
+2. Add a matching `@mcp.tool()` wrapper in `python/adapters/mcp_adapter.py`
+3. Keep parameter naming and documentation aligned with the underlying tool
+4. Re-check the exported-tool count and update docs if the MCP subset changed
+
+The adapter is intentionally a **curated subset** of the in-app tool surface. Not every chat tool should automatically become an MCP tool.
+
+## How to add or extend a CLEF provider
+
+CLEF providers live under `python/compare/providers/`.
+
+A provider change usually touches three layers:
+
+1. provider implementation / metadata under `python/compare/providers/`
+2. any server-side compute or coverage handling
+3. Compare-mode UI surfaces that consume the results
+
+When extending CLEF:
+
+- keep the provider registry explicit
+- document new coverage or source assumptions
+- update the provider list in user-facing docs if the provider set changes
+
+## Contributing guidelines
+
+### Keep claims aligned with code
+
+PARSE moves quickly. Documentation, API surface, and workflow details can drift unless they are updated together.
+
+A good rule:
+
+- if a feature changes the user workflow, update the relevant `docs/*.md`
+- if it changes the route/tool surface, update `docs/api-reference.md`
+- if it changes system shape, update `docs/architecture.md`
+- if it changes the first impression of the project, update `README.md`
+
+### Keep workflows explicit
+
+PARSE is a fieldwork/research tool. Contributors should prefer:
+
+- explicit job boundaries
+- visible status reporting
+- human-reviewable outputs
+- reproducible export paths
+
+### Preserve the workspace mindset
+
+Be careful with any change that assumes the repo itself is the live data root. In active PARSE usage, the workspace may be external and mutable while the repo remains a code checkout.
+
+## Related docs
+
+- Runtime setup: [Getting Started](./getting-started.md)
+- User workflow: [User Guide](./user-guide.md)
+- AI providers and tool surface: [AI Integration](./ai-integration.md)
+- System shape and data model: [Architecture](./architecture.md)
+- Thesis/citation framing: [Research Context](./research-context.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,401 @@
+# Getting Started
+
+> Last updated: 2026-04-24
+>
+> This guide reflects the current React + Vite frontend, the Python backend in `python/server.py`, and the launcher workflow documented in the latest `README.md` and tracked scripts.
+
+PARSE is a browser-based dual-mode research workstation for linguistic fieldwork and cross-speaker comparison. The fastest path is the tracked launcher script, which starts the Python API and the Vite frontend together and prints the working URLs.
+
+If you are new to the project, use this page in order:
+
+1. Check [requirements](#requirements)
+2. Run the [one-command launcher](#one-command-launch-recommended)
+3. Configure [`ai_config.json`](#configure-aiconfigjson)
+4. Review the [workspace-first setup](#workspace-first-bootstrap-recommended-on-a-fresh-machine)
+5. Use the [troubleshooting](#troubleshooting) section if startup or GPU inference fails
+
+## Requirements
+
+### Runtime expectations
+
+PARSE currently assumes:
+
+- **WSL / Linux shell tooling** for the default launcher workflow
+- **Node.js 18+** with `npm install` run once per clone
+- **Python 3.10–3.12** for the backend stack
+- A working Python environment with the PARSE dependencies installed
+- For thesis-scale speech work, a **CUDA-capable GPU** is the intended path for local STT, ORTH, and wav2vec2-based alignment
+
+### Recommended Python environment
+
+The current PARSE launcher supports two common cases:
+
+- **Linux/WSL-native Python** (`python3`)
+- **Windows `python.exe` from WSL**, typically a conda environment such as:
+
+```bash
+/mnt/c/Users/Lucas/anaconda3/envs/kurdish_asr/python.exe
+```
+
+This second setup matters because some local speech/model stacks may already be installed in a Windows-side conda environment.
+
+### Required repository-local setup
+
+Clone the repository and install frontend dependencies once per clone:
+
+```bash
+git clone https://github.com/ArdeleanLucas/PARSE.git
+cd PARSE
+npm install
+```
+
+## One-command launch (recommended)
+
+The tracked launcher script starts both servers, integrates the latest code, cleans up stale processes, checks API health, and prints the URLs you should open.
+
+```bash
+./scripts/parse-run.sh
+```
+
+On success, you should see output in this shape:
+
+```text
+[parse-run] ════════════════════════════════════════
+[parse-run]   PARSE is running
+[parse-run]   React UI:  http://localhost:5173/
+[parse-run]   Compare:   http://localhost:5173/compare
+[parse-run]   API:       http://localhost:8766/api/config
+[parse-run] ════════════════════════════════════════
+```
+
+Open:
+
+- **Annotate**: `http://localhost:5173/`
+- **Compare**: `http://localhost:5173/compare`
+
+### What `scripts/parse-run.sh` does
+
+The launcher is more than a simple two-process wrapper. It currently:
+
+1. Integrates the latest `origin/main` according to `PARSE_PULL_MODE` unless `PARSE_SKIP_PULL=1`
+2. Kills stale Python and Vite processes on both WSL and Windows sides
+3. Probes whether the API port is actually bindable before starting the backend
+4. Starts the Python API server (`python/server.py`) on `:8766`
+5. Waits for `/api/config` to return `200`
+6. Starts the Vite dev server on `:5173`
+7. Waits for Vite to respond, then prints the URLs
+
+Two helper commands are also part of the expected workflow:
+
+```bash
+scripts/parse-stop.sh   # kill both servers
+parse-logs api          # tail Python API stderr
+parse-logs vite         # tail Vite dev server output
+```
+
+## Workspace-first bootstrap (recommended on a fresh machine)
+
+For real fieldwork workspaces, PARSE is designed to keep generated runtime state outside the git checkout.
+
+Use the workspace initializer once:
+
+```bash
+# Scaffold a standalone workspace once
+scripts/parse-init-workspace.sh /path/to/parse-workspace
+
+# Then launch PARSE against that workspace
+PARSE_WORKSPACE_ROOT="/path/to/parse-workspace" \
+  PARSE_CHAT_MEMORY_PATH="/path/to/parse-workspace/parse-memory.md" \
+  PARSE_EXTERNAL_READ_ROOTS="/mnt/c/Users/Lucas/Thesis" \
+  ./scripts/parse-run.sh
+```
+
+This keeps original source WAV/CSV files untouched and lets PARSE copy selected files into the workspace instead of mutating an external source tree.
+
+### Why this matters
+
+The active frontend speaker list comes from the live workspace behind `/api/config`, not necessarily from the bare repo checkout. When `PARSE_WORKSPACE_ROOT` is set, runtime writes and imports must land in that workspace for the UI to reflect them.
+
+This is especially important for:
+
+- chat-assisted onboarding
+- processed-speaker imports
+- generated peaks and transcript caches
+- persistent chat memory
+- annotation and enrichment state during active fieldwork
+
+## Configure `ai_config.json`
+
+PARSE keeps machine-local AI configuration in `config/ai_config.json`, which is intentionally gitignored because it contains model paths, provider choices, and environment-specific settings.
+
+Start from the tracked template:
+
+```bash
+cp config/ai_config.example.json config/ai_config.json
+```
+
+Then edit the file for your machine.
+
+### Minimum configuration surface to review
+
+#### `stt`
+
+This controls the main speech-to-text provider.
+
+Current template defaults:
+
+```json
+"stt": {
+  "provider": "faster-whisper",
+  "model_path": "",
+  "language": "ku",
+  "device": "cuda",
+  "compute_type": "float16",
+  "beam_size": 5
+}
+```
+
+Important note: if `config/ai_config.json` is missing entirely, the backend can still start by falling back to built-in defaults, but STT falls back to a generic Whisper `base` model instead of a locally configured Razhan path.
+
+#### `ortho`
+
+This configures the orthographic transcription path. The tracked template documents **Razhan** as the canonical Southern Kurdish model:
+
+```json
+"ortho": {
+  "provider": "faster-whisper",
+  "model_path": "razhan/whisper-base-sdh",
+  "language": "sd",
+  "device": "cuda",
+  "compute_type": "float16",
+  "beam_size": 5,
+  "vad_filter": false,
+  "initial_prompt": "",
+  "refine_lexemes": false
+}
+```
+
+The template also explains two operational details worth preserving:
+
+- `vad_filter` defaults to **false** for ORTH so Razhan can cover the full waveform unless you deliberately retune VAD for your recordings.
+- `refine_lexemes=true` enables a short-clip Whisper pass after Tier 2 forced alignment, improving `tiers.ortho_words` at the cost of extra runtime.
+
+#### `ipa` and `wav2vec2`
+
+Tier 3 IPA is currently **acoustic wav2vec2-only**. The template is explicit that the older text-based IPA paths are gone.
+
+```json
+"ipa": {
+  "engine": "wav2vec2",
+  "model": "facebook/wav2vec2-xlsr-53-espeak-cv-ft",
+  "model_only": true
+},
+"wav2vec2": {
+  "provider": "wav2vec2-ipa",
+  "model": "facebook/wav2vec2-xlsr-53-espeak-cv-ft",
+  "device": "cuda",
+  "force_cpu": false,
+  "chunk_size": 150
+}
+```
+
+#### `llm` and `chat`
+
+These blocks control the in-app assistant provider and chat behavior:
+
+```json
+"llm": {
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "api_key_env": "OPENAI_API_KEY"
+},
+"chat": {
+  "enabled": true,
+  "read_only": false,
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "api_key_env": "OPENAI_API_KEY"
+}
+```
+
+Supported LLM/chat backends are currently **OpenAI** and **xAI (Grok)**.
+
+For the wider provider/model overview, see [AI Integration](./ai-integration.md).
+
+## Environment variables
+
+The launcher and MCP adapter both rely on a shared set of `PARSE_*` environment conventions.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PARSE_PY` | `python3` | Python interpreter for the backend. Can point to a Windows `python.exe` when launching from WSL. |
+| `PARSE_ROOT` | auto-detected | Repository root. |
+| `PARSE_WORKSPACE_ROOT` | `PARSE_ROOT` | Workspace/data root used by backend chat tools and runtime files. |
+| `PARSE_CHAT_DOCS_ROOT` | `PARSE_WORKSPACE_ROOT` | Optional docs/text root used by text-preview tooling. |
+| `PARSE_CHAT_MEMORY_PATH` | `PARSE_WORKSPACE_ROOT/parse-memory.md` | Persistent markdown memory file used by the chat assistant. |
+| `PARSE_EXTERNAL_READ_ROOTS` | empty | Absolute roots that chat tools may read outside the workspace. Use OS path separators for multiple roots, or `*` to disable the sandbox entirely. |
+| `PARSE_CHAT_READ_ONLY` | empty | Override chat mutability: `1` forces read-only, `0` forces write-enabled. Otherwise PARSE defers to `config/ai_config.json`. |
+| `PARSE_API_PORT` | `8766` | Python API server port. |
+| `PARSE_VITE_PORT` | `5173` | Vite dev server port. |
+| `PARSE_SKIP_PULL` | `0` | Skip the `git pull` step in `parse-run.sh`. |
+| `PARSE_PULL_MODE` | `auto` | Git integration strategy: `auto`, `ff`, `rebase`, or `reset`. |
+| `PARSE_USE_PERSISTENT_WORKER` | empty | Enable the persistent compute worker path so wav2vec2 can stay warm across jobs. |
+| `PARSE_COMPUTE_MODE` | empty | Explicit compute launcher mode such as `thread`, `subprocess`, or `persistent`. |
+
+### `.parse-env` for machine-local overrides
+
+For persistent machine-local settings, create a gitignored `.parse-env` file at the repo root.
+
+Example:
+
+```bash
+PARSE_EXTERNAL_READ_ROOTS=/mnt/c/Users/Lucas/Thesis
+PARSE_PY=/mnt/c/Users/Lucas/miniconda3/python.exe
+PARSE_CHAT_MEMORY_PATH=/path/to/parse-memory.md
+```
+
+The launcher reads this file before applying defaults. The standalone MCP adapter mirrors the same convention.
+
+## Manual launch (alternative)
+
+If you prefer to start each server yourself:
+
+```bash
+# One-time per clone
+cp config/ai_config.example.json config/ai_config.json
+
+# Terminal 1 — Python API backend
+cd /path/to/parse
+/path/to/anaconda3/envs/kurdish_asr/python.exe python/server.py
+
+# Terminal 2 — Vite frontend
+cd /path/to/parse
+npm install   # once per clone
+npm run dev
+```
+
+The backend runs on `8766`; Vite runs on `5173`.
+
+## Open in browser
+
+### Active development workflow
+
+- Annotate mode: `http://localhost:5173/`
+- Compare mode: `http://localhost:5173/compare`
+
+### Python-served built frontend
+
+After `npm run build`, the Python backend can serve the built UI at:
+
+- Annotate mode: `http://localhost:8766/`
+- Compare mode: `http://localhost:8766/compare`
+
+## GPU and model notes
+
+The current PARSE model stack documented in the repo centers on these components:
+
+- **faster-whisper** — local STT / ORTH inference backend
+- **CTranslate2** — optimized runtime for Whisper-family models
+- **Razhan** (`razhan/whisper-base-sdh`) — Southern Kurdish orthographic transcription
+- **Silero VAD** — segmentation for long recordings in Whisper-style decoding
+- **wav2vec2** (`facebook/wav2vec2-xlsr-53-espeak-cv-ft`) — Tier 2 forced alignment and Tier 3 acoustic IPA
+
+Operationally:
+
+- The tracked config template defaults to **`device: "cuda"`** and **`compute_type: "float16"`**
+- The intended research workflow is GPU-backed local inference
+- The faster-whisper path includes explicit CUDA-runtime detection plus a CPU/int8 fallback if the local CUDA stack is unavailable
+- `PARSE_STT_FORCE_CPU=1` is available as an emergency override when a WSL/driver stack is unstable and you need STT / ORTH to stay on CPU deliberately
+- Tier 3 IPA is no longer text-based; it depends on the wav2vec2 acoustic path
+- On WSL, the aligner now resolves to **CPU by default** for long wav2vec2 CTC workloads; the `wav2vec2.force_cpu` and `wav2vec2.chunk_size` settings in `config/ai_config.json` are the main tuning knobs for that path
+
+### Runtime and deployment modes
+
+The current backend runtime has a few operational features that are easy to miss if you only use the default launcher:
+
+- the HTTP server runs behind a **bounded 4-worker request pool** rather than one ad-hoc OS thread per request
+- compute jobs support three launcher modes:
+  - `thread` — default in-process mode
+  - `subprocess` — opt-in subprocess mode
+  - `persistent` — preloads wav2vec2 once and reuses it across compute jobs
+- `GET /api/worker/status` is the health endpoint for persistent-worker deployments
+- if you supervise the backend with PM2, the tracked file is `deploy/pm2-ecosystem.config.cjs`, and `cwd` should point at the **live workspace**, not just the git checkout
+- the PM2 config also documents WSL safety defaults such as `PARSE_STT_FORCE_CPU=1` and `CUDA_VISIBLE_DEVICES=""` for all-CPU fallback operation on unstable GPU stacks
+
+For provider-specific details, see [AI Integration](./ai-integration.md).
+
+## Troubleshooting
+
+### `config/ai_config.json` is missing
+
+Symptom:
+
+- PARSE starts, but local STT does not use your intended model path
+
+Fix:
+
+```bash
+cp config/ai_config.example.json config/ai_config.json
+```
+
+Then edit at least the `stt`, `ortho`, `llm`, `chat`, and `wav2vec2` blocks for your machine.
+
+### `parse-run.sh` reports that it cannot bind `127.0.0.1:8766`
+
+If the error mentions **`WinError 10013`** or **`10048`**, this is usually a Windows/WSL phantom port reservation.
+
+Fix:
+
+1. Run `wsl --shutdown` from Windows Command Prompt or PowerShell
+2. Relaunch PARSE
+3. If needed, temporarily override the port with `PARSE_API_PORT=<other>`
+
+### WSL cannot kill a stale Windows-side `python.exe`
+
+This happens when `PARSE_PY` points to a Windows conda environment. In that case, the real process is running on the Windows side, not inside WSL.
+
+Current launcher behavior:
+
+- detects the Windows-path case
+- calls `taskkill.exe` via `/mnt/c/Windows/System32/`
+- clears stale `python.exe` processes that still hold the API port
+
+### The UI loads, but the workspace appears empty
+
+One current config contract is worth knowing:
+
+- `/api/config` responses carry `schema_version: 1`
+- the React client validates that schema version at boot
+- a mismatch surfaces as a banner rather than silently rendering an empty workspace
+
+If you see a schema mismatch or outdated-server message, restart the Python backend with the latest code and reload the page.
+
+### STT or ORTH coverage looks partial
+
+PARSE distinguishes **"tier has intervals"** from **"the full WAV has been processed"**.
+
+When reviewing pipeline state, prefer the coverage-aware fields:
+
+- `duration_sec`
+- `coverage_start_sec`
+- `coverage_end_sec`
+- `coverage_fraction`
+- `full_coverage`
+
+This matters when old runs only covered a stale timestamp window rather than the entire recording.
+
+### Need logs during a launch failure
+
+Use the helper aliases/scripts documented in the launcher workflow:
+
+```bash
+parse-logs api
+parse-logs vite
+scripts/parse-stop.sh
+```
+
+## Where to go next
+
+- New user doing annotation work: [User Guide](./user-guide.md)
+- Configuring models, chat providers, or tool surfaces: [AI Integration](./ai-integration.md)
+- Extending the project itself: [Developer Guide](./developer-guide.md)

--- a/docs/research-context.md
+++ b/docs/research-context.md
@@ -1,0 +1,191 @@
+# Research Context & Citation
+
+> Last updated: 2026-04-24
+>
+> This page frames PARSE as research software: why it exists, what scholarly workflow it supports, and how to cite it responsibly.
+
+## What research problem PARSE was built for
+
+PARSE was developed for a **Southern Kurdish dialect phylogenetics thesis** at the **University of Bamberg**.
+
+The current repository README describes the target workflow as one involving:
+
+- long field recordings
+- concept-based wordlists
+- multi-speaker datasets
+- iterative transcription and timing correction
+- cross-speaker cognate review
+- borrowing adjudication
+- export into downstream comparative / phylogenetic pipelines
+
+In other words, PARSE is not just an annotation UI. It is an attempt to keep the entire path from raw or processed field recordings to comparative export-ready datasets inside one research workstation.
+
+## Research motivation
+
+The underlying motivation is practical and methodological.
+
+### 1. Long recordings are hard to annotate consistently
+
+Elicitation sessions may run for hours. Target lexical items are often embedded inside prompts, repetitions, repairs, and commentary. Even when a recording has already been partially processed, locating the exact lexical spans again can still be slow.
+
+### 2. Annotation and comparison are usually fragmented across tools
+
+Traditional workflows often split:
+
+- waveform review
+- transcription
+- speaker-specific annotation
+- comparative review
+- borrowing analysis
+- export preparation
+
+across separate applications and ad hoc scripts.
+
+PARSE's dual-mode architecture is explicitly designed to reduce that fragmentation.
+
+### 3. Historical-comparative work needs reviewed structure, not just transcripts
+
+The thesis use case is not satisfied by speech-to-text alone. It needs:
+
+- trustworthy timestamps
+- explicit segment review
+- cross-speaker concept alignment
+- cognate grouping decisions
+- borrowing-aware comparison
+- export formats that downstream tools can use
+
+That is why PARSE combines Annotate mode, Compare mode, CLEF, and export tooling inside one system.
+
+## Current research framing of the project
+
+The current README positions PARSE as:
+
+- **browser-based**
+- **dual-mode**
+- **fieldwork-first**
+- **AI-assisted**
+- **research software rather than production software**
+
+That framing is important. PARSE is still in active development, and thesis-critical features are landing quickly. Anyone using it in research should therefore document the specific version, provider configuration, and export path used in a given analysis.
+
+## Where PARSE fits in the workflow
+
+At a high level, PARSE bridges these stages:
+
+```text
+Field recordings / processed speaker artifacts
+        ↓
+Per-speaker annotation and timing review
+        ↓
+Cross-speaker comparison and cognate adjudication
+        ↓
+Borrowing-oriented contact evidence via CLEF
+        ↓
+LingPy TSV / NEXUS export
+        ↓
+Downstream comparative and phylogenetic analysis
+```
+
+The current README specifically mentions downstream use with:
+
+- **LingPy**
+- **LexStat**
+- **BEAST 2**
+
+## Related software and external components
+
+PARSE sits in an ecosystem of existing libraries, models, and downstream tools.
+
+The current README explicitly calls out these as major external components materially shaping PARSE's runtime behavior or outputs:
+
+- `razhan/whisper-base-sdh`
+- `facebook/wav2vec2-xlsr-53-espeak-cv-ft`
+- Silero VAD
+- faster-whisper
+- CTranslate2
+- WaveSurfer.js
+- React
+- Vite
+- Tailwind CSS
+- Lucide
+
+These are not "related work" in the sense of a full literature review, but they are the primary technical dependencies and adjacent toolchain pieces the repository itself foregrounds.
+
+For the full dependency/citation table, see [AI Integration](./ai-integration.md).
+
+## Citation instructions
+
+### Repository citation
+
+If you use PARSE in academic work, cite it as **research software**.
+
+The repository includes a machine-readable [`CITATION.cff`](../CITATION.cff) file, and GitHub's **Cite this repository** button will generate standard citation formats automatically.
+
+The current README gives this suggested citation:
+
+> Ardelean, L. M. (2026). *PARSE: Phonetic Analysis & Review Source Explorer* [Computer software]. University of Bamberg. https://github.com/ArdeleanLucas/PARSE
+
+### BibTeX
+
+```bibtex
+@software{ardelean_parse_2026,
+  author  = {Ardelean, Lucas M.},
+  title   = {{PARSE}: Phonetic Analysis \& Review Source Explorer},
+  year    = {2026},
+  url     = {https://github.com/ArdeleanLucas/PARSE},
+  note    = {Research software for Southern Kurdish dialect phylogenetics}
+}
+```
+
+### CITATION.cff summary
+
+The current `CITATION.cff` describes PARSE as:
+
+- software
+- authored by **Lucas M. Ardelean**
+- licensed under **MIT**
+- focused on computational linguistics, phonetics, annotation, cognate detection, phylogenetics, Southern Kurdish, fieldwork, and speech-to-text
+
+It also includes an abstract summarizing PARSE as a browser-based dual-mode research workstation combining waveform review, tiered annotation, AI-assisted STT, cognate adjudication, and CLEF.
+
+## What else should be cited in a serious methods section?
+
+The current README makes a useful methodological point: the major external models and repositories that materially shape PARSE output should also be cited or acknowledged when they are used in a given run.
+
+In practice that means documenting:
+
+- the PARSE version / commit
+- the configured STT / ORTH / chat providers
+- any local or remote models used (for example Razhan, wav2vec2, Whisper-family backends)
+- any contact-language evidence sources materially used in CLEF
+- the downstream export target and later analysis environment
+
+If proprietary API services such as OpenAI or xAI are enabled, they should be acknowledged in methods sections as services used in the workflow, even though they are not source repositories in the same way as the open-weight models and libraries listed in the README.
+
+## Thesis context
+
+The README currently states that the working dataset covers multiple speakers of Southern Kurdish varieties with an **85-item Oxford Iranian wordlist**, targeting downstream Bayesian phylogenetic analysis in **BEAST 2**.
+
+That context matters because it explains several design choices in PARSE:
+
+- concept-based organization rather than free-form transcript-first design
+- strong emphasis on timestamps and repeated lexical items
+- comparative review as a first-class mode
+- borrowing adjudication via contact-language evidence
+- export pathways tailored to later comparative analysis
+
+## Recommended citation practice
+
+When publishing work that used PARSE, the most defensible citation bundle is:
+
+1. **Cite PARSE itself** via [`CITATION.cff`](../CITATION.cff)
+2. **Cite the associated thesis** once publicly available
+3. **Acknowledge major enabled models/providers** used in the actual workflow
+4. **Document export and downstream analysis tools** used after PARSE
+
+## Related docs
+
+- Project landing page: [README](../README.md)
+- Setup and configuration: [Getting Started](./getting-started.md)
+- Models, providers, and tool surface: [AI Integration](./ai-integration.md)
+- System design and data model: [Architecture](./architecture.md)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,319 @@
+# User Guide
+
+> Last updated: 2026-04-24
+>
+> This guide focuses on the current PARSE workstation as described in the latest repository README: the unified React shell, Annotate route `/`, Compare route `/compare`, CLEF, the AI chat dock, and processed-speaker workspace hydration.
+
+PARSE is organized around two tightly linked research modes:
+
+- **Annotate** — per-speaker segmentation, transcription, timing correction, and anchor confirmation
+- **Compare** — cross-speaker lexical comparison, cognate adjudication, borrowing review, and export preparation
+
+The same workspace, tag system, and backend data model support both.
+
+<!-- TODO: Add an Annotate-mode screenshot here: waveform, tiers, transcription lanes, and chat dock visible together. -->
+<!-- TODO: Add a Compare-mode screenshot here: concept × speaker matrix, cognate controls, and CLEF panel. -->
+
+## Workflow at a glance
+
+A typical PARSE session moves through these stages:
+
+1. Import or hydrate a speaker into the active workspace
+2. Normalize the audio if needed
+3. Run STT, ORTH, and acoustic IPA support jobs
+4. Review and correct boundaries in Annotate mode
+5. Use **Search & anchor lexeme** when concept locations are difficult to find
+6. Switch to Compare mode for cross-speaker adjudication
+7. Consult **CLEF** when borrowing or contact influence is in question
+8. Export LingPy TSV or NEXUS for downstream analysis
+
+## Annotate Mode (`/`)
+
+Annotate mode is the per-speaker workstation for turning long recordings into time-aligned annotation data.
+
+### What you see in Annotate mode
+
+The current Annotate surface includes:
+
+- **WaveSurfer 7 waveform review** for long recordings
+- **Four annotation tiers**:
+  - IPA
+  - orthography
+  - concept
+  - speaker
+- **Stacked transcription lanes** under the waveform for:
+  - STT
+  - IPA
+  - ORTH
+- **Synchronized horizontal scrolling** between waveform and lanes
+- **Clip-bounded playback** for the selected region
+- A global **Space** play/pause hotkey
+- Concept display and sorting controls
+- Tag/filter controls for selective review
+- The shared **AI chat dock**
+
+### Annotate jobs and automation
+
+PARSE's annotation workflow is designed around explicit, inspectable support jobs rather than opaque one-click automation.
+
+#### Audio normalization
+
+Normalization runs through `/api/normalize` and supports in-place working-audio generation.
+
+Use it when:
+
+- source levels are inconsistent
+- the recording needs a stable working copy for later STT/alignment
+- you want the workspace to reflect a reproducible audio-prep stage
+
+#### STT
+
+The speaker-level STT job (`/api/stt`) provides:
+
+- progress and error reporting
+- automatic language detection from project metadata when available
+- tunable task / VAD / beam-size settings through config
+- nested word-level timestamps in `segments[].words[]`
+
+This is the main starting point for locating lexical material in long recordings.
+
+#### ORTH
+
+The speaker-level ORTH job (`computeType='ortho'`) is backed by **Razhan** (`razhan/whisper-base-sdh`) for full-waveform Kurdish orthographic transcription.
+
+The current defaults keep VAD off so the whole recording is covered unless you deliberately retune it.
+
+#### Forced alignment
+
+Tier 2 forced alignment uses `torchaudio.functional.forced_align` against wav2vec2 to tighten word windows and optionally emit phoneme spans.
+
+This is the step that turns coarse word timing into more reviewable alignment.
+
+#### Acoustic IPA fill
+
+The current IPA path is **acoustic wav2vec2-only**.
+
+When word-level STT cache is available, `computeType='ipa_only'` uses the full forced-alignment path word by word. If that cache is missing, PARSE falls back to coarse ORTH-interval slices.
+
+### Batch transcription workflow
+
+Annotate mode also supports a batch runner for one or many speakers.
+
+The current batch flow includes:
+
+- preflight pipeline-state checks
+- overwrite warnings
+- explicit ordered steps: **normalize → STT → ORTH → IPA**
+- step-level failure isolation
+- rerun-failed support
+- a walk-away batch report with expandable tracebacks
+- explicit **empty-step detection** for runs that technically completed but wrote no intervals
+- skip-breakdown counters and exception samples for steps that ran but still produced no usable output
+
+A key detail is that preflight distinguishes **"has intervals"** from **"full WAV coverage"** via fields such as:
+
+- `duration_sec`
+- `coverage_start_sec`
+- `coverage_end_sec`
+- `coverage_fraction`
+- `full_coverage`
+
+That distinction matters in real fieldwork, where older runs may have seeded a tier without truly covering the full recording.
+
+### Manual review and timing correction
+
+Automation in PARSE is intentionally review-first.
+
+Annotate mode supports:
+
+- draggable lexeme timestamp editing
+- manual boundary correction
+- constant timestamp-offset detect/apply workflows for CSV↔audio misalignment
+- manual fallback from a trusted single pair when automated offset detection is weak
+
+This is one of the main places where PARSE differs from purely transcription-first tools: timestamps are not treated as disposable by-products.
+
+## Lexical Anchor Alignment System
+
+The **Lexical Anchor Alignment System** is one of PARSE's core research features.
+
+It exists because elicitation recordings are often long, noisy, and full of repeated prompts, commentary, and repairs. Manually scanning hours of audio to find each target concept across many speakers is too slow and too inconsistent.
+
+### The two signals
+
+PARSE combines two signals to rank candidate time ranges.
+
+#### Signal A — within-speaker repetition detection
+
+Elicited items are often produced two to four times in close succession. PARSE looks for phonetically similar clusters within a 30-second window and scores them using normalized Levenshtein distance on IPA strings.
+
+#### Signal B — cross-speaker concept matching
+
+PARSE compares unassigned segments against verified annotations from other speakers for the same concept using a four-strategy cascade:
+
+- exact orthographic
+- fuzzy orthographic
+- phonetic rule-based
+- positional prior
+
+The phonetic-rule layer is designed to tolerate documented Southern Kurdish alternations such as onset voicing, nucleus variation, and coda deletion.
+
+### Confidence model
+
+The current README documents the following scoring formula:
+
+```text
+confidence = 0.50 × phonetic + 0.25 × repetition + 0.15 × positional + 0.10 × cluster
+```
+
+The positional component uses a 45-second tolerance window derived from the cross-speaker median for each concept.
+
+### User-facing control: Search & anchor lexeme
+
+Annotate mode exposes this system directly as **Search & anchor lexeme**.
+
+You provide known orthographic variants of a target form, and PARSE ranks candidate time ranges across the available tiers:
+
+- `ortho_words`
+- `ortho`
+- `stt`
+- `ipa`
+
+The endpoint behind this feature is `GET /api/lexeme/search`.
+
+Current ranking combines:
+
+- within-speaker phonetic similarity
+- any available `ortho_words` confidence weighting
+- cross-speaker anchor evidence for the same `concept_id`
+- contact-language variant augmentation from `config/sil_contact_languages.json`
+
+When you choose **Confirm & Use**, PARSE writes the chosen candidate into `AnnotationRecord.confirmed_anchors[concept_id]`. Those confirmations survive Praat/TextGrid round-trips and improve the cross-speaker signal for later speakers. The Annotate control bar also exposes a numeric playhead readout (`m:ss.sss / m:ss.sss`), which makes anchor confirmation less dependent on eyeballing the waveform alone.
+
+## Compare Mode (`/compare`)
+
+Compare mode is the cross-speaker analysis workspace for historical and comparative work.
+
+### What you see in Compare mode
+
+The current Compare interface provides:
+
+- a **concept × speaker matrix** for side-by-side lexical review
+- **cognate controls** for accept, split, merge, and cycle
+- per-row cognate-group editing
+- speaker flags and secondary-action controls
+- borrowing adjudication aided by contact-language similarity signals
+- enrichment overlays for computed analysis metadata
+- the **CLEF** panel
+- the shared tag system
+- export actions for LingPy TSV and NEXUS
+
+### Cognate review workflow
+
+Compare mode is where annotation data becomes comparative data.
+
+Typical use:
+
+1. Open a concept row across speakers
+2. Review the forms side by side
+3. Accept, split, merge, or cycle cognate groups
+4. Mark speaker-level irregularities or flags where needed
+5. Consult enrichment overlays and contact-language evidence
+6. Preserve manual adjudications for export
+
+The goal is not just visualization — it is structured decision-making for downstream comparative analysis.
+
+## CLEF — Contact Lexeme Explorer Feature
+
+**CLEF** provides contact-language similarity data for borrowing adjudication.
+
+It is implemented as a provider-registry workflow under `python/compare/providers/` and surfaced in the `ContactLexemePanel` UI.
+
+### What CLEF does in practice
+
+When a lexical item might reflect contact influence rather than straightforward inheritance, CLEF can fetch comparison data from multiple external and local sources, then surface that evidence during Compare-mode review.
+
+### Current provider set (10)
+
+| Provider | Source type |
+|---|---|
+| `asjp` | ASJP database |
+| `cldf` | CLDF datasets |
+| `csv_override` | Local CSV overrides |
+| `grokipedia` | LLM-assisted lookup (xAI/Grok) |
+| `lingpy_wordlist` | LingPy wordlist data |
+| `literature` | Published literature references |
+| `pycldf_provider` | `pycldf` library |
+| `pylexibank_provider` | `pylexibank` library |
+| `wikidata` | Wikidata lexemes |
+| `wiktionary` | Wiktionary entries |
+
+### Current CLEF endpoints
+
+- `POST /api/compute/contact-lexemes` — start a contact-lexeme fetch job
+- `GET /api/contact-lexemes/coverage` — inspect current provider coverage
+
+## AI Workflow Assistant in daily use
+
+Both Annotate and Compare include the built-in AI chat dock.
+
+In user-facing terms, it can currently help with:
+
+### Audio setup and file management
+
+- locating and loading `.wav` sources
+- checking audio health
+- guiding normalization
+
+### Annotation workflow
+
+- walking through the four tiers
+- launching STT to locate candidate segments
+- assisting with boundary correction and iterative review
+
+### Cross-speaker analysis
+
+- preparing Compare mode sessions
+- explaining cognate controls
+- helping interpret borrowing and enrichment evidence
+
+### Export and downstream work
+
+- guiding LingPy TSV export
+- explaining export structure for later pipelines
+
+### Troubleshooting
+
+- diagnosing STT, IPA, normalization, and pipeline failures
+- identifying missing files, metadata mismatches, or annotation gaps
+- explaining server-log errors in workflow terms
+
+The in-app assistant has read and write access to the project through its bounded PARSE tool layer, so it can stage workflow actions rather than only answering questions.
+
+## Speaker import and workspace hydration
+
+Recent PARSE work expanded the project beyond raw upload-only onboarding.
+
+The current workstation and MCP adapter support **processed-speaker imports**, meaning a speaker can be hydrated into the active workspace from an existing artifact set rather than from a fresh raw upload alone.
+
+Supported source artifacts currently include:
+
+- a working WAV under `audio/working/<Speaker>/`
+- `annotations/<Speaker>.json` or `annotations/<Speaker>.parse.json`
+- `peaks/<Speaker>.json`
+- optional `coarse_transcripts/<Speaker>.json`
+- optional legacy transcript CSV under `imports/legacy/<Speaker>/`
+
+This matters for thesis workflows where the richest aligned source is an already processed speaker package, not a brand-new pipeline run.
+
+## Recommended user path
+
+If you are starting from scratch:
+
+1. Read [Getting Started](./getting-started.md)
+2. Launch PARSE and configure `ai_config.json`
+3. Import or hydrate one speaker
+4. Work through Annotate mode until timestamps are trustworthy
+5. Move to Compare mode for cognate and borrowing decisions
+6. Use [AI Integration](./ai-integration.md) when configuring providers or the built-in assistant
+7. Use [API Reference](./api-reference.md) if you are automating any part of the workflow


### PR DESCRIPTION
## Summary
- replace the oversized root README with a shorter landing-page version
- split technical depth into focused docs pages for getting started, user workflow, AI integration, API surface, architecture, developer guidance, and research context
- preserve the current PARSE feature/tooling surface while making GitHub navigation much easier

## What changed
- rewrote `README.md` as a high-signal landing page with links into the docs set
- added `docs/getting-started.md`
- added `docs/user-guide.md`
- added `docs/ai-integration.md`
- added `docs/api-reference.md`
- added `docs/architecture.md`
- added `docs/developer-guide.md`
- added `docs/research-context.md`
- preserved existing planning/history docs under the current `docs/`, `docs/plans/`, and `docs/archive/` layout

## Validation
- relative-link check across all new markdown files: passed
- `npm run test -- --run`: 36 files, 222 tests passed
- `./node_modules/.bin/tsc --noEmit`: passed

## Notes
- kept active-development caveats visible in the README and developer docs
- documented the `/api/config` schema-version maintenance rule in the API/developer docs
