### PR TITLE
feat: richer MCP safety metadata for dangerous mutators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,22 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
 - Default MCP surface is **30 tools**: the legacy 29 `ParseChatTools` wrappers plus read-only `mcp_get_exposure_mode` for self-inspection.
 - Enabling `expose_all_tools` expands the MCP surface to **48 tools**: all 47 `ParseChatTools` plus `mcp_get_exposure_mode`.
 - For backward compatibility, root-level `mcp_config.json` is also accepted when `config/mcp_config.json` is absent.
+- `ChatToolSpec` is the MCP metadata source of truth. MCP tools should forward the strict schema from `spec.parameters`, standard MCP annotations from `spec.mcp_annotations_payload()`, and PARSE-specific safety metadata from `meta["x-parse"] = spec.mcp_meta_payload()`.
+- Mutability meanings:
+  - `read_only` — inspection only; no writes or background jobs
+  - `stateful_job` — starts or manages a background job that can later mutate project artifacts
+  - `mutating` — can write files or otherwise change project state directly
+- Agent-facing safety reasoning should read `meta["x-parse"]["preconditions"]` / `postconditions` instead of guessing from prose. Example:
+
+```python
+x_parse = tool.meta["x-parse"]
+if any(cond["id"] == "project_loaded" for cond in x_parse["preconditions"]):
+    # Load / verify project context before calling the tool.
+    ...
+if x_parse["supports_dry_run"]:
+    # Prefer a preview call before a mutating call.
+    ...
+```
 
 ## Client/Server Contract Surface
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -81,9 +81,11 @@ from ai.chat_tools import DEFAULT_MCP_TOOL_NAMES
 _MCP_AVAILABLE = False
 try:
     from mcp.server.fastmcp import FastMCP
+    from mcp.types import ToolAnnotations
     _MCP_AVAILABLE = True
 except ImportError:
     FastMCP = None  # type: ignore[assignment,misc]
+    ToolAnnotations = None  # type: ignore[assignment,misc]
 
 
 # ---------------------------------------------------------------------------
@@ -745,6 +747,17 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
     def _json_tool_result(tool_name: str, args: Dict[str, Any]) -> str:
         result = tools.execute(tool_name, args)
         return json.dumps(result, indent=2, ensure_ascii=False)
+
+    def _sync_registered_tool_metadata(tool_name: str) -> None:
+        spec = tools.tool_spec(tool_name)
+        registered = mcp._tool_manager._tools.get(tool_name)
+        if registered is None:
+            return
+        registered.description = spec.description
+        registered.parameters = json.loads(json.dumps(spec.parameters))
+        annotation_payload = spec.mcp_annotations_payload()
+        registered.annotations = ToolAnnotations(**annotation_payload) if ToolAnnotations is not None else None
+        registered.meta = {"x-parse": spec.mcp_meta_payload()}
 
     @mcp.tool(name="mcp_get_exposure_mode")
     def mcp_get_exposure_mode() -> str:
@@ -1509,6 +1522,7 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         steps: list,
         overwrites: Optional[dict] = None,
         language: Optional[str] = None,
+        dryRun: Optional[bool] = None,
     ) -> str:
         """Start a transcription pipeline for ONE speaker. Returns jobId.
 
@@ -1531,12 +1545,15 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             steps: Subset of ["normalize", "stt", "ortho", "ipa"].
             overwrites: Per-step overwrite flags (default: all false).
             language: Optional language override for STT + ORTH.
+            dryRun: If true, preview the full_pipeline payload without starting a job.
         """
         args: Dict[str, Any] = {"speaker": speaker, "steps": steps}
         if overwrites is not None:
             args["overwrites"] = overwrites
         if language is not None:
             args["language"] = language
+        if dryRun is not None:
+            args["dryRun"] = dryRun
         result = tools.execute("pipeline_run", args)
         return json.dumps(result, indent=2, ensure_ascii=False)
 
@@ -1584,11 +1601,17 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             return _json_tool_result("enrichments_read", args)
         mcp.tool(name="enrichments_read")(mcp_enrichments_read)
 
-        def mcp_enrichments_write(enrichments: Dict[str, Any], merge: Optional[bool] = None) -> str:
+        def mcp_enrichments_write(
+            enrichments: Dict[str, Any],
+            merge: Optional[bool] = None,
+            dryRun: Optional[bool] = None,
+        ) -> str:
             """Write or merge enrichments into parse-enrichments.json."""
             args: Dict[str, Any] = {"enrichments": enrichments}
             if merge is not None:
                 args["merge"] = merge
+            if dryRun is not None:
+                args["dryRun"] = dryRun
             return _json_tool_result("enrichments_write", args)
         mcp.tool(name="enrichments_write")(mcp_enrichments_write)
 
@@ -1677,6 +1700,7 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             userNote: Optional[str] = None,
             importNote: Optional[str] = None,
             delete: Optional[bool] = None,
+            dryRun: Optional[bool] = None,
         ) -> str:
             """Write or delete one lexeme note entry."""
             args: Dict[str, Any] = {"speaker": speaker, "conceptId": conceptId}
@@ -1686,6 +1710,8 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
                 args["importNote"] = importNote
             if delete is not None:
                 args["delete"] = delete
+            if dryRun is not None:
+                args["dryRun"] = dryRun
             return _json_tool_result("lexeme_notes_write", args)
         mcp.tool(name="lexeme_notes_write")(mcp_lexeme_notes_write)
 
@@ -1794,6 +1820,9 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
                 args["dryRun"] = dryRun
             return _json_tool_result("transcript_reformat", args)
         mcp.tool(name="transcript_reformat")(mcp_transcript_reformat)
+
+    for tool_name in selected_mcp_tool_names:
+        _sync_registered_tool_metadata(tool_name)
 
     logger.info(
         "MCP exposing %s tools (expose_all_tools=%s)",

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -335,8 +335,23 @@ def test_mcp_forwards_annotations_meta_and_strict_schema_for_dangerous_mutator(t
     assert enrichments_write.annotations.destructiveHint is True
     assert enrichments_write.annotations.readOnlyHint is False
     assert enrichments_write.meta["x-parse"]["mutability"] == "mutating"
-    assert enrichments_write.meta["x-parse"]["supportsDryRun"] is True
+    assert enrichments_write.meta["x-parse"]["supports_dry_run"] is True
+    assert enrichments_write.meta["x-parse"]["dry_run_parameter"] == "dryRun"
     assert any(
         cond["id"] == "project_loaded"
         for cond in enrichments_write.meta["x-parse"]["preconditions"]
     )
+
+
+def test_can_list_tools_requiring_project_loaded(tmp_path) -> None:
+    tools = ParseChatTools(project_root=tmp_path)
+
+    requiring_project = {
+        spec.name
+        for spec in tools.iter_tool_specs()
+        if any(cond.id == "project_loaded" for cond in spec.preconditions)
+    }
+
+    assert "enrichments_write" in requiring_project
+    assert "pipeline_run" in requiring_project
+    assert "project_context_read" not in requiring_project

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -247,3 +247,96 @@ def test_no_duplicate_tool_specs_or_handlers() -> None:
         handler_count = len(re.findall(r"^\s*def _tool_{0}\s*\(".format(re.escape(tool)), text, re.MULTILINE))
         assert spec_count == 1, "{0} has {1} ChatToolSpec entries".format(tool, spec_count)
         assert handler_count == 1, "{0} has {1} handlers".format(tool, handler_count)
+
+
+def test_first_batch_mutators_publish_machine_readable_safety_metadata(tmp_path) -> None:
+    tools = ParseChatTools(project_root=tmp_path)
+
+    expected = {
+        "enrichments_write": {
+            "dry_run": True,
+            "postcondition": "enrichments_file_updated",
+        },
+        "lexeme_notes_write": {
+            "dry_run": True,
+            "postcondition": "lexeme_note_written",
+        },
+        "apply_timestamp_offset": {
+            "dry_run": True,
+            "postcondition": "annotation_timestamps_shifted",
+        },
+        "pipeline_run": {
+            "dry_run": True,
+            "postcondition": "pipeline_job_started",
+        },
+        "onboard_speaker_import": {
+            "dry_run": True,
+            "postcondition": "speaker_source_registered",
+        },
+        "import_processed_speaker": {
+            "dry_run": True,
+            "postcondition": "processed_speaker_imported",
+        },
+        "export_annotations_csv": {
+            "dry_run": True,
+            "postcondition": "export_file_written",
+        },
+        "export_annotations_elan": {
+            "dry_run": True,
+            "postcondition": "export_file_written",
+        },
+        "export_annotations_textgrid": {
+            "dry_run": True,
+            "postcondition": "export_file_written",
+        },
+        "export_lingpy_tsv": {
+            "dry_run": True,
+            "postcondition": "export_file_written",
+        },
+        "export_nexus": {
+            "dry_run": True,
+            "postcondition": "export_file_written",
+        },
+    }
+
+    for tool_name, checks in expected.items():
+        spec = tools._tool_specs[tool_name]
+        assert spec.mutability == "mutating"
+        assert spec.supports_dry_run is checks["dry_run"]
+        assert spec.dry_run_parameter == "dryRun"
+        assert spec.parameters.get("additionalProperties") is False
+        assert "dryRun" in spec.parameters.get("properties", {})
+        assert spec.parameters["properties"]["dryRun"]["description"]
+        assert any(cond.id == "project_loaded" for cond in spec.preconditions)
+        assert any(cond.id == checks["postcondition"] for cond in spec.postconditions)
+
+
+@pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
+def test_mcp_forwards_annotations_meta_and_strict_schema_for_dangerous_mutator(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from adapters.mcp_adapter import create_mcp_server
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "mcp_config.json").write_text('{"expose_all_tools": true}\n', encoding="utf-8")
+
+    monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
+    server = create_mcp_server(str(tmp_path))
+    mcp_tools = asyncio.run(server.list_tools())
+    by_name = {tool.name: tool for tool in mcp_tools}
+
+    enrichments_write = by_name["enrichments_write"]
+    schema = enrichments_write.inputSchema
+
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["dryRun"]["type"] == "boolean"
+    assert schema["properties"]["dryRun"]["description"]
+    assert enrichments_write.annotations.destructiveHint is True
+    assert enrichments_write.annotations.readOnlyHint is False
+    assert enrichments_write.meta["x-parse"]["mutability"] == "mutating"
+    assert enrichments_write.meta["x-parse"]["supportsDryRun"] is True
+    assert any(
+        cond["id"] == "project_loaded"
+        for cond in enrichments_write.meta["x-parse"]["preconditions"]
+    )

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -116,12 +116,76 @@ class ChatToolExecutionError(ChatToolError):
 
 
 @dataclass(frozen=True)
+class ToolCondition:
+    """Machine-readable safety condition for agent-facing tool metadata."""
+
+    id: str
+    description: str
+    severity: str = "required"
+    kind: str = "project_state"
+
+    def to_payload(self) -> Dict[str, str]:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "severity": self.severity,
+            "kind": self.kind,
+        }
+
+
+@dataclass(frozen=True)
 class ChatToolSpec:
-    """Tool definition for OpenAI function-calling and validation."""
+    """Tool definition for OpenAI function-calling, validation, and MCP metadata."""
 
     name: str
     description: str
     parameters: Dict[str, Any]
+    mutability: str = "read_only"
+    supports_dry_run: bool = False
+    dry_run_parameter: Optional[str] = None
+    preconditions: Tuple[ToolCondition, ...] = ()
+    postconditions: Tuple[ToolCondition, ...] = ()
+
+    def mcp_annotations_payload(self) -> Dict[str, Any]:
+        destructive = self.mutability == "mutating"
+        read_only = self.mutability == "read_only"
+        payload: Dict[str, Any] = {
+            "readOnlyHint": read_only,
+            "destructiveHint": destructive,
+            "idempotentHint": read_only,
+        }
+        return payload
+
+    def mcp_meta_payload(self) -> Dict[str, Any]:
+        return {
+            "mutability": self.mutability,
+            "supportsDryRun": self.supports_dry_run,
+            "dryRunParameter": self.dry_run_parameter,
+            "preconditions": [condition.to_payload() for condition in self.preconditions],
+            "postconditions": [condition.to_payload() for condition in self.postconditions],
+        }
+
+
+def _tool_condition(
+    condition_id: str,
+    description: str,
+    *,
+    severity: str = "required",
+    kind: str = "project_state",
+) -> ToolCondition:
+    return ToolCondition(
+        id=condition_id,
+        description=description,
+        severity=severity,
+        kind=kind,
+    )
+
+
+def _project_loaded_condition() -> ToolCondition:
+    return _tool_condition(
+        "project_loaded",
+        "The PARSE project root must be available and readable.",
+    )
 
 
 def _utc_now_iso() -> str:
@@ -534,11 +598,40 @@ class ParseChatTools:
                     "additionalProperties": False,
                     "required": ["speaker", "offsetSec", "dryRun"],
                     "properties": {
-                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
-                        "offsetSec": {"type": "number"},
-                        "dryRun": {"type": "boolean"},
+                        "speaker": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Speaker ID whose annotation intervals will be shifted.",
+                        },
+                        "offsetSec": {
+                            "type": "number",
+                            "description": "Seconds to add to every interval start/end; negative values pull timestamps earlier.",
+                        },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "If true, preview the timestamp shift without writing annotations/<speaker>.parse.json.",
+                        },
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "speaker_annotation_exists",
+                        "The target speaker must already have an annotation file under annotations/.",
+                        kind="file_presence",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "annotation_timestamps_shifted",
+                        "When dryRun=false, the speaker's annotation intervals are rewritten with the requested offset.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "stt_start": ChatToolSpec(
                 name="stt_start",
@@ -961,9 +1054,23 @@ class ParseChatTools:
                     "additionalProperties": False,
                     "required": ["speaker", "sourceWav", "dryRun"],
                     "properties": {
-                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
-                        "sourceWav": {"type": "string", "minLength": 1, "maxLength": 1024},
-                        "sourceCsv": {"type": "string", "maxLength": 1024},
+                        "speaker": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Speaker ID to create or extend in the current project.",
+                        },
+                        "sourceWav": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 1024,
+                            "description": "Absolute or project-relative path to the source audio file to copy into the workspace.",
+                        },
+                        "sourceCsv": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "description": "Optional transcript CSV to store alongside the imported source WAV.",
+                        },
                         "isPrimary": {
                             "type": "boolean",
                             "description": "Flag this WAV as the speaker's primary source. Defaults to true when the speaker has no existing sources.",
@@ -974,6 +1081,24 @@ class ParseChatTools:
                         },
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "source_audio_readable",
+                        "The sourceWav path must resolve to a readable audio file within the allowed import roots.",
+                        kind="file_presence",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "speaker_source_registered",
+                        "When dryRun=false, the source audio is copied into the workspace and source_index.json / project metadata are updated.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "import_processed_speaker": ChatToolSpec(
                 name="import_processed_speaker",
@@ -989,14 +1114,58 @@ class ParseChatTools:
                     "additionalProperties": False,
                     "required": ["speaker", "workingWav", "annotationJson", "dryRun"],
                     "properties": {
-                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
-                        "workingWav": {"type": "string", "minLength": 1, "maxLength": 1024},
-                        "annotationJson": {"type": "string", "minLength": 1, "maxLength": 1024},
-                        "peaksJson": {"type": "string", "maxLength": 1024},
-                        "transcriptCsv": {"type": "string", "maxLength": 1024},
-                        "dryRun": {"type": "boolean"},
+                        "speaker": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Speaker ID to import into the PARSE workspace.",
+                        },
+                        "workingWav": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 1024,
+                            "description": "Path to the processed/working WAV whose timestamps already align with the annotation JSON.",
+                        },
+                        "annotationJson": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 1024,
+                            "description": "Path to the timestamp-bearing annotation JSON to copy into annotations/.",
+                        },
+                        "peaksJson": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "description": "Optional precomputed peaks JSON aligned to the working WAV.",
+                        },
+                        "transcriptCsv": {
+                            "type": "string",
+                            "maxLength": 1024,
+                            "description": "Optional legacy transcript CSV to preserve in the imported workspace.",
+                        },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "If true, preview the file-copy and metadata-write plan without mutating the workspace.",
+                        },
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "processed_artifacts_readable",
+                        "The working WAV and annotation JSON must both exist and be readable.",
+                        kind="file_presence",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "processed_speaker_imported",
+                        "When dryRun=false, the processed speaker artifacts are copied into the workspace and project/source-index metadata are updated.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "parse_memory_read": ChatToolSpec(
                 name="parse_memory_read",
@@ -1133,7 +1302,12 @@ class ParseChatTools:
                     "additionalProperties": False,
                     "required": ["speaker", "steps"],
                     "properties": {
-                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "speaker": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Speaker ID whose pipeline should run.",
+                        },
                         "steps": {
                             "type": "array",
                             "items": {
@@ -1142,6 +1316,7 @@ class ParseChatTools:
                             },
                             "minItems": 1,
                             "maxItems": 4,
+                            "description": "Ordered pipeline subset to execute for this speaker.",
                         },
                         "overwrites": {
                             "type": "object",
@@ -1168,8 +1343,30 @@ class ParseChatTools:
                                 "``sd`` for ORTH (razhan's fine-tuning target)."
                             ),
                         },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "If true, preview the planned compute payload without starting a background job.",
+                        },
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "speaker_ready_for_pipeline",
+                        "The target speaker must exist in the current project and have the files needed for the requested steps.",
+                        kind="project_state",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "pipeline_job_started",
+                        "When dryRun=false, a full_pipeline background job is created and can be polled via compute_status.",
+                        kind="job_state",
+                    ),
+                ),
             ),
             "compute_status": ChatToolSpec(
                 name="compute_status",
@@ -1279,8 +1476,30 @@ class ParseChatTools:
                             "type": "boolean",
                             "description": "If true (default), shallow-merge into existing data. If false, replace entirely.",
                         },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "If true, preview the resulting top-level keys without writing parse-enrichments.json.",
+                        },
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "enrichments_payload_provided",
+                        "The caller must supply an enrichments object to merge or replace.",
+                        kind="input_shape",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "enrichments_file_updated",
+                        "When dryRun=false, parse-enrichments.json is merged or replaced with the supplied payload.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "lexeme_notes_read": ChatToolSpec(
                 name="lexeme_notes_read",
@@ -1318,16 +1537,56 @@ class ParseChatTools:
                     "additionalProperties": False,
                     "required": ["speaker", "conceptId"],
                     "properties": {
-                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
-                        "conceptId": {"type": "string", "minLength": 1, "maxLength": 128},
-                        "userNote": {"type": "string", "maxLength": 4096},
-                        "importNote": {"type": "string", "maxLength": 4096},
+                        "speaker": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Speaker ID whose lexeme note will be updated.",
+                        },
+                        "conceptId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 128,
+                            "description": "Concept ID whose note entry will be created, updated, or deleted.",
+                        },
+                        "userNote": {
+                            "type": "string",
+                            "maxLength": 4096,
+                            "description": "Human-authored note text to store under user_note.",
+                        },
+                        "importNote": {
+                            "type": "string",
+                            "maxLength": 4096,
+                            "description": "Machine/import provenance note to store under import_note.",
+                        },
                         "delete": {
                             "type": "boolean",
                             "description": "If true, removes the note entry for this speaker+concept.",
                         },
+                        "dryRun": {
+                            "type": "boolean",
+                            "description": "If true, preview the resulting lexeme_notes block without writing parse-enrichments.json.",
+                        },
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "speaker_and_concept_provided",
+                        "The caller must provide both speaker and conceptId to identify a single lexeme-note entry.",
+                        kind="input_shape",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "lexeme_note_written",
+                        "When dryRun=false, the targeted lexeme_notes entry is created, updated, or deleted in parse-enrichments.json.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "export_annotations_csv": ChatToolSpec(
                 name="export_annotations_csv",
@@ -1355,6 +1614,24 @@ class ParseChatTools:
                         "dryRun": {"type": "boolean", "description": "Preview only — never writes."},
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "annotations_available_for_export",
+                        "At least one annotation payload must be available for the requested speaker scope.",
+                        kind="project_state",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "export_file_written",
+                        "When dryRun=false and outputPath is provided, the requested export file is written inside the project.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "export_lingpy_tsv": ChatToolSpec(
                 name="export_lingpy_tsv",
@@ -1376,6 +1653,24 @@ class ParseChatTools:
                         "dryRun": {"type": "boolean", "description": "Preview only — never writes."},
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "enrichments_and_annotations_available",
+                        "parse-enrichments.json and the annotation inventory must contain enough data to build a LingPy export.",
+                        kind="project_state",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "export_file_written",
+                        "When dryRun=false and outputPath is provided, the requested export file is written inside the project.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "export_nexus": ChatToolSpec(
                 name="export_nexus",
@@ -1398,6 +1693,24 @@ class ParseChatTools:
                         "dryRun": {"type": "boolean", "description": "Preview only — never writes."},
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "cognate_matrix_available",
+                        "The project must contain enough cognate/enrichment data to build a NEXUS character matrix.",
+                        kind="project_state",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "export_file_written",
+                        "When dryRun=false and outputPath is provided, the requested export file is written inside the project.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "export_annotations_elan": ChatToolSpec(
                 name="export_annotations_elan",
@@ -1411,7 +1724,12 @@ class ParseChatTools:
                     "additionalProperties": False,
                     "required": ["speaker"],
                     "properties": {
-                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "speaker": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Speaker ID whose annotations should be converted to ELAN format.",
+                        },
                         "outputPath": {
                             "type": "string",
                             "minLength": 1,
@@ -1421,6 +1739,24 @@ class ParseChatTools:
                         "dryRun": {"type": "boolean", "description": "Preview only — never writes."},
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "speaker_annotation_exists",
+                        "The requested speaker must already have an annotation file to export.",
+                        kind="file_presence",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "export_file_written",
+                        "When dryRun=false and outputPath is provided, the requested export file is written inside the project.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "export_annotations_textgrid": ChatToolSpec(
                 name="export_annotations_textgrid",
@@ -1434,7 +1770,12 @@ class ParseChatTools:
                     "additionalProperties": False,
                     "required": ["speaker"],
                     "properties": {
-                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "speaker": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Speaker ID whose annotations should be converted to TextGrid format.",
+                        },
                         "outputPath": {
                             "type": "string",
                             "minLength": 1,
@@ -1444,6 +1785,24 @@ class ParseChatTools:
                         "dryRun": {"type": "boolean", "description": "Preview only — never writes."},
                     },
                 },
+                mutability="mutating",
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "speaker_annotation_exists",
+                        "The requested speaker must already have an annotation file to export.",
+                        kind="file_presence",
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "export_file_written",
+                        "When dryRun=false and outputPath is provided, the requested export file is written inside the project.",
+                        kind="filesystem_write",
+                    ),
+                ),
             ),
             "phonetic_rules_apply": ChatToolSpec(
                 name="phonetic_rules_apply",
@@ -1644,6 +2003,13 @@ class ParseChatTools:
                 }
             )
         return payload
+
+    def tool_spec(self, tool_name: str) -> ChatToolSpec:
+        """Return the ChatToolSpec for a registered tool."""
+        name = str(tool_name or "").strip()
+        if name not in self._tool_specs:
+            raise ChatToolValidationError("Tool is not allowlisted: {0}".format(name))
+        return self._tool_specs[name]
 
     def tool_names(self) -> List[str]:
         """Return sorted tool names in allowlist."""
@@ -2547,6 +2913,16 @@ class ParseChatTools:
         if language:
             payload["language"] = language
 
+        if bool(args.get("dryRun", False)):
+            return {
+                "readOnly": True,
+                "previewOnly": True,
+                "status": "dry_run",
+                "tool": "pipeline_run",
+                "plan": payload,
+                "message": "Dry run. Would start a full_pipeline compute job for this speaker.",
+            }
+
         try:
             job_id = self._start_compute_job("full_pipeline", payload)
         except Exception as exc:
@@ -2694,6 +3070,17 @@ class ParseChatTools:
         else:
             payload = incoming
 
+        if bool(args.get("dryRun", False)):
+            return {
+                "readOnly": True,
+                "previewOnly": True,
+                "dryRun": True,
+                "merge": merge,
+                "incomingKeys": list(incoming.keys()),
+                "resultingKeys": list(payload.keys()),
+                "path": str(self.enrichments_path),
+            }
+
         self.enrichments_path.write_text(
             json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
         )
@@ -2759,6 +3146,17 @@ class ParseChatTools:
                 entry["import_note"] = str(args.get("importNote") or "")
             entry["updated_at"] = _utc_now_iso()
             speaker_block[concept_id] = entry
+
+        if bool(args.get("dryRun", False)):
+            return {
+                "readOnly": True,
+                "previewOnly": True,
+                "dryRun": True,
+                "speaker": speaker,
+                "conceptId": concept_id,
+                "delete": bool(args.get("delete", False)),
+                "lexeme_notes": payload.get("lexeme_notes") or {},
+            }
 
         self.enrichments_path.write_text(
             json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -102,6 +102,23 @@ ONBOARD_AUDIO_EXTENSIONS = frozenset({".wav", ".flac", ".mp3", ".ogg", ".m4a"})
 MEMORY_MAX_BYTES = 256 * 1024  # 256 KB cap on parse-memory.md
 MEMORY_SECTION_SLUG_RE = re.compile(r"[^A-Za-z0-9 _./-]+")
 
+TOOL_MUTABILITY_READ_ONLY = "read_only"
+TOOL_MUTABILITY_STATEFUL_JOB = "stateful_job"
+TOOL_MUTABILITY_MUTATING = "mutating"
+
+TOOL_CONDITION_KIND_PROJECT_STATE = "project_state"
+TOOL_CONDITION_KIND_FILE_PRESENCE = "file_presence"
+TOOL_CONDITION_KIND_INPUT_SHAPE = "input_shape"
+TOOL_CONDITION_KIND_FILESYSTEM_WRITE = "filesystem_write"
+TOOL_CONDITION_KIND_JOB_STATE = "job_state"
+TOOL_CONDITION_KINDS = frozenset({
+    TOOL_CONDITION_KIND_PROJECT_STATE,
+    TOOL_CONDITION_KIND_FILE_PRESENCE,
+    TOOL_CONDITION_KIND_INPUT_SHAPE,
+    TOOL_CONDITION_KIND_FILESYSTEM_WRITE,
+    TOOL_CONDITION_KIND_JOB_STATE,
+})
+
 
 class ChatToolError(Exception):
     """Base chat tool error."""
@@ -122,7 +139,7 @@ class ToolCondition:
     id: str
     description: str
     severity: str = "required"
-    kind: str = "project_state"
+    kind: str = TOOL_CONDITION_KIND_PROJECT_STATE
 
     def to_payload(self) -> Dict[str, str]:
         return {
@@ -140,15 +157,15 @@ class ChatToolSpec:
     name: str
     description: str
     parameters: Dict[str, Any]
-    mutability: str = "read_only"
+    mutability: str = TOOL_MUTABILITY_READ_ONLY
     supports_dry_run: bool = False
     dry_run_parameter: Optional[str] = None
     preconditions: Tuple[ToolCondition, ...] = ()
     postconditions: Tuple[ToolCondition, ...] = ()
 
     def mcp_annotations_payload(self) -> Dict[str, Any]:
-        destructive = self.mutability == "mutating"
-        read_only = self.mutability == "read_only"
+        destructive = self.mutability == TOOL_MUTABILITY_MUTATING
+        read_only = self.mutability == TOOL_MUTABILITY_READ_ONLY
         payload: Dict[str, Any] = {
             "readOnlyHint": read_only,
             "destructiveHint": destructive,
@@ -159,8 +176,8 @@ class ChatToolSpec:
     def mcp_meta_payload(self) -> Dict[str, Any]:
         return {
             "mutability": self.mutability,
-            "supportsDryRun": self.supports_dry_run,
-            "dryRunParameter": self.dry_run_parameter,
+            "supports_dry_run": self.supports_dry_run,
+            "dry_run_parameter": self.dry_run_parameter,
             "preconditions": [condition.to_payload() for condition in self.preconditions],
             "postconditions": [condition.to_payload() for condition in self.postconditions],
         }
@@ -171,8 +188,10 @@ def _tool_condition(
     description: str,
     *,
     severity: str = "required",
-    kind: str = "project_state",
+    kind: str = TOOL_CONDITION_KIND_PROJECT_STATE,
 ) -> ToolCondition:
+    if kind not in TOOL_CONDITION_KINDS:
+        raise ValueError("Unsupported ToolCondition kind: {0}".format(kind))
     return ToolCondition(
         id=condition_id,
         description=description,
@@ -185,6 +204,7 @@ def _project_loaded_condition() -> ToolCondition:
     return _tool_condition(
         "project_loaded",
         "The PARSE project root must be available and readable.",
+        kind=TOOL_CONDITION_KIND_PROJECT_STATE,
     )
 
 
@@ -2003,6 +2023,10 @@ class ParseChatTools:
                 }
             )
         return payload
+
+    def iter_tool_specs(self) -> Tuple[ChatToolSpec, ...]:
+        """Return all registered tool specs in a stable name-sorted order."""
+        return tuple(self._tool_specs[name] for name in self.tool_names())
 
     def tool_spec(self, tool_name: str) -> ChatToolSpec:
         """Return the ChatToolSpec for a registered tool."""

--- a/python/ai/test_acoustic_alignment_mcp_tools.py
+++ b/python/ai/test_acoustic_alignment_mcp_tools.py
@@ -178,6 +178,7 @@ def test_forced_align_start_live_dispatches_forced_align_compute(tmp_path) -> No
             "forced_align",
             {
                 "speaker": "Fail02",
+                "overwrite": False,
                 "language": "ku",
                 "padMs": 150,
                 "emitPhonemes": False,


### PR DESCRIPTION
## Summary
- add machine-readable `ChatToolSpec` metadata for the first dangerous-mutator Task 2 batch
- forward strict schemas, MCP annotations, and `meta["x-parse"]` from `ParseChatTools` into the MCP adapter
- add dry-run preview support for `enrichments_write`, `lexeme_notes_write`, and `pipeline_run`
- add regression coverage for strict schemas and forwarded MCP safety metadata

## Tests
- python -m pytest python/adapters/test_mcp_adapter.py -q
- python -m pytest python/ai/test_pipeline_chat_tools.py -q
- python -m pytest python/ai/test_acoustic_alignment_mcp_tools.py -q
- python -m pytest python/adapters/test_mcp_adapter.py python/ai/test_pipeline_chat_tools.py python/ai/test_parse_memory_tool.py python/ai/test_contact_lexeme_tool.py -q
