### PR TITLE
feat: add MCP workflow macros

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ if x_parse["supports_dry_run"]:
 
 Use the new MCP workflow macros when an agent wants a one-call end-to-end action rather than hand-assembling low-level job chains.
 
+Agent example: "Run the full PARSE annotation workflow on speaker `Fail02` and report back on concepts `1`, `2`, and `3`."
+
 ```python
 run_full_annotation_pipeline(
   speaker_id="Fail02",
@@ -108,6 +110,8 @@ export_complete_lingpy_dataset(
   dryRun=False,
 )
 ```
+
+Naming note: `prepare_compare_mode` is the current stable public name. If a future cleanup wants a more action-oriented label, add a backward-compatible alias such as `build_compare_session` rather than silently renaming the macro.
 
 ## Client/Server Contract Surface
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,12 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
 ## MCP adapter note
 
 - `python/adapters/mcp_adapter.py` now supports `config/mcp_config.json` with `{ "expose_all_tools": true }`.
-- Default MCP surface is **30 tools**: the legacy 29 `ParseChatTools` wrappers plus read-only `mcp_get_exposure_mode` for self-inspection.
-- Enabling `expose_all_tools` expands the MCP surface to **48 tools**: all 47 `ParseChatTools` plus `mcp_get_exposure_mode`.
+- Default MCP surface is **33 tools**: the legacy 29 `ParseChatTools` wrappers, 3 high-level `WorkflowTools` macros from `python/ai/workflow_tools.py`, plus read-only `mcp_get_exposure_mode` for self-inspection.
+- Enabling `expose_all_tools` expands the MCP surface to **51 tools**: all 47 `ParseChatTools`, the 3 `WorkflowTools` macros, plus `mcp_get_exposure_mode`.
+- The workflow macros are:
+  - `run_full_annotation_pipeline`
+  - `prepare_compare_mode`
+  - `export_complete_lingpy_dataset`
 - For backward compatibility, root-level `mcp_config.json` is also accepted when `config/mcp_config.json` is absent.
 - `ChatToolSpec` is the MCP metadata source of truth. MCP tools should forward the strict schema from `spec.parameters`, standard MCP annotations from `spec.mcp_annotations_payload()`, and PARSE-specific safety metadata from `meta["x-parse"] = spec.mcp_meta_payload()`.
 - Mutability meanings:
@@ -80,6 +84,29 @@ if any(cond["id"] == "project_loaded" for cond in x_parse["preconditions"]):
 if x_parse["supports_dry_run"]:
     # Prefer a preview call before a mutating call.
     ...
+```
+
+### Workflow Macro Examples
+
+Use the new MCP workflow macros when an agent wants a one-call end-to-end action rather than hand-assembling low-level job chains.
+
+```python
+run_full_annotation_pipeline(
+  speaker_id="Fail02",
+  concept_list=["1", "2", "3"],
+  dryRun=True,
+)
+
+prepare_compare_mode(
+  concept_range="1-25",
+  speakers=["Fail01", "Fail02", "Kalh01"],
+  dryRun=False,
+)
+
+export_complete_lingpy_dataset(
+  with_contact_lexemes=True,
+  dryRun=False,
+)
 ```
 
 ## Client/Server Contract Surface

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Annotate per-speaker recordings with tiered IPA/orthography, then compare across
 - **Dual-mode unified React shell** for annotation and comparison in one workspace
 - **Fieldwork-first design** for long recordings, uneven metadata, and iterative review
 - **AI-native workflow surface** with a built-in chat assistant powered by **47 PARSE-specific tools**
-- **Full MCP server mode** exposing a curated **29-tool** subset for external agents and automation
+- **Full MCP server mode** exposing a curated **32-tool task surface** for external agents and automation, plus `mcp_get_exposure_mode`
 - **CLEF — Contact Lexeme Explorer Feature** for borrowing adjudication via a 10-provider contact-language lookup stack
 - **Lexical Anchor Alignment System** for locating repeated lexical items across long recordings and across speakers
 - **Export pipeline** for LingPy TSV and NEXUS outputs used in downstream comparative workflows
@@ -91,14 +91,14 @@ PARSE can also run as an **MCP (Model Context Protocol) server**.
 
 That means external agent clients such as Claude Code, Cursor, Cline, Hermes, Windsurf, Codex, or other MCP-capable tools can call a curated subset of PARSE functions programmatically, without going through the browser UI.
 
-The MCP adapter currently exposes **29 tools** drawn from the broader in-app PARSE tool surface.
+The MCP adapter currently exposes **32 task tools** drawn from the broader in-app PARSE tool surface, plus read-only `mcp_get_exposure_mode` for self-inspection.
 
 ## 📚 Documentation
 
 - [Getting Started](docs/getting-started.md) — installation, launch paths, requirements, environment variables, `ai_config.json`, GPU notes, and troubleshooting
 - [User Guide](docs/user-guide.md) — detailed Annotate/Compare workflows, CLEF usage, Lexical Anchor Alignment, and workspace hydration
-- [AI Integration](docs/ai-integration.md) — provider routing, model roles, configuration, external dependencies, and the full 47-tool chat surface
-- [API Reference](docs/api-reference.md) — HTTP endpoints, compute routes, examples, and the full 29-tool MCP surface
+- [AI Integration](docs/ai-integration.md) — provider routing, model roles, configuration, external dependencies, the full 47-tool chat surface, and MCP workflow macros
+- [API Reference](docs/api-reference.md) — HTTP endpoints, compute routes, examples, and the full 32-tool MCP task surface
 - [Architecture](docs/architecture.md) — unified shell, backend/data design, Lexical Anchor Alignment scoring, and CLEF provider registry
 - [Developer Guide](docs/developer-guide.md) — project structure, tech stack, local development flow, and extension points for chat tools, MCP tools, and endpoints
 - [Research Context](docs/research-context.md) — thesis background, citation guidance, and research-software framing

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -302,11 +302,21 @@ The current README calls out two important operational boundaries:
 
 Multi-source speakers may still require manual or virtual-timeline coordination because PARSE does not yet auto-align multiple WAVs into a single shared annotation timeline.
 
+### MCP workflow macros (3)
+
+| Tool | Description |
+|---|---|
+| `run_full_annotation_pipeline` | Run STT → forced alignment → acoustic IPA for one speaker in one call |
+| `prepare_compare_mode` | Build a compare-ready concept × speaker bundle with fresh preview data |
+| `export_complete_lingpy_dataset` | Export LingPy TSV + NEXUS, optionally refreshing contact lexeme references first |
+
 ## MCP subset versus in-app tool surface
 
-Not every in-app chat tool is exported over MCP.
+Not every in-app chat tool is exported over MCP, and MCP also exposes 3 workflow-only macros that live outside the built-in 47-tool chat surface.
 
 - **Built-in chat tools**: 47
-- **MCP-exposed tools**: 29
+- **Default MCP task tools**: 32
+- **Default MCP adapter surface including `mcp_get_exposure_mode`**: 33
+- **Full MCP adapter surface with `expose_all_tools=true`**: 51
 
 For the exact MCP subset, startup instructions, and usage examples, see [API Reference](./api-reference.md).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -340,7 +340,7 @@ pip install 'mcp[cli]'
 
 If no explicit environment block is passed, the adapter also reads repo-local overrides from `.parse-env`.
 
-## Full MCP tool surface (29 tools)
+## Full MCP tool surface (32 tools)
 
 ### Inspection / preview / preflight
 
@@ -391,9 +391,17 @@ If no explicit environment block is passed, the adapter also reads repo-local ov
 | `import_processed_speaker` | Import one speaker from existing processed artifacts |
 | `parse_memory_upsert_section` | Upsert a `## Section` block in `parse-memory.md` |
 
+### Workflow macros
+
+| Tool | Description |
+|---|---|
+| `run_full_annotation_pipeline` | Run STT → forced alignment → acoustic IPA for one speaker in one call |
+| `prepare_compare_mode` | Resolve a concept slice across speakers and return a compare-ready preview bundle |
+| `export_complete_lingpy_dataset` | Export LingPy TSV + NEXUS, optionally refreshing contact lexeme references first |
+
 ## MCP usage notes
 
-The MCP surface is a **subset** of the full in-app chat tool surface.
+The MCP surface is a curated subset of the low-level chat tools plus 3 high-level workflow macros.
 
 A few operational rules remain important:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ flowchart LR
     Server --> ChatTools[python/ai/chat_tools.py\n47 PARSE-specific tools]
     Server --> Compare[python/compare/*\ncognates + CLEF providers]
     Server --> Models[local & remote AI providers\nfaster-whisper / wav2vec2 / OpenAI / xAI]
-    ChatTools --> MCP[python/adapters/mcp_adapter.py\n29-tool MCP server mode]
+    ChatTools --> MCP[python/adapters/mcp_adapter.py\n32-task MCP surface + workflow macros]
     Compare --> Exports[LingPy TSV + NEXUS]
 ```
 
@@ -284,7 +284,8 @@ The in-app assistant works through `python/ai/chat_tools.py`.
 Current counts:
 
 - **47** built-in PARSE chat tools
-- **29** MCP-exposed tools via `python/adapters/mcp_adapter.py`
+- **32** MCP task tools via `python/adapters/mcp_adapter.py`
+- **33** total default MCP adapter tools including `mcp_get_exposure_mode`
 
 This separation matters architecturally:
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -241,6 +241,8 @@ At minimum update:
 
 The built-in assistant works through `ParseChatTools` in `python/ai/chat_tools.py`.
 
+For high-level MCP-only workflow macros, use `python/ai/workflow_tools.py` instead. Those tools should stay thin orchestration layers over existing low-level tool handlers and publish their own `ChatToolSpec` metadata.
+
 A new tool should follow this pattern:
 
 1. Add the new `ChatToolSpec` entry in `python/ai/chat_tools.py`
@@ -264,12 +266,12 @@ The MCP adapter lives in `python/adapters/mcp_adapter.py`.
 
 To expose a tool over MCP:
 
-1. Ensure the underlying functionality already exists in `ParseChatTools`
+1. Ensure the underlying functionality already exists in `ParseChatTools` or `WorkflowTools`
 2. Add a matching `@mcp.tool()` wrapper in `python/adapters/mcp_adapter.py`
 3. Keep parameter naming and documentation aligned with the underlying tool
 4. Re-check the exported-tool count and update docs if the MCP subset changed
 
-The adapter is intentionally a **curated subset** of the in-app tool surface. Not every chat tool should automatically become an MCP tool.
+The adapter is intentionally a curated PARSE tool surface. Low-level browser/chat tools live in `ParseChatTools`; high-level agent workflow macros live in `WorkflowTools`.
 
 ## How to add or extend a CLEF provider
 

--- a/docs/mcp_agent_roadmap.md
+++ b/docs/mcp_agent_roadmap.md
@@ -10,8 +10,8 @@ Future improvements to make PARSE a first-class citizen in agent-driven workflow
 
 **Shipped:**
 - `python/adapters/mcp_adapter.py` still exposes the legacy **29 `ParseChatTools`** surface by default.
-- MCP now also includes read-only `mcp_get_exposure_mode`, so the total adapter surface is **30 tools by default**.
-- Opt-in config at `config/mcp_config.json` (or fallback root `mcp_config.json`) enables the full **47-tool** `ParseChatTools` surface, for **48 MCP tools total** including `mcp_get_exposure_mode`:
+- Task 3 adds 3 workflow macros on top of that base, so the current default adapter surface is **33 tools total** including `mcp_get_exposure_mode`.
+- Opt-in config at `config/mcp_config.json` (or fallback root `mcp_config.json`) enables the full **47-tool** `ParseChatTools` surface; with the 3 workflow macros and `mcp_get_exposure_mode`, the current full adapter surface is **51 tools total**:
 
 ```json
 { "expose_all_tools": true }
@@ -36,13 +36,20 @@ Future improvements to make PARSE a first-class citizen in agent-driven workflow
 
 ## 3. High-level composite / workflow tools
 
-Instead of chaining 47 low-level calls, give agents a handful of macro tools:
+**Status:** ✅ Complete
 
-| Tool | Purpose |
-|------|---------|
-| `run_full_annotation_pipeline(speaker_id, concept_list)` | STT → alignment → IPA in one call |
-| `prepare_compare_mode(concept_range, speakers)` | Load and diff a concept set across speakers |
-| `export_complete_lingpy_dataset(with_contact_lexemes=True)` | Full phylogenetics export |
+**Shipped:**
+- Added `python/ai/workflow_tools.py` with a dedicated `WorkflowTools` class.
+- New macros are exposed via MCP with their own `ChatToolSpec` metadata:
+  - `run_full_annotation_pipeline(speaker_id, concept_list, dryRun=False)`
+  - `prepare_compare_mode(concept_range, speakers, dryRun=False)`
+  - `export_complete_lingpy_dataset(with_contact_lexemes=True, dryRun=False)`
+- The macros orchestrate existing low-level tool handlers directly rather than duplicating business logic:
+  - annotation workflow: `stt_start` → `stt_status` → `forced_align_start` → `forced_align_status` → `ipa_transcribe_acoustic_start` → `ipa_transcribe_acoustic_status`
+  - compare prep: `speakers_list`, `annotation_read`, `cognate_compute_preview`, `cross_speaker_match_preview`
+  - export bundle: `contact_lexeme_lookup`, `export_lingpy_tsv`, `export_nexus`
+- Each macro publishes machine-readable preconditions/postconditions and supports `dryRun` where appropriate.
+- MCP adapter now exposes the workflow macros in both default and full-exposure modes.
 
 Macros are easier to discover, easier to prompt, and safer to execute.
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -73,6 +73,7 @@ if str(_PYTHON_DIR) not in sys.path:
     sys.path.insert(0, str(_PYTHON_DIR))
 
 from ai.chat_tools import DEFAULT_MCP_TOOL_NAMES
+from ai.workflow_tools import DEFAULT_MCP_WORKFLOW_TOOL_NAMES
 
 # ---------------------------------------------------------------------------
 # Lazy MCP SDK import
@@ -160,6 +161,7 @@ def _mcp_exposure_payload(
     expose_all_tools: bool,
     config_source: Optional[str],
     parse_chat_tool_count: int,
+    workflow_tool_count: int,
     mcp_tool_count: int,
 ) -> Dict[str, Any]:
     """Build a read-only MCP payload describing the active exposure mode."""
@@ -173,8 +175,10 @@ def _mcp_exposure_payload(
             "exposeAllTools": expose_all_tools,
             "configSource": config_source,
             "parseChatToolCount": parse_chat_tool_count,
+            "workflowToolCount": workflow_tool_count,
             "mcpToolCount": mcp_tool_count,
             "defaultParseMcpToolCount": len(DEFAULT_MCP_TOOL_NAMES),
+            "defaultWorkflowMcpToolCount": len(DEFAULT_MCP_WORKFLOW_TOOL_NAMES),
         },
     }
 
@@ -698,6 +702,7 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         )
 
     from ai.chat_tools import ParseChatTools
+    from ai.workflow_tools import WorkflowTools
 
     root = _resolve_project_root(project_root)
     applied_env = _load_repo_parse_env(root)
@@ -730,10 +735,24 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         start_normalize_job=normalize_cb,
         list_active_jobs=jobs_cb,
     )
+    workflow_tools = WorkflowTools(
+        project_root=root,
+        start_stt_job=start_stt,
+        get_job_snapshot=get_snapshot,
+        external_read_roots=external_roots,
+        memory_path=memory_path,
+        onboard_speaker=onboard_callback,
+        pipeline_state=pipeline_state_cb,
+        start_compute_job=start_compute_cb,
+        start_normalize_job=normalize_cb,
+        list_active_jobs=jobs_cb,
+    )
     mcp_config = _load_mcp_config(root)
     expose_all_tools = mcp_config.get("expose_all_tools", False)
     all_mcp_tool_names = ParseChatTools.get_all_tool_names()
     selected_mcp_tool_names = _selected_mcp_tool_names(all_mcp_tool_names, expose_all_tools)
+    selected_workflow_tool_names = list(DEFAULT_MCP_WORKFLOW_TOOL_NAMES)
+    all_registered_tool_names = list(selected_mcp_tool_names) + list(selected_workflow_tool_names)
 
     mcp = FastMCP(
         "parse",
@@ -748,8 +767,12 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         result = tools.execute(tool_name, args)
         return json.dumps(result, indent=2, ensure_ascii=False)
 
-    def _sync_registered_tool_metadata(tool_name: str) -> None:
-        spec = tools.tool_spec(tool_name)
+    def _json_workflow_tool_result(tool_name: str, args: Dict[str, Any]) -> str:
+        result = workflow_tools.execute(tool_name, args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    def _sync_registered_tool_metadata(tool_name: str, spec_provider: Any) -> None:
+        spec = spec_provider.tool_spec(tool_name)
         registered = mcp._tool_manager._tools.get(tool_name)
         if registered is None:
             return
@@ -766,7 +789,8 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             expose_all_tools=expose_all_tools,
             config_source=mcp_config.get("config_path"),
             parse_chat_tool_count=len(all_mcp_tool_names),
-            mcp_tool_count=len(selected_mcp_tool_names) + 1,
+            workflow_tool_count=len(selected_workflow_tool_names),
+            mcp_tool_count=len(all_registered_tool_names) + 1,
         )
         return json.dumps(payload, indent=2, ensure_ascii=False)
 
@@ -1834,12 +1858,53 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             return _json_tool_result("transcript_reformat", args)
         mcp.tool(name="transcript_reformat")(mcp_transcript_reformat)
 
+    @mcp.tool()
+    def run_full_annotation_pipeline(
+        speaker_id: str,
+        concept_list: list,
+        dryRun: Optional[bool] = None,
+    ) -> str:
+        """Run STT, forced alignment, and acoustic IPA for one speaker in one call."""
+        args: Dict[str, Any] = {"speaker_id": speaker_id, "concept_list": concept_list}
+        if dryRun is not None:
+            args["dryRun"] = dryRun
+        return _json_workflow_tool_result("run_full_annotation_pipeline", args)
+
+    @mcp.tool()
+    def prepare_compare_mode(
+        concept_range: Any,
+        speakers: list,
+        dryRun: Optional[bool] = None,
+    ) -> str:
+        """Prepare a compare-mode bundle for a concept slice across speakers."""
+        args: Dict[str, Any] = {"concept_range": concept_range, "speakers": speakers}
+        if dryRun is not None:
+            args["dryRun"] = dryRun
+        return _json_workflow_tool_result("prepare_compare_mode", args)
+
+    @mcp.tool()
+    def export_complete_lingpy_dataset(
+        with_contact_lexemes: Optional[bool] = None,
+        dryRun: Optional[bool] = None,
+    ) -> str:
+        """Export LingPy TSV + NEXUS, optionally hydrating contact lexeme references first."""
+        args: Dict[str, Any] = {}
+        if with_contact_lexemes is not None:
+            args["with_contact_lexemes"] = with_contact_lexemes
+        if dryRun is not None:
+            args["dryRun"] = dryRun
+        return _json_workflow_tool_result("export_complete_lingpy_dataset", args)
+
     for tool_name in selected_mcp_tool_names:
-        _sync_registered_tool_metadata(tool_name)
+        _sync_registered_tool_metadata(tool_name, tools)
+    for tool_name in selected_workflow_tool_names:
+        _sync_registered_tool_metadata(tool_name, workflow_tools)
 
     logger.info(
-        "MCP exposing %s tools (expose_all_tools=%s)",
+        "MCP exposing %s tools (parse_chat=%s, workflow=%s, expose_all_tools=%s)",
+        len(all_registered_tool_names),
         len(selected_mcp_tool_names),
+        len(selected_workflow_tool_names),
         str(expose_all_tools).lower(),
     )
 

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -17,6 +17,7 @@ if str(_PYTHON_DIR) not in sys.path:
     sys.path.insert(0, str(_PYTHON_DIR))
 
 from ai.chat_tools import ParseChatTools
+from ai.workflow_tools import WorkflowTools
 
 
 def test_load_repo_parse_env_sets_missing_vars(tmp_path, monkeypatch) -> None:
@@ -91,8 +92,9 @@ def test_every_mcp_tool_is_allowlisted_in_parse_chat_tools(tmp_path) -> None:
     mcp_names = {t.name for t in mcp_tools}
 
     chat_names = set(ParseChatTools(project_root=tmp_path).tool_names())
+    workflow_names = set(WorkflowTools(project_root=tmp_path).tool_names())
 
-    phantom = mcp_names - chat_names
+    phantom = mcp_names - (chat_names | workflow_names)
     adapter_only = {"mcp_get_exposure_mode"}
     assert phantom <= adapter_only, (
         "MCP tools that are NOT in ParseChatTools.tool_names() will raise "
@@ -107,7 +109,7 @@ def test_parse_chat_tools_get_all_tool_names_matches_instance(tmp_path) -> None:
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
-def test_create_mcp_server_defaults_to_30_tools_without_config(tmp_path, monkeypatch) -> None:
+def test_create_mcp_server_defaults_to_33_tools_without_config(tmp_path, monkeypatch) -> None:
     import asyncio
     import json
 
@@ -118,20 +120,24 @@ def test_create_mcp_server_defaults_to_30_tools_without_config(tmp_path, monkeyp
     mcp_tools = asyncio.run(server.list_tools())
     tool_names = {tool.name for tool in mcp_tools}
 
-    assert len(mcp_tools) == 30
+    assert len(mcp_tools) == 33
     assert "mcp_get_exposure_mode" in tool_names
+    assert "run_full_annotation_pipeline" in tool_names
+    assert "prepare_compare_mode" in tool_names
+    assert "export_complete_lingpy_dataset" in tool_names
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is False
     assert payload["result"]["configSource"] is None
-    assert payload["result"]["mcpToolCount"] == 30
+    assert payload["result"]["mcpToolCount"] == 33
     assert payload["result"]["parseChatToolCount"] == 47
+    assert payload["result"]["workflowToolCount"] == 3
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
-def test_create_mcp_server_exposes_all_48_tools_when_enabled_in_config_dir(tmp_path, monkeypatch) -> None:
+def test_create_mcp_server_exposes_all_51_tools_when_enabled_in_config_dir(tmp_path, monkeypatch) -> None:
     import asyncio
     import json
 
@@ -147,18 +153,19 @@ def test_create_mcp_server_exposes_all_48_tools_when_enabled_in_config_dir(tmp_p
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
-    assert len(mcp_tools) == 48
+    assert len(mcp_tools) == 51
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is True
-    assert payload["result"]["mcpToolCount"] == 48
+    assert payload["result"]["mcpToolCount"] == 51
     assert payload["result"]["parseChatToolCount"] == 47
+    assert payload["result"]["workflowToolCount"] == 3
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
-def test_create_mcp_server_exposes_all_48_tools_when_enabled_in_root_config(tmp_path, monkeypatch) -> None:
+def test_create_mcp_server_exposes_all_51_tools_when_enabled_in_root_config(tmp_path, monkeypatch) -> None:
     import asyncio
     import json
 
@@ -172,7 +179,7 @@ def test_create_mcp_server_exposes_all_48_tools_when_enabled_in_root_config(tmp_
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
-    assert len(mcp_tools) == 48
+    assert len(mcp_tools) == 51
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])

--- a/python/ai/test_workflow_tools.py
+++ b/python/ai/test_workflow_tools.py
@@ -134,11 +134,54 @@ def test_run_full_annotation_pipeline_orchestrates_low_level_jobs(tmp_path: path
         "forced_align": "job-align",
         "ipa": "job-ipa",
     }
+    assert payload["progress"]["completedStages"] == 3
+    assert payload["progress"]["totalStages"] == 3
+    assert payload["progress"]["percent"] == 100.0
+    assert payload["progress"]["done"] is True
+    assert [event["event"] for event in payload["events"]] == [
+        "stage_started",
+        "stage_completed",
+        "stage_started",
+        "stage_completed",
+        "stage_started",
+        "stage_completed",
+    ]
     assert stt_calls == [("Fail02", "audio/original/Fail02.wav", None)]
     assert start_calls == [
         ("forced_align", {"speaker": "Fail02", "overwrite": False, "language": "ku", "padMs": 100, "emitPhonemes": True}),
         ("ipa_only", {"speaker": "Fail02", "overwrite": False}),
     ]
+
+
+def test_run_full_annotation_pipeline_returns_structured_failure_payload(tmp_path: pathlib.Path) -> None:
+    _seed_annotation(tmp_path, "Fail02")
+
+    workflow = WorkflowTools(
+        project_root=tmp_path,
+        start_stt_job=lambda *_args: "job-stt",
+        start_compute_job=lambda *_args, **_kwargs: "unused",
+        get_job_snapshot=lambda job_id: {
+            "type": "stt",
+            "status": "error",
+            "progress": 42.0,
+            "error": "decoder crash",
+            "result": {"speaker": "Fail02", "sourceWav": "audio/original/Fail02.wav"},
+        } if job_id == "job-stt" else None,
+    )
+
+    payload = workflow.execute(
+        "run_full_annotation_pipeline",
+        {"speaker_id": "Fail02", "concept_list": ["1"]},
+    )["result"]
+
+    assert payload["final_status"] == "error"
+    assert payload["failedStep"] == "stt"
+    assert payload["failedTool"] == "stt_status"
+    assert payload["error"]["message"] == "decoder crash"
+    assert payload["progress"]["completedStages"] == 0
+    assert payload["progress"]["currentStage"] == "stt"
+    assert payload["progress"]["done"] is False
+    assert payload["events"][-1]["event"] == "stage_failed"
 
 
 def test_prepare_compare_mode_builds_compare_bundle_from_selected_range(tmp_path: pathlib.Path) -> None:

--- a/python/ai/test_workflow_tools.py
+++ b/python/ai/test_workflow_tools.py
@@ -1,0 +1,237 @@
+"""Tests for PARSE MCP composite workflow tools.
+
+These tests cover the Task 3 macro surface implemented in
+`python/ai/workflow_tools.py`. The macros should remain thin orchestration
+layers over the existing low-level tool handlers, while exposing their own
+ChatToolSpec metadata for MCP discovery.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ai.workflow_tools import WorkflowTools
+
+
+def _write_concepts_csv(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "concepts.csv").write_text(
+        "id,concept_en\n1,water\n2,fire\n3,sun\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_annotation(
+    tmp_path: pathlib.Path,
+    speaker: str,
+    *,
+    source_audio: str | None = None,
+    concepts: List[str] | None = None,
+) -> None:
+    concepts = concepts or ["1", "2"]
+    ann_dir = tmp_path / "annotations"
+    ann_dir.mkdir(exist_ok=True)
+
+    if source_audio is None:
+        source_audio = f"audio/original/{speaker}.wav"
+    audio_path = tmp_path / source_audio
+    audio_path.parent.mkdir(parents=True, exist_ok=True)
+    audio_path.write_bytes(b"RIFFWAVE")
+
+    concept_intervals = []
+    ortho_intervals = []
+    ipa_intervals = []
+    speaker_intervals = []
+    for index, concept_id in enumerate(concepts):
+        start = float(index)
+        end = float(index + 1)
+        concept_intervals.append({"start": start, "end": end, "text": concept_id})
+        ortho_intervals.append({"start": start, "end": end, "text": f"{speaker}-orth-{concept_id}"})
+        ipa_intervals.append({"start": start, "end": end, "text": f"{speaker}-ipa-{concept_id}"})
+        speaker_intervals.append({"start": start, "end": end, "text": speaker})
+
+    payload = {
+        "version": 1,
+        "speaker": speaker,
+        "source_audio": source_audio,
+        "tiers": {
+            "concept": {"type": "interval", "intervals": concept_intervals},
+            "ortho": {"type": "interval", "intervals": ortho_intervals},
+            "ipa": {"type": "interval", "intervals": ipa_intervals},
+            "speaker": {"type": "interval", "intervals": speaker_intervals},
+        },
+    }
+    (ann_dir / f"{speaker}.parse.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_run_full_annotation_pipeline_orchestrates_low_level_jobs(tmp_path: pathlib.Path) -> None:
+    _seed_annotation(tmp_path, "Fail02")
+
+    start_calls: List[Tuple[str, Dict[str, Any]]] = []
+    stt_calls: List[Tuple[str, str, str | None]] = []
+
+    def fake_start_stt(speaker: str, source_wav: str, language: str | None) -> str:
+        stt_calls.append((speaker, source_wav, language))
+        return "job-stt"
+
+    def fake_start_compute(compute_type: str, payload: Dict[str, Any]) -> str:
+        start_calls.append((compute_type, dict(payload)))
+        if compute_type == "forced_align":
+            return "job-align"
+        if compute_type == "ipa_only":
+            return "job-ipa"
+        raise AssertionError(f"Unexpected compute type: {compute_type}")
+
+    snapshots = {
+        "job-stt": {
+            "type": "stt",
+            "status": "complete",
+            "progress": 100.0,
+            "result": {
+                "speaker": "Fail02",
+                "sourceWav": "audio/original/Fail02.wav",
+                "segments": [{"start": 0.0, "end": 1.0, "text": "alpha"}],
+            },
+        },
+        "job-align": {
+            "type": "compute:forced_align",
+            "status": "complete",
+            "progress": 100.0,
+            "result": {"aligned": 2},
+        },
+        "job-ipa": {
+            "type": "compute:ipa_only",
+            "status": "complete",
+            "progress": 100.0,
+            "result": {"filled": 2},
+        },
+    }
+
+    workflow = WorkflowTools(
+        project_root=tmp_path,
+        start_stt_job=fake_start_stt,
+        start_compute_job=fake_start_compute,
+        get_job_snapshot=lambda job_id: snapshots.get(job_id),
+    )
+
+    result = workflow.execute(
+        "run_full_annotation_pipeline",
+        {"speaker_id": "Fail02", "concept_list": ["1", "2"]},
+    )
+    payload = result["result"]
+
+    assert payload["speaker_id"] == "Fail02"
+    assert payload["concept_list"] == ["1", "2"]
+    assert payload["final_status"] == "complete"
+    assert [stage["stage"] for stage in payload["stages"]] == ["stt", "forced_align", "ipa"]
+    assert payload["job_ids"] == {
+        "stt": "job-stt",
+        "forced_align": "job-align",
+        "ipa": "job-ipa",
+    }
+    assert stt_calls == [("Fail02", "audio/original/Fail02.wav", None)]
+    assert start_calls == [
+        ("forced_align", {"speaker": "Fail02", "overwrite": False, "language": "ku", "padMs": 100, "emitPhonemes": True}),
+        ("ipa_only", {"speaker": "Fail02", "overwrite": False}),
+    ]
+
+
+def test_prepare_compare_mode_builds_compare_bundle_from_selected_range(tmp_path: pathlib.Path) -> None:
+    _write_concepts_csv(tmp_path)
+    _seed_annotation(tmp_path, "Fail01", concepts=["1", "2", "3"])
+    _seed_annotation(tmp_path, "Fail02", concepts=["1", "2", "3"])
+    (tmp_path / "parse-enrichments.json").write_text("{}", encoding="utf-8")
+
+    workflow = WorkflowTools(project_root=tmp_path)
+
+    workflow._parse_tools._tool_cognate_compute_preview = lambda args: {
+        "readOnly": True,
+        "previewOnly": True,
+        "summary": {"conceptCount": len(args["conceptIds"]), "speakerCount": len(args["speakers"]), "hasSimilarity": True},
+        "enrichmentsPreview": {"config": {"concepts_included": list(args["conceptIds"])}},
+    }
+    workflow._parse_tools._tool_cross_speaker_match_preview = lambda args: {
+        "readOnly": True,
+        "previewOnly": True,
+        "speaker": args["speaker"],
+        "matches": [{"conceptId": "1", "score": 0.9}],
+    }
+
+    result = workflow.execute(
+        "prepare_compare_mode",
+        {"concept_range": "1-2", "speakers": ["Fail01", "Fail02"]},
+    )
+    payload = result["result"]
+
+    assert payload["concept_ids"] == ["1", "2"]
+    assert payload["speaker_count"] == 2
+    assert set(payload["speaker_annotations"].keys()) == {"Fail01", "Fail02"}
+    assert payload["compare_preview"]["summary"]["conceptCount"] == 2
+    assert set(payload["cross_speaker_matches"].keys()) == {"Fail01", "Fail02"}
+
+
+def test_export_complete_lingpy_dataset_chains_contact_lookup_and_exports(tmp_path: pathlib.Path) -> None:
+    workflow = WorkflowTools(project_root=tmp_path)
+    calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    workflow._parse_tools._tool_contact_lexeme_lookup = lambda args: calls.append(("contact_lexeme_lookup", dict(args))) or {
+        "ok": True,
+        "dryRun": args.get("dryRun", False),
+        "configPath": str(tmp_path / "config" / "sil_contact_languages.json"),
+    }
+    workflow._parse_tools._tool_export_lingpy_tsv = lambda args: calls.append(("export_lingpy_tsv", dict(args))) or {
+        "success": True,
+        "outputPath": args["outputPath"],
+        "rowCount": 12,
+    }
+    workflow._parse_tools._tool_export_nexus = lambda args: calls.append(("export_nexus", dict(args))) or {
+        "success": True,
+        "outputPath": args["outputPath"],
+        "totalChars": 321,
+    }
+
+    result = workflow.execute(
+        "export_complete_lingpy_dataset",
+        {"with_contact_lexemes": True, "dryRun": False},
+    )
+    payload = result["result"]
+
+    assert [name for name, _args in calls] == [
+        "contact_lexeme_lookup",
+        "export_lingpy_tsv",
+        "export_nexus",
+    ]
+    assert calls[0][1]["dryRun"] is False
+    assert calls[1][1]["outputPath"] == "exports/lingpy/wordlist.tsv"
+    assert calls[2][1]["outputPath"] == "exports/lingpy/dataset.nex"
+    assert payload["final_status"] == "complete"
+    assert payload["artifacts"]["lingpy_tsv"] == "exports/lingpy/wordlist.tsv"
+    assert payload["artifacts"]["nexus"] == "exports/lingpy/dataset.nex"
+
+
+def test_workflow_tools_publish_metadata_for_macro_specs(tmp_path: pathlib.Path) -> None:
+    workflow = WorkflowTools(project_root=tmp_path)
+
+    annotation_spec = workflow.tool_spec("run_full_annotation_pipeline")
+    assert annotation_spec.supports_dry_run is True
+    assert annotation_spec.dry_run_parameter == "dryRun"
+    assert any(cond.id == "project_loaded" for cond in annotation_spec.preconditions)
+
+    compare_spec = workflow.tool_spec("prepare_compare_mode")
+    assert compare_spec.mutability == "read_only"
+    assert any(cond.id == "compare_inputs_available" for cond in compare_spec.postconditions)
+
+    export_spec = workflow.tool_spec("export_complete_lingpy_dataset")
+    assert export_spec.mutability == "mutating"
+    assert any(cond.id == "export_bundle_written" for cond in export_spec.postconditions)
+
+    assert workflow.tool_names() == [
+        "export_complete_lingpy_dataset",
+        "prepare_compare_mode",
+        "run_full_annotation_pipeline",
+    ]

--- a/python/ai/workflow_tools.py
+++ b/python/ai/workflow_tools.py
@@ -1,0 +1,719 @@
+#!/usr/bin/env python3
+"""High-level PARSE workflow macros for agent-friendly MCP usage.
+
+These tools compose the existing low-level ParseChatTools handlers into a small
+set of end-to-end workflows. They intentionally live outside chat_tools.py so
+that the low-level 47-tool surface remains stable and focused, while agents get
+safe, discoverable one-call workflows.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from .chat_tools import (
+    ChatToolExecutionError,
+    ChatToolSpec,
+    ChatToolValidationError,
+    ParseChatTools,
+    TOOL_CONDITION_KIND_FILE_PRESENCE,
+    TOOL_CONDITION_KIND_FILESYSTEM_WRITE,
+    TOOL_CONDITION_KIND_INPUT_SHAPE,
+    TOOL_CONDITION_KIND_JOB_STATE,
+    TOOL_CONDITION_KIND_PROJECT_STATE,
+    TOOL_MUTABILITY_MUTATING,
+    TOOL_MUTABILITY_READ_ONLY,
+    _deepcopy_jsonable,
+    _normalize_concept_id,
+    _normalize_space,
+    _project_loaded_condition,
+    _read_json_file,
+    _tool_condition,
+    _utc_now_iso,
+    _validate_schema,
+)
+
+DEFAULT_MCP_WORKFLOW_TOOL_NAMES: Tuple[str, ...] = (
+    "run_full_annotation_pipeline",
+    "prepare_compare_mode",
+    "export_complete_lingpy_dataset",
+)
+
+_TERMINAL_JOB_STATUSES = {"complete", "completed", "done", "error", "failed", "not_found", "invalid_job_type"}
+
+
+class WorkflowTools:
+    """Composite PARSE workflow macros built on top of ParseChatTools handlers."""
+
+    def __init__(
+        self,
+        project_root: Path,
+        config_path: Optional[Path] = None,
+        docs_root: Optional[Path] = None,
+        start_stt_job: Optional[Callable[[str, str, Optional[str]], str]] = None,
+        get_job_snapshot: Optional[Callable[[str], Optional[Dict[str, Any]]]] = None,
+        external_read_roots: Optional[Sequence[Path]] = None,
+        memory_path: Optional[Path] = None,
+        onboard_speaker: Optional[Callable[[str, Path, Optional[Path], bool], Dict[str, Any]]] = None,
+        start_compute_job: Optional[Callable[[str, Dict[str, Any]], str]] = None,
+        pipeline_state: Optional[Callable[[str], Dict[str, Any]]] = None,
+        start_normalize_job: Optional[Callable[[str, Optional[str]], str]] = None,
+        list_active_jobs: Optional[Callable[[], List[Dict[str, Any]]]] = None,
+    ) -> None:
+        self.project_root = Path(project_root).expanduser().resolve()
+        self._parse_tools = ParseChatTools(
+            project_root=self.project_root,
+            config_path=config_path,
+            docs_root=docs_root,
+            start_stt_job=start_stt_job,
+            get_job_snapshot=get_job_snapshot,
+            external_read_roots=external_read_roots,
+            memory_path=memory_path,
+            onboard_speaker=onboard_speaker,
+            start_compute_job=start_compute_job,
+            pipeline_state=pipeline_state,
+            start_normalize_job=start_normalize_job,
+            list_active_jobs=list_active_jobs,
+        )
+        self.concepts_path = self.project_root / "concepts.csv"
+        self.annotations_dir = self.project_root / "annotations"
+        self.enrichments_path = self.project_root / "parse-enrichments.json"
+
+        self._tool_specs: Dict[str, ChatToolSpec] = {
+            "run_full_annotation_pipeline": ChatToolSpec(
+                name="run_full_annotation_pipeline",
+                description=(
+                    "Run the high-level annotation workflow for one speaker: STT, forced alignment, "
+                    "then acoustic IPA transcription. The workflow uses the existing low-level tool "
+                    "handlers internally and waits for each stage to reach a terminal job status. "
+                    "concept_list is used for reporting/summary, not for concept-scoped compute."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["speaker_id", "concept_list"],
+                    "properties": {
+                        "speaker_id": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "concept_list": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 500,
+                            "items": {"type": "string", "minLength": 1, "maxLength": 64},
+                            "description": "Concept IDs used for workflow reporting and post-run filtering.",
+                        },
+                        "dryRun": {"type": "boolean", "description": "Validate inputs and preview the planned workflow without starting jobs."},
+                    },
+                },
+                mutability=TOOL_MUTABILITY_MUTATING,
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "speaker_audio_available",
+                        "The requested speaker must resolve to a readable source audio file.",
+                        kind=TOOL_CONDITION_KIND_FILE_PRESENCE,
+                    ),
+                    _tool_condition(
+                        "concept_list_provided",
+                        "The caller must provide a non-empty concept_list for workflow reporting.",
+                        kind=TOOL_CONDITION_KIND_INPUT_SHAPE,
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "annotation_workflow_completed",
+                        "When dryRun=false, STT, forced alignment, and acoustic IPA are each started and polled to a terminal status.",
+                        kind=TOOL_CONDITION_KIND_JOB_STATE,
+                    ),
+                ),
+            ),
+            "prepare_compare_mode": ChatToolSpec(
+                name="prepare_compare_mode",
+                description=(
+                    "Prepare a compare-mode bundle for a concept range across multiple speakers. Loads the "
+                    "requested annotations, computes a fresh cognate preview, and derives cross-speaker "
+                    "match previews from inline segments built from the selected concept windows."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["concept_range", "speakers"],
+                    "properties": {
+                        "concept_range": {
+                            "description": "Either a range string like '1-25' or an explicit concept ID list.",
+                        },
+                        "speakers": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 200,
+                            "items": {"type": "string", "minLength": 1, "maxLength": 200},
+                        },
+                        "dryRun": {"type": "boolean", "description": "Preview the resolved speaker + concept scope without computing the full compare bundle."},
+                    },
+                },
+                mutability=TOOL_MUTABILITY_READ_ONLY,
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "compare_scope_provided",
+                        "The caller must provide a concept_range and at least one speaker.",
+                        kind=TOOL_CONDITION_KIND_INPUT_SHAPE,
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "compare_inputs_available",
+                        "The tool returns a structured compare bundle for the selected concepts and speakers.",
+                        kind=TOOL_CONDITION_KIND_PROJECT_STATE,
+                    ),
+                ),
+            ),
+            "export_complete_lingpy_dataset": ChatToolSpec(
+                name="export_complete_lingpy_dataset",
+                description=(
+                    "Export a complete PARSE phylogenetics bundle using the existing low-level export tools. "
+                    "Writes LingPy TSV and NEXUS under exports/lingpy/, and can optionally refresh contact "
+                    "lexeme references before export."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "with_contact_lexemes": {
+                            "type": "boolean",
+                            "description": "If true, run contact_lexeme_lookup before the export steps.",
+                        },
+                        "dryRun": {"type": "boolean", "description": "Preview the export bundle and planned artifacts without writing files."},
+                    },
+                },
+                mutability=TOOL_MUTABILITY_MUTATING,
+                supports_dry_run=True,
+                dry_run_parameter="dryRun",
+                preconditions=(
+                    _project_loaded_condition(),
+                    _tool_condition(
+                        "annotations_available_for_export",
+                        "At least some annotated project data must exist before exporting LingPy artifacts.",
+                        kind=TOOL_CONDITION_KIND_PROJECT_STATE,
+                    ),
+                ),
+                postconditions=(
+                    _tool_condition(
+                        "export_bundle_written",
+                        "When dryRun=false, the LingPy TSV and NEXUS outputs are written inside the project export directory.",
+                        kind=TOOL_CONDITION_KIND_FILESYSTEM_WRITE,
+                    ),
+                ),
+            ),
+        }
+
+    def iter_tool_specs(self) -> Tuple[ChatToolSpec, ...]:
+        return tuple(self._tool_specs[name] for name in self.tool_names())
+
+    def tool_spec(self, tool_name: str) -> ChatToolSpec:
+        name = str(tool_name or "").strip()
+        if name not in self._tool_specs:
+            raise ChatToolValidationError("Tool is not allowlisted: {0}".format(name))
+        return self._tool_specs[name]
+
+    def tool_names(self) -> List[str]:
+        return sorted(self._tool_specs.keys())
+
+    @classmethod
+    def get_all_tool_names(cls) -> List[str]:
+        return list(DEFAULT_MCP_WORKFLOW_TOOL_NAMES)
+
+    def execute(self, tool_name: str, raw_args: Any) -> Dict[str, Any]:
+        name = str(tool_name or "").strip()
+        if name not in self._tool_specs:
+            raise ChatToolValidationError("Tool is not allowlisted: {0}".format(name))
+
+        args = raw_args
+        if args is None:
+            args = {}
+        if isinstance(args, str):
+            text = args.strip()
+            if not text:
+                args = {}
+            else:
+                try:
+                    args = json.loads(text)
+                except json.JSONDecodeError as exc:
+                    raise ChatToolValidationError("Tool arguments must be valid JSON: {0}".format(exc))
+        if not isinstance(args, dict):
+            raise ChatToolValidationError("Tool arguments must be a JSON object")
+
+        spec = self._tool_specs[name]
+        _validate_schema(args, spec.parameters)
+
+        handler = getattr(self, "_tool_{0}".format(name), None)
+        if not callable(handler):
+            raise ChatToolExecutionError("Tool handler missing for {0}".format(name))
+
+        result = handler(args)
+        if not isinstance(result, dict):
+            raise ChatToolExecutionError("Tool handler must return a JSON object")
+
+        return {"tool": name, "ok": True, "result": self._finalize_result(spec, result)}
+
+    def _finalize_result(self, spec: ChatToolSpec, payload: Dict[str, Any]) -> Dict[str, Any]:
+        result = _deepcopy_jsonable(payload)
+        if spec.mutability == TOOL_MUTABILITY_READ_ONLY:
+            result.setdefault("readOnly", True)
+            result.setdefault("previewOnly", True)
+            result.setdefault("mode", "read-only")
+            return result
+
+        preview_only = bool(result.get("previewOnly") or result.get("dryRun"))
+        result.setdefault("previewOnly", preview_only)
+        result.setdefault("readOnly", preview_only)
+        result.setdefault("mode", "read-only" if bool(result.get("readOnly")) else "write-allowed")
+        return result
+
+    def _normalize_speaker_id(self, raw_value: Any) -> str:
+        return self._parse_tools._normalize_speaker(raw_value)
+
+    def _annotation_path_for_speaker(self, speaker_id: str) -> Path:
+        path = self._parse_tools._annotation_path_for_speaker(speaker_id)
+        if path is None:
+            raise ChatToolExecutionError("Annotation path could not be resolved for speaker: {0}".format(speaker_id))
+        return path
+
+    def _load_annotation(self, speaker_id: str) -> Dict[str, Any]:
+        path = self._annotation_path_for_speaker(speaker_id)
+        payload = _read_json_file(path, {})
+        if not isinstance(payload, dict):
+            raise ChatToolExecutionError("Annotation file is not a JSON object for speaker: {0}".format(speaker_id))
+        return payload
+
+    def _resolve_source_wav(self, speaker_id: str) -> str:
+        annotation = self._load_annotation(speaker_id)
+        source_audio = str(annotation.get("source_audio") or "").strip()
+        if source_audio:
+            resolved = self.project_root / source_audio
+            if resolved.exists():
+                return source_audio
+
+        source_index = _read_json_file(self._parse_tools.source_index_path, {})
+        speakers_block = source_index.get("speakers") if isinstance(source_index, dict) else {}
+        if isinstance(speakers_block, dict):
+            speaker_entry = speakers_block.get(speaker_id)
+            if isinstance(speaker_entry, dict):
+                source_entries = speaker_entry.get("source_wavs")
+                if not isinstance(source_entries, list):
+                    source_entries = speaker_entry.get("source_files")
+                if isinstance(source_entries, list):
+                    chosen: Optional[Dict[str, Any]] = None
+                    for entry in source_entries:
+                        if isinstance(entry, dict) and entry.get("is_primary"):
+                            chosen = entry
+                            break
+                    if chosen is None:
+                        for entry in source_entries:
+                            if isinstance(entry, dict):
+                                chosen = entry
+                                break
+                    if isinstance(chosen, dict):
+                        raw_path = str(chosen.get("path") or chosen.get("file") or "").strip()
+                        filename = str(chosen.get("filename") or "").strip()
+                        candidates = [raw_path]
+                        if filename:
+                            candidates.extend(
+                                [
+                                    "audio/original/{0}/{1}".format(speaker_id, filename),
+                                    "audio/working/{0}/{1}".format(speaker_id, filename),
+                                ]
+                            )
+                        for candidate in candidates:
+                            if not candidate:
+                                continue
+                            resolved = self.project_root / candidate
+                            if resolved.exists():
+                                return candidate
+
+        raise ChatToolExecutionError("No readable source audio could be resolved for speaker: {0}".format(speaker_id))
+
+    def _resolve_concept_ids(self, concept_range: Any) -> List[str]:
+        if isinstance(concept_range, list):
+            concept_ids: List[str] = []
+            seen: set[str] = set()
+            for raw_value in concept_range:
+                concept_id = _normalize_concept_id(raw_value)
+                if concept_id and concept_id not in seen:
+                    seen.add(concept_id)
+                    concept_ids.append(concept_id)
+            if concept_ids:
+                return concept_ids
+            raise ChatToolValidationError("concept_range list must contain at least one concept ID")
+
+        text = _normalize_space(concept_range)
+        if not text:
+            raise ChatToolValidationError("concept_range is required")
+
+        if text.isdigit():
+            return [text]
+
+        if "-" in text:
+            start_text, end_text = [piece.strip() for piece in text.split("-", 1)]
+            if not start_text or not end_text or not start_text.isdigit() or not end_text.isdigit():
+                raise ChatToolValidationError("concept_range must be a list, a single concept ID, or a numeric range like '1-25'")
+            start_value = int(start_text)
+            end_value = int(end_text)
+            if end_value < start_value:
+                raise ChatToolValidationError("concept_range end must be >= start")
+            return [str(value) for value in range(start_value, end_value + 1)]
+
+        raise ChatToolValidationError("concept_range must be a list, a single concept ID, or a numeric range like '1-25'")
+
+    def _load_project_concepts(self) -> List[Dict[str, Any]]:
+        return self._parse_tools._load_project_concepts()
+
+    def _first_overlapping_text(self, intervals: Sequence[Dict[str, Any]], start: float, end: float) -> str:
+        for interval in intervals:
+            interval_start = float(interval.get("start", 0.0) or 0.0)
+            interval_end = float(interval.get("end", interval_start) or interval_start)
+            if interval_end <= start or interval_start >= end:
+                continue
+            text = _normalize_space(interval.get("text"))
+            if text:
+                return text
+        return ""
+
+    def _inline_segments_from_annotation(self, annotation_payload: Dict[str, Any], concept_ids: Sequence[str]) -> List[Dict[str, Any]]:
+        concept_intervals = self._parse_tools._tier_intervals(annotation_payload, "concept")
+        ortho_intervals = self._parse_tools._tier_intervals(annotation_payload, "ortho")
+        ipa_intervals = self._parse_tools._tier_intervals(annotation_payload, "ipa")
+        concept_filter = {_normalize_concept_id(value) for value in concept_ids}
+        segments: List[Dict[str, Any]] = []
+        for concept_interval in concept_intervals:
+            concept_id = _normalize_concept_id(concept_interval.get("text"))
+            if concept_filter and concept_id not in concept_filter:
+                continue
+            start = float(concept_interval.get("start", 0.0) or 0.0)
+            end = float(concept_interval.get("end", start) or start)
+            ortho_text = self._first_overlapping_text(ortho_intervals, start, end)
+            ipa_text = self._first_overlapping_text(ipa_intervals, start, end)
+            segments.append(
+                {
+                    "start": start,
+                    "end": end,
+                    "text": ortho_text or concept_id,
+                    "ortho": ortho_text,
+                    "ipa": ipa_text,
+                    "conceptId": concept_id,
+                }
+            )
+        return segments
+
+    def _poll_tool_status(
+        self,
+        status_handler: Callable[[Dict[str, Any]], Dict[str, Any]],
+        *,
+        job_id: str,
+        include_segments: bool = False,
+        max_polls: int = 1200,
+        sleep_sec: float = 0.5,
+    ) -> Dict[str, Any]:
+        status_args: Dict[str, Any] = {"jobId": job_id}
+        if include_segments:
+            status_args["includeSegments"] = True
+        last_payload: Dict[str, Any] = {}
+        polls = max(1, int(max_polls))
+        for poll_index in range(polls):
+            payload = status_handler(status_args)
+            last_payload = payload
+            status = str(payload.get("status") or "").strip().lower()
+            if status in _TERMINAL_JOB_STATUSES:
+                return payload
+            if sleep_sec > 0 and poll_index + 1 < polls:
+                time.sleep(sleep_sec)
+        return last_payload
+
+    def _terminal_stage_status(self, payload: Dict[str, Any]) -> str:
+        status = str(payload.get("status") or "").strip().lower()
+        if status in {"complete", "completed", "done"}:
+            return "complete"
+        return status or "unknown"
+
+    def _is_complete_stage(self, payload: Dict[str, Any]) -> bool:
+        return self._terminal_stage_status(payload) == "complete"
+
+    def _tool_run_full_annotation_pipeline(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        speaker_id = self._normalize_speaker_id(args.get("speaker_id"))
+        concept_list_raw = args.get("concept_list")
+        if not isinstance(concept_list_raw, list) or not concept_list_raw:
+            raise ChatToolValidationError("concept_list must be a non-empty list")
+        concept_list: List[str] = []
+        seen_concepts: set[str] = set()
+        for raw_value in concept_list_raw:
+            concept_id = _normalize_concept_id(raw_value)
+            if concept_id and concept_id not in seen_concepts:
+                seen_concepts.add(concept_id)
+                concept_list.append(concept_id)
+        if not concept_list:
+            raise ChatToolValidationError("concept_list must contain at least one valid concept ID")
+
+        source_wav = self._resolve_source_wav(speaker_id)
+        pipeline_state = None
+        if self._parse_tools._pipeline_state is not None:
+            try:
+                pipeline_state = self._parse_tools._tool_pipeline_state_read({"speaker": speaker_id})
+            except Exception:
+                pipeline_state = None
+
+        if bool(args.get("dryRun", False)):
+            return {
+                "readOnly": True,
+                "previewOnly": True,
+                "dryRun": True,
+                "speaker_id": speaker_id,
+                "concept_list": concept_list,
+                "source_wav": source_wav,
+                "stages": [
+                    {"stage": "stt", "tool": "stt_start", "status": "planned"},
+                    {"stage": "forced_align", "tool": "forced_align_start", "status": "planned"},
+                    {"stage": "ipa", "tool": "ipa_transcribe_acoustic_start", "status": "planned"},
+                ],
+                "pipeline_state": pipeline_state,
+                "note": "Dry run only. concept_list is used for reporting; the underlying workflow remains speaker-wide.",
+            }
+
+        stt_started = self._parse_tools._tool_stt_start({"speaker": speaker_id, "sourceWav": source_wav})
+        stt_job_id = str(stt_started.get("jobId") or "").strip()
+        if not stt_job_id:
+            raise ChatToolExecutionError("STT stage did not return a jobId")
+        stt_status = self._poll_tool_status(
+            self._parse_tools._tool_stt_status,
+            job_id=stt_job_id,
+            include_segments=True,
+        )
+        stages: List[Dict[str, Any]] = [
+            {"stage": "stt", "tool": "stt_start", "status": self._terminal_stage_status(stt_status), "payload": stt_status}
+        ]
+        if not self._is_complete_stage(stt_status):
+            return {
+                "speaker_id": speaker_id,
+                "concept_list": concept_list,
+                "source_wav": source_wav,
+                "job_ids": {"stt": stt_job_id},
+                "stages": stages,
+                "annotation_summary": None,
+                "final_status": self._terminal_stage_status(stt_status),
+                "completed_at": _utc_now_iso(),
+            }
+
+        align_started = self._parse_tools._tool_forced_align_start({"speaker": speaker_id})
+        align_job_id = str(align_started.get("jobId") or "").strip()
+        if not align_job_id:
+            raise ChatToolExecutionError("forced_align stage did not return a jobId")
+        align_status = self._poll_tool_status(
+            self._parse_tools._tool_forced_align_status,
+            job_id=align_job_id,
+        )
+        stages.append({
+            "stage": "forced_align",
+            "tool": "forced_align_start",
+            "status": self._terminal_stage_status(align_status),
+            "payload": align_status,
+        })
+        if not self._is_complete_stage(align_status):
+            return {
+                "speaker_id": speaker_id,
+                "concept_list": concept_list,
+                "source_wav": source_wav,
+                "job_ids": {"stt": stt_job_id, "forced_align": align_job_id},
+                "stages": stages,
+                "annotation_summary": None,
+                "final_status": self._terminal_stage_status(align_status),
+                "completed_at": _utc_now_iso(),
+            }
+
+        ipa_started = self._parse_tools._tool_ipa_transcribe_acoustic_start({"speaker": speaker_id})
+        ipa_job_id = str(ipa_started.get("jobId") or "").strip()
+        if not ipa_job_id:
+            raise ChatToolExecutionError("ipa stage did not return a jobId")
+        ipa_status = self._poll_tool_status(
+            self._parse_tools._tool_ipa_transcribe_acoustic_status,
+            job_id=ipa_job_id,
+        )
+        stages.append({
+            "stage": "ipa",
+            "tool": "ipa_transcribe_acoustic_start",
+            "status": self._terminal_stage_status(ipa_status),
+            "payload": ipa_status,
+        })
+
+        annotation_summary = self._parse_tools._tool_annotation_read(
+            {
+                "speaker": speaker_id,
+                "conceptIds": concept_list,
+                "includeTiers": ["ipa", "ortho", "concept", "speaker"],
+                "maxIntervals": 5000,
+            }
+        )
+        final_status = "complete" if self._is_complete_stage(ipa_status) else self._terminal_stage_status(ipa_status)
+
+        return {
+            "speaker_id": speaker_id,
+            "concept_list": concept_list,
+            "source_wav": source_wav,
+            "job_ids": {
+                "stt": stt_job_id,
+                "forced_align": align_job_id,
+                "ipa": ipa_job_id,
+            },
+            "stages": stages,
+            "annotation_summary": annotation_summary,
+            "final_status": final_status,
+            "completed_at": _utc_now_iso(),
+        }
+
+    def _tool_prepare_compare_mode(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        concept_ids = self._resolve_concept_ids(args.get("concept_range"))
+        speakers_raw = args.get("speakers")
+        if not isinstance(speakers_raw, list) or not speakers_raw:
+            raise ChatToolValidationError("speakers must be a non-empty list")
+        speakers: List[str] = []
+        seen_speakers: set[str] = set()
+        for raw_speaker in speakers_raw:
+            speaker_id = self._normalize_speaker_id(raw_speaker)
+            if speaker_id not in seen_speakers:
+                seen_speakers.add(speaker_id)
+                speakers.append(speaker_id)
+
+        available = set(self._parse_tools._tool_speakers_list({}).get("speakers") or [])
+        missing = [speaker for speaker in speakers if speaker not in available]
+        if missing:
+            raise ChatToolExecutionError("Unknown speakers for compare workflow: {0}".format(", ".join(missing)))
+
+        if bool(args.get("dryRun", False)):
+            return {
+                "readOnly": True,
+                "previewOnly": True,
+                "dryRun": True,
+                "concept_ids": concept_ids,
+                "speakers": speakers,
+                "speaker_count": len(speakers),
+                "note": "Dry run only. No compare preview computations were executed.",
+            }
+
+        speaker_annotations: Dict[str, Any] = {}
+        inline_segments_by_speaker: Dict[str, List[Dict[str, Any]]] = {}
+        for speaker_id in speakers:
+            annotation_payload = self._parse_tools._tool_annotation_read(
+                {
+                    "speaker": speaker_id,
+                    "conceptIds": concept_ids,
+                    "includeTiers": ["ipa", "ortho", "concept", "speaker"],
+                    "maxIntervals": 5000,
+                }
+            )
+            speaker_annotations[speaker_id] = annotation_payload
+            try:
+                annotation_record = self._load_annotation(speaker_id)
+                inline_segments_by_speaker[speaker_id] = self._inline_segments_from_annotation(annotation_record, concept_ids)
+            except Exception:
+                inline_segments_by_speaker[speaker_id] = []
+
+        compare_preview = self._parse_tools._tool_cognate_compute_preview(
+            {
+                "speakers": speakers,
+                "conceptIds": concept_ids,
+                "includeSimilarity": True,
+                "maxConcepts": max(1, len(concept_ids)),
+            }
+        )
+
+        cross_speaker_matches: Dict[str, Any] = {}
+        for speaker_id in speakers:
+            segments = inline_segments_by_speaker.get(speaker_id) or []
+            if not segments:
+                cross_speaker_matches[speaker_id] = {
+                    "readOnly": True,
+                    "previewOnly": True,
+                    "status": "no_segments",
+                    "speaker": speaker_id,
+                    "matches": [],
+                }
+                continue
+            cross_speaker_matches[speaker_id] = self._parse_tools._tool_cross_speaker_match_preview(
+                {
+                    "speaker": speaker_id,
+                    "sttSegments": segments,
+                    "topK": 3,
+                    "maxConcepts": max(1, len(concept_ids)),
+                }
+            )
+
+        return {
+            "readOnly": True,
+            "previewOnly": True,
+            "concept_ids": concept_ids,
+            "speaker_count": len(speakers),
+            "speakers": speakers,
+            "speaker_annotations": speaker_annotations,
+            "compare_preview": compare_preview,
+            "cross_speaker_matches": cross_speaker_matches,
+            "prepared_at": _utc_now_iso(),
+        }
+
+    def _tool_export_complete_lingpy_dataset(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        with_contact_lexemes = bool(args.get("with_contact_lexemes", True))
+        dry_run = bool(args.get("dryRun", False))
+        export_dir = "exports/lingpy"
+        lingpy_path = "{0}/wordlist.tsv".format(export_dir)
+        nexus_path = "{0}/dataset.nex".format(export_dir)
+
+        stages: List[Dict[str, Any]] = []
+        artifacts = {
+            "lingpy_tsv": lingpy_path,
+            "nexus": nexus_path,
+        }
+
+        if with_contact_lexemes:
+            contact_payload = self._parse_tools._tool_contact_lexeme_lookup({"dryRun": dry_run})
+            stages.append({
+                "stage": "contact_lexemes",
+                "tool": "contact_lexeme_lookup",
+                "status": "preview" if dry_run else "complete",
+                "payload": contact_payload,
+            })
+
+        lingpy_payload = self._parse_tools._tool_export_lingpy_tsv({"outputPath": lingpy_path, "dryRun": dry_run})
+        stages.append({
+            "stage": "lingpy_tsv",
+            "tool": "export_lingpy_tsv",
+            "status": "preview" if dry_run else "complete",
+            "payload": lingpy_payload,
+        })
+
+        nexus_payload = self._parse_tools._tool_export_nexus({"outputPath": nexus_path, "dryRun": dry_run})
+        stages.append({
+            "stage": "nexus",
+            "tool": "export_nexus",
+            "status": "preview" if dry_run else "complete",
+            "payload": nexus_payload,
+        })
+
+        return {
+            "dryRun": dry_run,
+            "readOnly": dry_run,
+            "previewOnly": dry_run,
+            "with_contact_lexemes": with_contact_lexemes,
+            "artifacts": artifacts,
+            "stages": stages,
+            "final_status": "preview" if dry_run else "complete",
+            "exported_at": _utc_now_iso(),
+        }
+
+
+__all__ = [
+    "DEFAULT_MCP_WORKFLOW_TOOL_NAMES",
+    "WorkflowTools",
+]

--- a/python/ai/workflow_tools.py
+++ b/python/ai/workflow_tools.py
@@ -444,6 +444,109 @@ class WorkflowTools:
     def _is_complete_stage(self, payload: Dict[str, Any]) -> bool:
         return self._terminal_stage_status(payload) == "complete"
 
+    def _stage_progress_percent(self, completed_stages: int, total_stages: int) -> float:
+        if total_stages <= 0:
+            return 0.0
+        return round((float(completed_stages) / float(total_stages)) * 100.0, 1)
+
+    def _workflow_progress_payload(
+        self,
+        *,
+        completed_stages: int,
+        total_stages: int,
+        current_stage: Optional[str],
+        failed_step: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        normalized_completed = max(0, min(int(completed_stages), int(total_stages)))
+        percent = self._stage_progress_percent(normalized_completed, total_stages)
+        done = failed_step is None and normalized_completed >= int(total_stages) and current_stage is None
+        return {
+            "completedStages": normalized_completed,
+            "totalStages": int(total_stages),
+            "percent": 100.0 if done else percent,
+            "currentStage": current_stage,
+            "failedStep": failed_step,
+            "done": done,
+        }
+
+    def _stage_event(
+        self,
+        *,
+        event: str,
+        stage: str,
+        tool: str,
+        completed_stages: int,
+        total_stages: int,
+        status: Optional[str] = None,
+        job_id: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = {
+            "event": event,
+            "stage": stage,
+            "tool": tool,
+            "progressPercent": self._stage_progress_percent(completed_stages, total_stages),
+            "at": _utc_now_iso(),
+        }
+        if status is not None:
+            payload["status"] = status
+        if job_id is not None:
+            payload["jobId"] = job_id
+        if message:
+            payload["message"] = message
+        return payload
+
+    def _workflow_failure_payload(
+        self,
+        *,
+        speaker_id: str,
+        concept_list: Sequence[str],
+        source_wav: Optional[str],
+        stages: Sequence[Dict[str, Any]],
+        events: Sequence[Dict[str, Any]],
+        job_ids: Dict[str, str],
+        completed_stages: int,
+        total_stages: int,
+        failed_step: str,
+        failed_tool: str,
+        failed_payload: Optional[Dict[str, Any]] = None,
+        error_message: Optional[str] = None,
+        error_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        stage_status = self._terminal_stage_status(failed_payload or {})
+        resolved_message = str(
+            error_message
+            or ((failed_payload or {}).get("error") if isinstance(failed_payload, dict) else "")
+            or ((failed_payload or {}).get("message") if isinstance(failed_payload, dict) else "")
+            or "Workflow stage failed"
+        ).strip()
+        resolved_type = str(error_type or "workflow_stage_failure").strip() or "workflow_stage_failure"
+        return {
+            "speaker_id": speaker_id,
+            "concept_list": list(concept_list),
+            "source_wav": source_wav,
+            "job_ids": dict(job_ids),
+            "stages": list(stages),
+            "events": list(events),
+            "progress": self._workflow_progress_payload(
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                current_stage=failed_step,
+                failed_step=failed_step,
+            ),
+            "annotation_summary": None,
+            "final_status": "error",
+            "failedStep": failed_step,
+            "failedTool": failed_tool,
+            "error": {
+                "type": resolved_type,
+                "status": stage_status,
+                "message": resolved_message,
+                "payload": _deepcopy_jsonable(failed_payload) if isinstance(failed_payload, dict) else None,
+            },
+            "completed_at": _utc_now_iso(),
+        }
+
     def _tool_run_full_annotation_pipeline(self, args: Dict[str, Any]) -> Dict[str, Any]:
         speaker_id = self._normalize_speaker_id(args.get("speaker_id"))
         concept_list_raw = args.get("concept_list")
@@ -459,7 +562,41 @@ class WorkflowTools:
         if not concept_list:
             raise ChatToolValidationError("concept_list must contain at least one valid concept ID")
 
-        source_wav = self._resolve_source_wav(speaker_id)
+        total_stages = 3
+        completed_stages = 0
+        events: List[Dict[str, Any]] = []
+        stages: List[Dict[str, Any]] = []
+        job_ids: Dict[str, str] = {}
+
+        try:
+            source_wav = self._resolve_source_wav(speaker_id)
+        except Exception as exc:
+            events.append(
+                self._stage_event(
+                    event="stage_failed",
+                    stage="preflight",
+                    tool="source_audio_resolve",
+                    completed_stages=0,
+                    total_stages=total_stages,
+                    status="error",
+                    message=str(exc),
+                )
+            )
+            return self._workflow_failure_payload(
+                speaker_id=speaker_id,
+                concept_list=concept_list,
+                source_wav=None,
+                stages=stages,
+                events=events,
+                job_ids=job_ids,
+                completed_stages=0,
+                total_stages=total_stages,
+                failed_step="preflight",
+                failed_tool="source_audio_resolve",
+                error_message=str(exc),
+                error_type=type(exc).__name__,
+            )
+
         pipeline_state = None
         if self._parse_tools._pipeline_state is not None:
             try:
@@ -480,97 +617,351 @@ class WorkflowTools:
                     {"stage": "forced_align", "tool": "forced_align_start", "status": "planned"},
                     {"stage": "ipa", "tool": "ipa_transcribe_acoustic_start", "status": "planned"},
                 ],
+                "events": [
+                    self._stage_event(event="stage_planned", stage="stt", tool="stt_start", completed_stages=0, total_stages=total_stages, status="planned"),
+                    self._stage_event(event="stage_planned", stage="forced_align", tool="forced_align_start", completed_stages=0, total_stages=total_stages, status="planned"),
+                    self._stage_event(event="stage_planned", stage="ipa", tool="ipa_transcribe_acoustic_start", completed_stages=0, total_stages=total_stages, status="planned"),
+                ],
+                "progress": self._workflow_progress_payload(
+                    completed_stages=0,
+                    total_stages=total_stages,
+                    current_stage="stt",
+                ),
                 "pipeline_state": pipeline_state,
                 "note": "Dry run only. concept_list is used for reporting; the underlying workflow remains speaker-wide.",
             }
 
-        stt_started = self._parse_tools._tool_stt_start({"speaker": speaker_id, "sourceWav": source_wav})
-        stt_job_id = str(stt_started.get("jobId") or "").strip()
-        if not stt_job_id:
-            raise ChatToolExecutionError("STT stage did not return a jobId")
-        stt_status = self._poll_tool_status(
-            self._parse_tools._tool_stt_status,
-            job_id=stt_job_id,
-            include_segments=True,
+        events.append(
+            self._stage_event(
+                event="stage_started",
+                stage="stt",
+                tool="stt_start",
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                status="running",
+            )
         )
-        stages: List[Dict[str, Any]] = [
-            {"stage": "stt", "tool": "stt_start", "status": self._terminal_stage_status(stt_status), "payload": stt_status}
-        ]
-        if not self._is_complete_stage(stt_status):
-            return {
-                "speaker_id": speaker_id,
-                "concept_list": concept_list,
-                "source_wav": source_wav,
-                "job_ids": {"stt": stt_job_id},
-                "stages": stages,
-                "annotation_summary": None,
-                "final_status": self._terminal_stage_status(stt_status),
-                "completed_at": _utc_now_iso(),
-            }
+        try:
+            stt_started = self._parse_tools._tool_stt_start({"speaker": speaker_id, "sourceWav": source_wav})
+            stt_job_id = str(stt_started.get("jobId") or "").strip()
+            if not stt_job_id:
+                raise ChatToolExecutionError("STT stage did not return a jobId")
+            job_ids["stt"] = stt_job_id
+            stt_status = self._poll_tool_status(
+                self._parse_tools._tool_stt_status,
+                job_id=stt_job_id,
+                include_segments=True,
+            )
+        except Exception as exc:
+            events.append(
+                self._stage_event(
+                    event="stage_failed",
+                    stage="stt",
+                    tool="stt_start",
+                    completed_stages=completed_stages,
+                    total_stages=total_stages,
+                    status="error",
+                    job_id=job_ids.get("stt"),
+                    message=str(exc),
+                )
+            )
+            return self._workflow_failure_payload(
+                speaker_id=speaker_id,
+                concept_list=concept_list,
+                source_wav=source_wav,
+                stages=stages,
+                events=events,
+                job_ids=job_ids,
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                failed_step="stt",
+                failed_tool="stt_start",
+                error_message=str(exc),
+                error_type=type(exc).__name__,
+            )
 
-        align_started = self._parse_tools._tool_forced_align_start({"speaker": speaker_id})
-        align_job_id = str(align_started.get("jobId") or "").strip()
-        if not align_job_id:
-            raise ChatToolExecutionError("forced_align stage did not return a jobId")
-        align_status = self._poll_tool_status(
-            self._parse_tools._tool_forced_align_status,
-            job_id=align_job_id,
+        stt_stage_status = self._terminal_stage_status(stt_status)
+        stages.append({"stage": "stt", "tool": "stt_start", "status": stt_stage_status, "payload": stt_status})
+        if not self._is_complete_stage(stt_status):
+            events.append(
+                self._stage_event(
+                    event="stage_failed",
+                    stage="stt",
+                    tool="stt_status",
+                    completed_stages=completed_stages,
+                    total_stages=total_stages,
+                    status=stt_stage_status,
+                    job_id=job_ids.get("stt"),
+                    message=str(stt_status.get("error") or stt_status.get("message") or stt_stage_status),
+                )
+            )
+            return self._workflow_failure_payload(
+                speaker_id=speaker_id,
+                concept_list=concept_list,
+                source_wav=source_wav,
+                stages=stages,
+                events=events,
+                job_ids=job_ids,
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                failed_step="stt",
+                failed_tool="stt_status",
+                failed_payload=stt_status,
+                error_type="workflow_stage_status",
+            )
+        completed_stages += 1
+        events.append(
+            self._stage_event(
+                event="stage_completed",
+                stage="stt",
+                tool="stt_status",
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                status=stt_stage_status,
+                job_id=job_ids.get("stt"),
+            )
         )
+
+        events.append(
+            self._stage_event(
+                event="stage_started",
+                stage="forced_align",
+                tool="forced_align_start",
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                status="running",
+            )
+        )
+        try:
+            align_started = self._parse_tools._tool_forced_align_start({"speaker": speaker_id})
+            align_job_id = str(align_started.get("jobId") or "").strip()
+            if not align_job_id:
+                raise ChatToolExecutionError("forced_align stage did not return a jobId")
+            job_ids["forced_align"] = align_job_id
+            align_status = self._poll_tool_status(
+                self._parse_tools._tool_forced_align_status,
+                job_id=align_job_id,
+            )
+        except Exception as exc:
+            events.append(
+                self._stage_event(
+                    event="stage_failed",
+                    stage="forced_align",
+                    tool="forced_align_start",
+                    completed_stages=completed_stages,
+                    total_stages=total_stages,
+                    status="error",
+                    job_id=job_ids.get("forced_align"),
+                    message=str(exc),
+                )
+            )
+            return self._workflow_failure_payload(
+                speaker_id=speaker_id,
+                concept_list=concept_list,
+                source_wav=source_wav,
+                stages=stages,
+                events=events,
+                job_ids=job_ids,
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                failed_step="forced_align",
+                failed_tool="forced_align_start",
+                error_message=str(exc),
+                error_type=type(exc).__name__,
+            )
+
+        align_stage_status = self._terminal_stage_status(align_status)
         stages.append({
             "stage": "forced_align",
             "tool": "forced_align_start",
-            "status": self._terminal_stage_status(align_status),
+            "status": align_stage_status,
             "payload": align_status,
         })
         if not self._is_complete_stage(align_status):
-            return {
-                "speaker_id": speaker_id,
-                "concept_list": concept_list,
-                "source_wav": source_wav,
-                "job_ids": {"stt": stt_job_id, "forced_align": align_job_id},
-                "stages": stages,
-                "annotation_summary": None,
-                "final_status": self._terminal_stage_status(align_status),
-                "completed_at": _utc_now_iso(),
-            }
-
-        ipa_started = self._parse_tools._tool_ipa_transcribe_acoustic_start({"speaker": speaker_id})
-        ipa_job_id = str(ipa_started.get("jobId") or "").strip()
-        if not ipa_job_id:
-            raise ChatToolExecutionError("ipa stage did not return a jobId")
-        ipa_status = self._poll_tool_status(
-            self._parse_tools._tool_ipa_transcribe_acoustic_status,
-            job_id=ipa_job_id,
+            events.append(
+                self._stage_event(
+                    event="stage_failed",
+                    stage="forced_align",
+                    tool="forced_align_status",
+                    completed_stages=completed_stages,
+                    total_stages=total_stages,
+                    status=align_stage_status,
+                    job_id=job_ids.get("forced_align"),
+                    message=str(align_status.get("error") or align_status.get("message") or align_stage_status),
+                )
+            )
+            return self._workflow_failure_payload(
+                speaker_id=speaker_id,
+                concept_list=concept_list,
+                source_wav=source_wav,
+                stages=stages,
+                events=events,
+                job_ids=job_ids,
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                failed_step="forced_align",
+                failed_tool="forced_align_status",
+                failed_payload=align_status,
+                error_type="workflow_stage_status",
+            )
+        completed_stages += 1
+        events.append(
+            self._stage_event(
+                event="stage_completed",
+                stage="forced_align",
+                tool="forced_align_status",
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                status=align_stage_status,
+                job_id=job_ids.get("forced_align"),
+            )
         )
+
+        events.append(
+            self._stage_event(
+                event="stage_started",
+                stage="ipa",
+                tool="ipa_transcribe_acoustic_start",
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                status="running",
+            )
+        )
+        try:
+            ipa_started = self._parse_tools._tool_ipa_transcribe_acoustic_start({"speaker": speaker_id})
+            ipa_job_id = str(ipa_started.get("jobId") or "").strip()
+            if not ipa_job_id:
+                raise ChatToolExecutionError("ipa stage did not return a jobId")
+            job_ids["ipa"] = ipa_job_id
+            ipa_status = self._poll_tool_status(
+                self._parse_tools._tool_ipa_transcribe_acoustic_status,
+                job_id=ipa_job_id,
+            )
+        except Exception as exc:
+            events.append(
+                self._stage_event(
+                    event="stage_failed",
+                    stage="ipa",
+                    tool="ipa_transcribe_acoustic_start",
+                    completed_stages=completed_stages,
+                    total_stages=total_stages,
+                    status="error",
+                    job_id=job_ids.get("ipa"),
+                    message=str(exc),
+                )
+            )
+            return self._workflow_failure_payload(
+                speaker_id=speaker_id,
+                concept_list=concept_list,
+                source_wav=source_wav,
+                stages=stages,
+                events=events,
+                job_ids=job_ids,
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                failed_step="ipa",
+                failed_tool="ipa_transcribe_acoustic_start",
+                error_message=str(exc),
+                error_type=type(exc).__name__,
+            )
+
+        ipa_stage_status = self._terminal_stage_status(ipa_status)
         stages.append({
             "stage": "ipa",
             "tool": "ipa_transcribe_acoustic_start",
-            "status": self._terminal_stage_status(ipa_status),
+            "status": ipa_stage_status,
             "payload": ipa_status,
         })
-
-        annotation_summary = self._parse_tools._tool_annotation_read(
-            {
-                "speaker": speaker_id,
-                "conceptIds": concept_list,
-                "includeTiers": ["ipa", "ortho", "concept", "speaker"],
-                "maxIntervals": 5000,
-            }
+        if not self._is_complete_stage(ipa_status):
+            events.append(
+                self._stage_event(
+                    event="stage_failed",
+                    stage="ipa",
+                    tool="ipa_transcribe_acoustic_status",
+                    completed_stages=completed_stages,
+                    total_stages=total_stages,
+                    status=ipa_stage_status,
+                    job_id=job_ids.get("ipa"),
+                    message=str(ipa_status.get("error") or ipa_status.get("message") or ipa_stage_status),
+                )
+            )
+            return self._workflow_failure_payload(
+                speaker_id=speaker_id,
+                concept_list=concept_list,
+                source_wav=source_wav,
+                stages=stages,
+                events=events,
+                job_ids=job_ids,
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                failed_step="ipa",
+                failed_tool="ipa_transcribe_acoustic_status",
+                failed_payload=ipa_status,
+                error_type="workflow_stage_status",
+            )
+        completed_stages += 1
+        events.append(
+            self._stage_event(
+                event="stage_completed",
+                stage="ipa",
+                tool="ipa_transcribe_acoustic_status",
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                status=ipa_stage_status,
+                job_id=job_ids.get("ipa"),
+            )
         )
-        final_status = "complete" if self._is_complete_stage(ipa_status) else self._terminal_stage_status(ipa_status)
+
+        try:
+            annotation_summary = self._parse_tools._tool_annotation_read(
+                {
+                    "speaker": speaker_id,
+                    "conceptIds": concept_list,
+                    "includeTiers": ["ipa", "ortho", "concept", "speaker"],
+                    "maxIntervals": 5000,
+                }
+            )
+        except Exception as exc:
+            events.append(
+                self._stage_event(
+                    event="stage_failed",
+                    stage="postflight",
+                    tool="annotation_read",
+                    completed_stages=completed_stages,
+                    total_stages=total_stages,
+                    status="error",
+                    message=str(exc),
+                )
+            )
+            return self._workflow_failure_payload(
+                speaker_id=speaker_id,
+                concept_list=concept_list,
+                source_wav=source_wav,
+                stages=stages,
+                events=events,
+                job_ids=job_ids,
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                failed_step="postflight",
+                failed_tool="annotation_read",
+                error_message=str(exc),
+                error_type=type(exc).__name__,
+            )
 
         return {
             "speaker_id": speaker_id,
             "concept_list": concept_list,
             "source_wav": source_wav,
-            "job_ids": {
-                "stt": stt_job_id,
-                "forced_align": align_job_id,
-                "ipa": ipa_job_id,
-            },
+            "job_ids": dict(job_ids),
             "stages": stages,
+            "events": events,
+            "progress": self._workflow_progress_payload(
+                completed_stages=completed_stages,
+                total_stages=total_stages,
+                current_stage=None,
+            ),
             "annotation_summary": annotation_summary,
-            "final_status": final_status,
+            "final_status": "complete",
             "completed_at": _utc_now_iso(),
         }
 


### PR DESCRIPTION
## Summary
- add `python/ai/workflow_tools.py` with high-level PARSE workflow macros
- expose the workflow macros through the MCP adapter with `ChatToolSpec` metadata
- add regression tests and update docs/counts for the expanded MCP surface
- include structured macro progress snapshots (`progress`, `events`) and sub-step failure context (`failedStep`, `failedTool`) for easier agent debugging
- add AGENTS.md usage examples plus naming guidance for `prepare_compare_mode`

## Notes
- Current workflow macros return structured stage-level progress in the final payload; a future iteration could add optional streaming/progressive status delivery for long-running workflows.
- `prepare_compare_mode` remains the stable public name for now. If we want a more natural label later, add a backward-compatible alias such as `build_compare_session` or `init_compare_mode` instead of silently renaming it.

## Testing
- python3 -m pytest python/ai/test_workflow_tools.py python/ai/test_pipeline_chat_tools.py python/ai/test_contact_lexeme_tool.py python/adapters/test_mcp_adapter.py -q
- npm run test -- --run
- ./node_modules/.bin/tsc --noEmit