### PR TITLE
feat: add PARSE job observability endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,15 @@ Use the generic tools when an agent needs transport-independent job inspection i
 Recommended agent pattern:
 1. Start a heavy job (`pipeline_run`, `stt_start`, `audio_normalize_start`, etc.)
 2. Poll `job_status` for transport-neutral state
+<<<<<<< HEAD
 3. Read `job_logs` when the human asks "what is it doing?" or when progress stalls
 4. Fall back to old per-type status tools only when a workflow needs type-specific payload shaping
+=======
+3. Inspect `locks` when coordinating speaker-scoped mutating work between humans and agents
+4. Read `job_logs` when the human asks "what is it doing?" or when progress stalls
+5. For HTTP-started jobs that need push completion, pass `callbackUrl` (absolute `http(s)` URL) on the job-start request so PARSE POSTs the final generic job payload on `complete` / `error`
+6. Fall back to old per-type status tools only when a workflow needs type-specific payload shaping
+>>>>>>> 660eb33 (feat: add job completion callbacks)
 
 ## Client/Server Contract Surface
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,12 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
 ## MCP adapter note
 
 - `python/adapters/mcp_adapter.py` now supports `config/mcp_config.json` with `{ "expose_all_tools": true }`.
-- Default MCP surface is **33 tools**: the legacy 29 workflow wrappers, the new generic observability tools (`jobs_list`, `job_status`, `job_logs`), plus read-only `mcp_get_exposure_mode` for self-inspection.
-- Enabling `expose_all_tools` expands the MCP surface to **51 tools**: all 50 `ParseChatTools` plus `mcp_get_exposure_mode`.
+- Default MCP surface is **36 tools**: the legacy 29 `ParseChatTools` wrappers, 3 high-level `WorkflowTools` macros from `python/ai/workflow_tools.py`, the 3 generic observability tools (`jobs_list`, `job_status`, `job_logs`), plus read-only `mcp_get_exposure_mode` for self-inspection.
+- Enabling `expose_all_tools` expands the MCP surface to **54 tools**: all 50 `ParseChatTools`, the 3 `WorkflowTools` macros, plus `mcp_get_exposure_mode`.
+- The workflow macros are:
+  - `run_full_annotation_pipeline`
+  - `prepare_compare_mode`
+  - `export_complete_lingpy_dataset`
 - For backward compatibility, root-level `mcp_config.json` is also accepted when `config/mcp_config.json` is absent.
 - `ChatToolSpec` is the MCP metadata source of truth. MCP tools should forward the strict schema from `spec.parameters`, standard MCP annotations from `spec.mcp_annotations_payload()`, and PARSE-specific safety metadata from `meta["x-parse"] = spec.mcp_meta_payload()`.
 - Mutability meanings:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,8 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
 ## MCP adapter note
 
 - `python/adapters/mcp_adapter.py` now supports `config/mcp_config.json` with `{ "expose_all_tools": true }`.
-- Default MCP surface is **33 tools**: the legacy 29 `ParseChatTools` wrappers, 3 high-level `WorkflowTools` macros from `python/ai/workflow_tools.py`, plus read-only `mcp_get_exposure_mode` for self-inspection.
-- Enabling `expose_all_tools` expands the MCP surface to **51 tools**: all 47 `ParseChatTools`, the 3 `WorkflowTools` macros, plus `mcp_get_exposure_mode`.
-- The workflow macros are:
-  - `run_full_annotation_pipeline`
-  - `prepare_compare_mode`
-  - `export_complete_lingpy_dataset`
+- Default MCP surface is **33 tools**: the legacy 29 workflow wrappers, the new generic observability tools (`jobs_list`, `job_status`, `job_logs`), plus read-only `mcp_get_exposure_mode` for self-inspection.
+- Enabling `expose_all_tools` expands the MCP surface to **51 tools**: all 50 `ParseChatTools` plus `mcp_get_exposure_mode`.
 - For backward compatibility, root-level `mcp_config.json` is also accepted when `config/mcp_config.json` is absent.
 - `ChatToolSpec` is the MCP metadata source of truth. MCP tools should forward the strict schema from `spec.parameters`, standard MCP annotations from `spec.mcp_annotations_payload()`, and PARSE-specific safety metadata from `meta["x-parse"] = spec.mcp_meta_payload()`.
 - Mutability meanings:
@@ -86,32 +82,22 @@ if x_parse["supports_dry_run"]:
     ...
 ```
 
-### Workflow Macro Examples
+### Generic job observability tools
 
-Use the new MCP workflow macros when an agent wants a one-call end-to-end action rather than hand-assembling low-level job chains.
+Use the generic tools when an agent needs transport-independent job inspection instead of guessing by job type.
 
-Agent example: "Run the full PARSE annotation workflow on speaker `Fail02` and report back on concepts `1`, `2`, and `3`."
+- `jobs_list(statuses=[...], types=[...], speaker="Fail01", limit=20)`
+  - lists active + recent jobs from the shared registry
+- `job_status(jobId="...")`
+  - returns the full generic snapshot: `type`, `status`, `progress`, `message`, `error`, `errorCode`, timestamps, `meta`, `logCount`
+- `job_logs(jobId="...", offset=0, limit=50)`
+  - returns structured log lines (`ts`, `level`, `event`, `message`, optional `progress`, optional `data`)
 
-```python
-run_full_annotation_pipeline(
-  speaker_id="Fail02",
-  concept_list=["1", "2", "3"],
-  dryRun=True,
-)
-
-prepare_compare_mode(
-  concept_range="1-25",
-  speakers=["Fail01", "Fail02", "Kalh01"],
-  dryRun=False,
-)
-
-export_complete_lingpy_dataset(
-  with_contact_lexemes=True,
-  dryRun=False,
-)
-```
-
-Naming note: `prepare_compare_mode` is the current stable public name. If a future cleanup wants a more action-oriented label, add a backward-compatible alias such as `build_compare_session` rather than silently renaming the macro.
+Recommended agent pattern:
+1. Start a heavy job (`pipeline_run`, `stt_start`, `audio_normalize_start`, etc.)
+2. Poll `job_status` for transport-neutral state
+3. Read `job_logs` when the human asks "what is it doing?" or when progress stalls
+4. Fall back to old per-type status tools only when a workflow needs type-specific payload shaping
 
 ## Client/Server Contract Surface
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -279,6 +279,32 @@ def _build_stt_callbacks() -> tuple:
 
     base_url = _resolve_api_base()
 
+    def _get_json(path: str, timeout: float = 20.0) -> Dict[str, Any]:
+        req = urllib.request.Request(
+            url="{0}{1}".format(base_url, path),
+            headers={"Accept": "application/json"},
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = resp.read().decode("utf-8") or "{}"
+        except urllib.error.HTTPError as http_err:
+            body = ""
+            try:
+                body = http_err.read().decode("utf-8") or ""
+            except Exception:
+                pass
+            try:
+                parsed_err = _json.loads(body) if body else {}
+            except _json.JSONDecodeError:
+                parsed_err = {"error": body[:400] or http_err.reason}
+            if isinstance(parsed_err, dict):
+                parsed_err.setdefault("httpStatus", http_err.code)
+                return parsed_err
+            return {"error": str(parsed_err), "httpStatus": http_err.code}
+        parsed = _json.loads(body)
+        return parsed if isinstance(parsed, dict) else {}
+
     def _post_json(path: str, payload: Dict[str, Any], timeout: float = 20.0) -> Dict[str, Any]:
         """POST JSON to the PARSE API and return the parsed body.
 
@@ -337,31 +363,20 @@ def _build_stt_callbacks() -> tuple:
         return job_id
 
     def get_job_snapshot(job_id: str) -> Optional[Dict[str, Any]]:
-        # First try STT-style status so existing stt_status paths work
-        # unchanged; if the server says "not an STT job", re-poll via the
-        # generic compute status so callers get the full job snapshot
-        # (result, progress, message) regardless of compute_type.
+        import urllib.parse
+
+        safe_job_id = urllib.parse.quote(str(job_id or "").strip(), safe="")
+        if not safe_job_id:
+            return None
         try:
-            response = _post_json("/api/stt/status", {"job_id": job_id})
+            response = _get_json("/api/jobs/{0}".format(safe_job_id))
         except urllib.error.URLError as exc:
             raise RuntimeError(
                 "PARSE API unreachable at {0} — cannot poll job. "
                 "Underlying error: {1}".format(base_url, exc)
             )
-        status = str((response or {}).get("status") or "").lower()
-        is_type_mismatch = (
-            (response or {}).get("error") == "jobId is not an STT job"
-            or status == "error"
-            and "is not an stt job" in str((response or {}).get("error") or "").lower()
-        )
-        if is_type_mismatch:
-            try:
-                response = _post_json(
-                    "/api/compute/status", {"job_id": job_id}
-                )
-            except urllib.error.URLError:
-                # Swallow — return the original STT-typed error.
-                pass
+        if isinstance(response, dict) and response.get("error") == "Unknown jobId":
+            return None
         return response or None
 
     return start_stt_job, get_job_snapshot
@@ -535,6 +550,78 @@ def _build_jobs_callback():
         return list(parsed.get("jobs") or [])
 
     return list_active_jobs
+
+
+
+def _build_jobs_list_callback():
+    """Build ParseChatTools' generic jobs_list callback via GET /api/jobs."""
+    import json as _json
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    base_url = _resolve_api_base()
+
+    def list_jobs(filters: Dict[str, Any]) -> Dict[str, Any]:
+        query_parts: List[tuple[str, str]] = []
+        filters_obj = dict(filters or {})
+        for status in filters_obj.get("statuses") or []:
+            query_parts.append(("status", str(status)))
+        for job_type in filters_obj.get("types") or []:
+            query_parts.append(("type", str(job_type)))
+        speaker = str(filters_obj.get("speaker") or "").strip()
+        if speaker:
+            query_parts.append(("speaker", speaker))
+        limit = filters_obj.get("limit")
+        if limit is not None:
+            query_parts.append(("limit", str(limit)))
+        query = urllib.parse.urlencode(query_parts, doseq=True)
+        url = "{0}/api/jobs{1}".format(base_url, "?{0}".format(query) if query else "")
+        req = urllib.request.Request(url=url, headers={"Accept": "application/json"}, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=10.0) as resp:
+                body = resp.read().decode("utf-8") or "{}"
+        except urllib.error.HTTPError as http_err:
+            raise RuntimeError("PARSE API /api/jobs failed ({0})".format(http_err.code))
+        except urllib.error.URLError as exc:
+            raise RuntimeError("PARSE API unreachable at {0}: {1}".format(base_url, exc))
+        parsed = _json.loads(body) if body else {}
+        return parsed if isinstance(parsed, dict) else {"jobs": [], "count": 0}
+
+    return list_jobs
+
+
+
+def _build_job_logs_callback():
+    """Build ParseChatTools' job_logs callback via GET /api/jobs/<jobId>/logs."""
+    import json as _json
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    base_url = _resolve_api_base()
+
+    def get_job_logs(job_id: str, offset: int, limit: int) -> Dict[str, Any]:
+        safe_job_id = urllib.parse.quote(str(job_id or "").strip(), safe="")
+        if not safe_job_id:
+            return {"jobId": "", "count": 0, "offset": offset, "limit": limit, "logs": []}
+        query = urllib.parse.urlencode({"offset": int(offset or 0), "limit": int(limit or 100)})
+        req = urllib.request.Request(
+            url="{0}/api/jobs/{1}/logs?{2}".format(base_url, safe_job_id, query),
+            headers={"Accept": "application/json"},
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10.0) as resp:
+                body = resp.read().decode("utf-8") or "{}"
+        except urllib.error.HTTPError as http_err:
+            raise RuntimeError("PARSE API job logs failed ({0})".format(http_err.code))
+        except urllib.error.URLError as exc:
+            raise RuntimeError("PARSE API unreachable at {0}: {1}".format(base_url, exc))
+        parsed = _json.loads(body) if body else {}
+        return parsed if isinstance(parsed, dict) else {"jobId": str(job_id or ""), "count": 0, "offset": offset, "limit": limit, "logs": []}
+
+    return get_job_logs
 
 
 def _resolve_external_read_roots() -> list:
@@ -723,10 +810,14 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
     onboard_callback = _build_onboard_callback()
     normalize_cb = _build_normalize_callback()
     jobs_cb = _build_jobs_callback()
+    jobs_list_cb = _build_jobs_list_callback()
+    job_logs_cb = _build_job_logs_callback()
     tools = ParseChatTools(
         project_root=root,
         start_stt_job=start_stt,
         get_job_snapshot=get_snapshot,
+        list_jobs=jobs_list_cb,
+        get_job_logs=job_logs_cb,
         external_read_roots=external_roots,
         memory_path=memory_path,
         onboard_speaker=onboard_callback,
@@ -1602,6 +1693,43 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
         if computeType is not None:
             args["computeType"] = computeType
         result = tools.execute("compute_status", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def jobs_list(
+        statuses: Optional[list] = None,
+        types: Optional[list] = None,
+        speaker: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> str:
+        """List active and recent jobs from the shared PARSE job registry."""
+        args: Dict[str, Any] = {}
+        if statuses is not None:
+            args["statuses"] = statuses
+        if types is not None:
+            args["types"] = types
+        if speaker is not None:
+            args["speaker"] = speaker
+        if limit is not None:
+            args["limit"] = limit
+        result = tools.execute("jobs_list", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def job_status(jobId: str) -> str:
+        """Read the generic status of any PARSE background job by jobId."""
+        result = tools.execute("job_status", {"jobId": jobId})
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def job_logs(jobId: str, offset: Optional[int] = None, limit: Optional[int] = None) -> str:
+        """Read structured log lines for a PARSE background job."""
+        args: Dict[str, Any] = {"jobId": jobId}
+        if offset is not None:
+            args["offset"] = offset
+        if limit is not None:
+            args["limit"] = limit
+        result = tools.execute("job_logs", args)
         return json.dumps(result, indent=2, ensure_ascii=False)
 
     if expose_all_tools:

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -108,6 +108,14 @@ def test_parse_chat_tools_get_all_tool_names_matches_instance(tmp_path) -> None:
     assert ParseChatTools.get_all_tool_names() == instance_names
 
 
+
+def test_job_observability_tools_are_allowlisted(tmp_path) -> None:
+    tools = ParseChatTools(project_root=tmp_path)
+
+    for tool_name in ["jobs_list", "job_status", "job_logs"]:
+        assert tool_name in tools.tool_names()
+
+
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
 def test_create_mcp_server_defaults_to_33_tools_without_config(tmp_path, monkeypatch) -> None:
     import asyncio
@@ -132,8 +140,7 @@ def test_create_mcp_server_defaults_to_33_tools_without_config(tmp_path, monkeyp
     assert payload["result"]["exposeAllTools"] is False
     assert payload["result"]["configSource"] is None
     assert payload["result"]["mcpToolCount"] == 33
-    assert payload["result"]["parseChatToolCount"] == 47
-    assert payload["result"]["workflowToolCount"] == 3
+    assert payload["result"]["parseChatToolCount"] == 50
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
@@ -160,8 +167,7 @@ def test_create_mcp_server_exposes_all_51_tools_when_enabled_in_config_dir(tmp_p
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is True
     assert payload["result"]["mcpToolCount"] == 51
-    assert payload["result"]["parseChatToolCount"] == 47
-    assert payload["result"]["workflowToolCount"] == 3
+    assert payload["result"]["parseChatToolCount"] == 50
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -441,6 +441,30 @@ def test_audio_normalize_start_supports_dry_run_preview(tmp_path) -> None:
     assert calls == []
 
 
+def test_job_status_surfaces_speaker_lock_metadata(tmp_path) -> None:
+    snapshot = {
+        "jobId": "job-lock",
+        "type": "stt",
+        "status": "running",
+        "progress": 12.5,
+        "message": "Transcribing",
+        "meta": {"speaker": "Fail01"},
+        "locks": {
+            "active": True,
+            "ttl_seconds": 600,
+            "resources": [{"kind": "speaker", "id": "Fail01"}],
+        },
+        "logs": [{"event": "job.created"}],
+    }
+    tools = ParseChatTools(project_root=tmp_path, get_job_snapshot=lambda job_id: snapshot)
+
+    payload = tools.execute("job_status", {"jobId": "job-lock"})["result"]
+
+    assert payload["jobId"] == "job-lock"
+    assert payload["locks"]["active"] is True
+    assert payload["locks"]["resources"] == [{"kind": "speaker", "id": "Fail01"}]
+
+
 def test_source_index_validate_dry_run_does_not_write_output(tmp_path) -> None:
     tools = ParseChatTools(project_root=tmp_path)
     output_path = tmp_path / "source_index.json"

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -128,7 +128,7 @@ def test_create_mcp_server_defaults_to_33_tools_without_config(tmp_path, monkeyp
     mcp_tools = asyncio.run(server.list_tools())
     tool_names = {tool.name for tool in mcp_tools}
 
-    assert len(mcp_tools) == 33
+    assert len(mcp_tools) == 36
     assert "mcp_get_exposure_mode" in tool_names
     assert "run_full_annotation_pipeline" in tool_names
     assert "prepare_compare_mode" in tool_names
@@ -139,12 +139,13 @@ def test_create_mcp_server_defaults_to_33_tools_without_config(tmp_path, monkeyp
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is False
     assert payload["result"]["configSource"] is None
-    assert payload["result"]["mcpToolCount"] == 33
+    assert payload["result"]["mcpToolCount"] == 36
     assert payload["result"]["parseChatToolCount"] == 50
+    assert payload["result"]["workflowToolCount"] == 3
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
-def test_create_mcp_server_exposes_all_51_tools_when_enabled_in_config_dir(tmp_path, monkeypatch) -> None:
+def test_create_mcp_server_exposes_all_54_tools_when_enabled_in_config_dir(tmp_path, monkeypatch) -> None:
     import asyncio
     import json
 
@@ -160,18 +161,19 @@ def test_create_mcp_server_exposes_all_51_tools_when_enabled_in_config_dir(tmp_p
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
-    assert len(mcp_tools) == 51
+    assert len(mcp_tools) == 54
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is True
-    assert payload["result"]["mcpToolCount"] == 51
+    assert payload["result"]["mcpToolCount"] == 54
     assert payload["result"]["parseChatToolCount"] == 50
+    assert payload["result"]["workflowToolCount"] == 3
 
 
 @pytest.mark.skipif(not _has_mcp(), reason="mcp package not installed")
-def test_create_mcp_server_exposes_all_51_tools_when_enabled_in_root_config(tmp_path, monkeypatch) -> None:
+def test_create_mcp_server_exposes_all_54_tools_when_enabled_in_root_config(tmp_path, monkeypatch) -> None:
     import asyncio
     import json
 
@@ -185,7 +187,7 @@ def test_create_mcp_server_exposes_all_51_tools_when_enabled_in_root_config(tmp_
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
-    assert len(mcp_tools) == 51
+    assert len(mcp_tools) == 54
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -4148,6 +4148,7 @@ class ParseChatTools:
             "progress": snapshot.get("progress"),
             "message": snapshot.get("message"),
             "error": snapshot.get("error"),
+            "errorCode": snapshot.get("error_code") or snapshot.get("errorCode"),
             "result": snapshot.get("result"),
             "createdAt": snapshot.get("created_at") or snapshot.get("createdAt"),
             "updatedAt": snapshot.get("updated_at") or snapshot.get("updatedAt"),
@@ -4174,6 +4175,8 @@ class ParseChatTools:
             raise ChatToolExecutionError("get_job_logs callback must return an object")
         result = {"readOnly": True}
         result.update(payload)
+        if "logs" in result and isinstance(result["logs"], list):
+            result["logCount"] = len(result["logs"])
         return result
 
     def _tool_jobs_list_active(self, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -4154,6 +4154,7 @@ class ParseChatTools:
             "updatedAt": snapshot.get("updated_at") or snapshot.get("updatedAt"),
             "completedAt": snapshot.get("completed_at") or snapshot.get("completedAt"),
             "meta": copy.deepcopy(snapshot.get("meta") if isinstance(snapshot.get("meta"), dict) else {}),
+            "locks": copy.deepcopy(snapshot.get("locks") if isinstance(snapshot.get("locks"), dict) else {}),
             "logCount": len(snapshot.get("logs")) if isinstance(snapshot.get("logs"), list) else int(snapshot.get("logCount") or 0),
         }
 

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -71,6 +71,9 @@ DEFAULT_MCP_TOOL_NAMES = (
     "pipeline_state_batch",
     "pipeline_run",
     "compute_status",
+    "jobs_list",
+    "job_status",
+    "job_logs",
 )
 WRITE_ALLOWED_TOOL_NAMES = frozenset({
     "audio_normalize_start",
@@ -403,6 +406,8 @@ class ParseChatTools:
         docs_root: Optional[Path] = None,
         start_stt_job: Optional[Callable[[str, str, Optional[str]], str]] = None,
         get_job_snapshot: Optional[Callable[[str], Optional[Dict[str, Any]]]] = None,
+        list_jobs: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+        get_job_logs: Optional[Callable[[str, int, int], Dict[str, Any]]] = None,
         external_read_roots: Optional[Sequence[Path]] = None,
         memory_path: Optional[Path] = None,
         onboard_speaker: Optional[
@@ -470,6 +475,8 @@ class ParseChatTools:
 
         self._start_stt_job = start_stt_job
         self._get_job_snapshot = get_job_snapshot
+        self._list_jobs = list_jobs
+        self._get_job_logs = get_job_logs
         self._onboard_speaker = onboard_speaker
         self._start_compute_job = start_compute_job
         self._pipeline_state = pipeline_state
@@ -2004,6 +2011,63 @@ class ParseChatTools:
                     },
                 },
             ),
+            "jobs_list": ChatToolSpec(
+                name="jobs_list",
+                description=(
+                    "List jobs from the PARSE job registry, including active and recent completed jobs. "
+                    "Supports filtering by status, type, and speaker, plus a bounded result limit."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "statuses": {
+                            "type": "array",
+                            "maxItems": 10,
+                            "items": {"type": "string", "minLength": 1, "maxLength": 32},
+                        },
+                        "types": {
+                            "type": "array",
+                            "maxItems": 20,
+                            "items": {"type": "string", "minLength": 1, "maxLength": 128},
+                        },
+                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 500},
+                    },
+                },
+            ),
+            "job_status": ChatToolSpec(
+                name="job_status",
+                description=(
+                    "Read the generic status of any PARSE background job by jobId. "
+                    "Returns type, status, progress, message, error, result, timestamps, and logCount."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["jobId"],
+                    "properties": {
+                        "jobId": {"type": "string", "minLength": 1, "maxLength": 128},
+                    },
+                },
+            ),
+            "job_logs": ChatToolSpec(
+                name="job_logs",
+                description=(
+                    "Read structured log lines for any PARSE background job. "
+                    "Returns timestamped entries for progress and terminal events."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["jobId"],
+                    "properties": {
+                        "jobId": {"type": "string", "minLength": 1, "maxLength": 128},
+                        "offset": {"type": "integer", "minimum": 0, "maximum": 10000},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 200},
+                    },
+                },
+            ),
             "jobs_list_active": ChatToolSpec(
                 name="jobs_list_active",
                 description=(
@@ -2056,7 +2120,7 @@ class ParseChatTools:
         return TOOL_MUTABILITY_READ_ONLY
 
     def _default_preconditions_for_tool(self, tool_name: str, mutability: str) -> Tuple[ToolCondition, ...]:
-        if tool_name in {"project_context_read", "speakers_list", "jobs_list_active"}:
+        if tool_name in {"project_context_read", "speakers_list", "jobs_list", "jobs_list_active"}:
             return ()
 
         if tool_name in {
@@ -4037,6 +4101,80 @@ class ParseChatTools:
             }
 
         raise ChatToolValidationError("mode must be 'speaker' or 'full'")
+
+    def _tool_jobs_list(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Return jobs from the PARSE job registry with optional filters."""
+        if self._list_jobs is None:
+            raise ChatToolExecutionError("list_jobs callback is unavailable")
+        try:
+            payload = self._list_jobs(
+                {
+                    "statuses": args.get("statuses") or [],
+                    "types": args.get("types") or [],
+                    "speaker": args.get("speaker"),
+                    "limit": args.get("limit"),
+                }
+            )
+        except Exception as exc:
+            raise ChatToolExecutionError("jobs_list failed: {0}".format(exc)) from exc
+        if not isinstance(payload, dict):
+            raise ChatToolExecutionError("jobs_list callback must return an object")
+        result = {"readOnly": True}
+        result.update(payload)
+        return result
+
+    def _tool_job_status(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        if self._get_job_snapshot is None:
+            raise ChatToolExecutionError("Job snapshot callback is unavailable")
+
+        job_id = str(args.get("jobId") or "").strip()
+        if not job_id:
+            raise ChatToolValidationError("jobId is required")
+
+        snapshot = self._get_job_snapshot(job_id)
+        if snapshot is None:
+            return {
+                "readOnly": True,
+                "jobId": job_id,
+                "status": "not_found",
+                "message": "Unknown jobId",
+            }
+
+        return {
+            "readOnly": True,
+            "jobId": job_id,
+            "type": snapshot.get("type"),
+            "status": snapshot.get("status"),
+            "progress": snapshot.get("progress"),
+            "message": snapshot.get("message"),
+            "error": snapshot.get("error"),
+            "result": snapshot.get("result"),
+            "createdAt": snapshot.get("created_at") or snapshot.get("createdAt"),
+            "updatedAt": snapshot.get("updated_at") or snapshot.get("updatedAt"),
+            "completedAt": snapshot.get("completed_at") or snapshot.get("completedAt"),
+            "meta": copy.deepcopy(snapshot.get("meta") if isinstance(snapshot.get("meta"), dict) else {}),
+            "logCount": len(snapshot.get("logs")) if isinstance(snapshot.get("logs"), list) else int(snapshot.get("logCount") or 0),
+        }
+
+    def _tool_job_logs(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        if self._get_job_logs is None:
+            raise ChatToolExecutionError("get_job_logs callback is unavailable")
+
+        job_id = str(args.get("jobId") or "").strip()
+        if not job_id:
+            raise ChatToolValidationError("jobId is required")
+
+        offset = int(args.get("offset") or 0)
+        limit = int(args.get("limit") or 100)
+        try:
+            payload = self._get_job_logs(job_id, offset, limit)
+        except Exception as exc:
+            raise ChatToolExecutionError("job_logs failed: {0}".format(exc)) from exc
+        if not isinstance(payload, dict):
+            raise ChatToolExecutionError("get_job_logs callback must return an object")
+        result = {"readOnly": True}
+        result.update(payload)
+        return result
 
     def _tool_jobs_list_active(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Return all running jobs from the PARSE job registry for session-restart recovery."""

--- a/python/server.py
+++ b/python/server.py
@@ -6468,7 +6468,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         progress after a page reload. See ``_list_active_jobs_snapshots``."""
         self._send_json(HTTPStatus.OK, {"jobs": _list_active_jobs_snapshots()})
 
-    def _api_get_job_logs(self, job_id: str) -> None:
+    def _api_get_job_error_logs(self, job_id: str) -> None:
         """Return the error, traceback, and tail of any stderr log files
         associated with a job. Powers the UI's "View crash log" modal.
 

--- a/python/server.py
+++ b/python/server.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 from urllib.parse import unquote, urlparse
+from urllib.request import Request, urlopen
 
 from ai.chat_orchestrator import ChatOrchestrator, ChatOrchestratorError, READ_ONLY_NOTICE
 from ai.chat_tools import ParseChatTools
@@ -1766,6 +1767,16 @@ def _chat_get_job_logs(job_id: str, offset: int, limit: int) -> Dict[str, Any]:
 
 
 
+def _job_callback_url_from_mapping(payload: Dict[str, Any]) -> Optional[str]:
+    body_obj = payload if isinstance(payload, dict) else {}
+    raw = body_obj.get("callbackUrl", body_obj.get("callback_url"))
+    try:
+        return _normalize_job_callback_url(raw)
+    except ValueError as exc:
+        raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
+
+
+
 def _chat_pipeline_state(speaker: str) -> Dict[str, Any]:
     """Thin wrapper so ParseChatTools can reach the preflight probe."""
     return _pipeline_state_for_speaker(speaker)
@@ -2637,6 +2648,70 @@ def _job_locks_payload(locks: Any) -> Dict[str, Any]:
 
 
 
+def _normalize_job_callback_url(raw_value: Any) -> Optional[str]:
+    value = str(raw_value or "").strip()
+    if not value:
+        return None
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("callbackUrl must be an absolute http(s) URL")
+    return value
+
+
+
+def _job_callback_payload(job: Dict[str, Any]) -> Dict[str, Any]:
+    payload = _job_detail_payload(job, include_logs=False)
+    payload["event"] = "job.{0}".format(str(job.get("status") or "unknown"))
+    return payload
+
+
+
+def _post_job_callback(callback_url: str, payload: Dict[str, Any]) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    request = Request(
+        callback_url,
+        data=body,
+        headers={"Content-Type": "application/json", "User-Agent": "PARSE-Job-Callback/1.0"},
+        method="POST",
+    )
+    with urlopen(request, timeout=10.0) as response:
+        response.read()
+
+
+
+def _dispatch_job_callback(job_snapshot: Dict[str, Any]) -> None:
+    meta = job_snapshot.get("meta") if isinstance(job_snapshot.get("meta"), dict) else {}
+    callback_url = str(meta.get("callbackUrl") or "").strip()
+    if not callback_url:
+        return
+    try:
+        _post_job_callback(callback_url, _job_callback_payload(job_snapshot))
+    except Exception as exc:
+        job_id = str(job_snapshot.get("jobId") or "")
+        with _jobs_lock:
+            live_job = _jobs.get(job_id)
+            if live_job is not None:
+                _append_job_log_locked(
+                    live_job,
+                    level="error",
+                    event="job.callback_failed",
+                    message="Callback delivery failed: {0}".format(exc),
+                    progress=_clamp_progress(live_job.get("progress", 0.0)),
+                    data={"callbackUrl": callback_url},
+                )
+
+
+
+def _dispatch_job_callback_async(job_snapshot: Dict[str, Any]) -> None:
+    meta = job_snapshot.get("meta") if isinstance(job_snapshot.get("meta"), dict) else {}
+    callback_url = str(meta.get("callbackUrl") or "").strip()
+    if not callback_url:
+        return
+    thread = threading.Thread(target=_dispatch_job_callback, args=(copy.deepcopy(job_snapshot),), daemon=True)
+    thread.start()
+
+
+
 def _create_job(
     job_type: str,
     metadata: Optional[Dict[str, Any]] = None,
@@ -2932,6 +3007,7 @@ def _set_job_complete(
     segments_processed: Optional[int] = None,
     total_segments: Optional[int] = None,
 ) -> None:
+    callback_snapshot: Optional[Dict[str, Any]] = None
     with _jobs_lock:
         job = _jobs.get(job_id)
         if job is None:
@@ -2968,6 +3044,10 @@ def _set_job_complete(
             message=str(job.get("message") or "Job complete"),
             progress=100.0,
         )
+        callback_snapshot = copy.deepcopy(job)
+
+    if callback_snapshot is not None:
+        _dispatch_job_callback_async(callback_snapshot)
 
 
 
@@ -2980,6 +3060,7 @@ def _set_job_error(
     the short error message so the UI's crash-log modal can render the
     one-line reason on top and the full Python traceback below without
     having to split-on-newline."""
+    callback_snapshot: Optional[Dict[str, Any]] = None
     with _jobs_lock:
         job = _jobs.get(job_id)
         if job is None:
@@ -3004,6 +3085,10 @@ def _set_job_error(
             message=str(error_message),
             progress=_clamp_progress(job.get("progress", 0.0)),
         )
+        callback_snapshot = copy.deepcopy(job)
+
+    if callback_snapshot is not None:
+        _dispatch_job_callback_async(callback_snapshot)
 
 def _get_job_snapshot(job_id: str) -> Optional[Dict[str, Any]]:
     with _jobs_lock:
@@ -6128,6 +6213,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         # Resolve source WAV — use explicit path if provided, else look up primary source
         source_wav = str(body.get("sourceWav") or body.get("source_wav") or "").strip()
+        callback_url = _job_callback_url_from_mapping(body)
         if not source_wav:
             source_wav = _annotation_primary_source_wav(speaker)
 
@@ -6143,6 +6229,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
                 {
                     "speaker": speaker,
                     "sourceWav": source_wav,
+                    "callbackUrl": callback_url,
                 },
             )
         except JobResourceConflictError as exc:
@@ -6474,6 +6561,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         language = str(language_raw).strip() if language_raw is not None else None
         if language == "":
             language = None
+        callback_url = _job_callback_url_from_mapping(body)
 
         if not speaker:
             raise ApiError(HTTPStatus.BAD_REQUEST, "speaker is required")
@@ -6487,6 +6575,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
                     "speaker": speaker,
                     "sourceWav": source_wav,
                     "language": language,
+                    "callbackUrl": callback_url,
                 },
             )
         except JobResourceConflictError as exc:
@@ -6584,6 +6673,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         raw_session_id = body.get("sessionId", body.get("session_id"))
         session_id = str(raw_session_id).strip() if raw_session_id is not None else ""
+        callback_url = _job_callback_url_from_mapping(body)
 
         try:
             session = _chat_create_or_get_session(session_id if session_id else None)
@@ -6596,6 +6686,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             "chat:run",
             {
                 "sessionId": resolved_session_id,
+                "callbackUrl": callback_url,
             },
         )
 
@@ -6647,11 +6738,13 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         body = self._read_json_body(required=False)
         body_obj = self._expect_object(body or {}, "Request body")
+        callback_url = _job_callback_url_from_mapping(body_obj)
 
         speaker = str(body_obj.get("speaker") or "").strip() or None
         job_metadata = {
             "computeType": normalized_type,
             "payload": body_obj,
+            "callbackUrl": callback_url,
         }
         if speaker:
             job_metadata["speaker"] = speaker

--- a/python/server.py
+++ b/python/server.py
@@ -101,8 +101,41 @@ class ApiError(Exception):
         self.message = message
 
 
+class JobResourceConflictError(Exception):
+    """Raised when a background job tries to mutate a speaker already locked by another active job."""
+
+    def __init__(
+        self,
+        *,
+        resource_kind: str,
+        resource_id: str,
+        holder_job_id: str,
+        holder_job_type: str,
+        holder_status: str,
+    ) -> None:
+        self.resource_kind = resource_kind
+        self.resource_id = resource_id
+        self.holder_job_id = holder_job_id
+        self.holder_job_type = holder_job_type
+        self.holder_status = holder_status
+        super().__init__(
+            "{0}:{1} is locked by job {2} ({3}, {4})".format(
+                resource_kind,
+                resource_id,
+                holder_job_id,
+                holder_job_type,
+                holder_status,
+            )
+        )
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+
+def _utc_iso_from_ts(timestamp: float) -> str:
+    return datetime.fromtimestamp(float(timestamp), timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _project_root() -> pathlib.Path:
@@ -2139,13 +2172,17 @@ def _chat_start_compute_job(compute_type: str, payload: Dict[str, Any]) -> str:
         raise ValueError("compute_type is required")
 
     body_obj = dict(payload or {})
+    speaker = str(body_obj.get("speaker") or "").strip() or None
+    job_metadata = {
+        "computeType": normalized_type,
+        "payload": body_obj,
+        "origin": "chat_tool",
+    }
+    if speaker:
+        job_metadata["speaker"] = speaker
     job_id = _create_job(
         "compute:{0}".format(normalized_type),
-        {
-            "computeType": normalized_type,
-            "payload": body_obj,
-            "origin": "chat_tool",
-        },
+        job_metadata,
     )
     # Delegates to thread / subprocess depending on PARSE_COMPUTE_MODE.
     _launch_compute_runner(job_id, normalized_type, body_obj)
@@ -2453,7 +2490,7 @@ def _append_job_log_locked(
     level: str,
     event: str,
     message: str,
-    source: str = "job_registry",
+    source: str = "server",
     progress: Optional[float] = None,
     data: Optional[Dict[str, Any]] = None,
 ) -> None:
@@ -2476,6 +2513,129 @@ def _append_job_log_locked(
         del logs[:-log_limit]
 
 
+_MUTATING_SPEAKER_JOB_TYPES = frozenset({"normalize", "stt", "onboard:speaker"})
+_MUTATING_SPEAKER_COMPUTE_TYPES = frozenset(
+    {"stt", "ortho", "ortho_only", "ipa", "ipa_only", "forced_align", "full_pipeline"}
+)
+
+
+
+def _job_lock_resources(job_type: str, metadata: Optional[Dict[str, Any]]) -> List[Dict[str, str]]:
+    meta = metadata if isinstance(metadata, dict) else {}
+    speaker = str(meta.get("speaker") or "").strip()
+    if not speaker:
+        return []
+
+    normalized_job_type = str(job_type or "").strip().lower()
+    if normalized_job_type in _MUTATING_SPEAKER_JOB_TYPES:
+        return [{"kind": "speaker", "id": speaker}]
+
+    if normalized_job_type.startswith("compute:"):
+        compute_type = str(meta.get("computeType") or normalized_job_type.split(":", 1)[1] or "").strip().lower()
+        if compute_type in _MUTATING_SPEAKER_COMPUTE_TYPES:
+            return [{"kind": "speaker", "id": speaker}]
+
+    return []
+
+
+
+def _expire_job_locks_locked(job: Dict[str, Any], now_ts: float, *, reason: str = "ttl_expired") -> None:
+    locks = job.get("locks")
+    if not isinstance(locks, dict) or not locks.get("active"):
+        return
+    locks["active"] = False
+    locks["expires_at"] = None
+    locks["expires_ts"] = None
+    locks["released_at"] = _utc_iso_from_ts(now_ts)
+    locks["released_ts"] = now_ts
+    locks["released_reason"] = reason
+
+
+
+def _find_job_resource_conflict_locked(
+    resources: Sequence[Dict[str, str]],
+    *,
+    now_ts: float,
+) -> Optional[Tuple[Dict[str, Any], Dict[str, str]]]:
+    wanted = {
+        (str(resource.get("kind") or "").strip(), str(resource.get("id") or "").strip())
+        for resource in resources
+        if str(resource.get("kind") or "").strip() and str(resource.get("id") or "").strip()
+    }
+    if not wanted:
+        return None
+
+    for job in _jobs.values():
+        if str(job.get("status") or "").strip().lower() not in {"queued", "running"}:
+            continue
+        locks = job.get("locks")
+        if not isinstance(locks, dict) or not locks.get("active"):
+            continue
+        try:
+            expires_ts = float(locks.get("expires_ts") or 0.0)
+        except (TypeError, ValueError):
+            expires_ts = 0.0
+        if expires_ts and expires_ts <= now_ts:
+            _expire_job_locks_locked(job, now_ts)
+            continue
+        for resource in locks.get("resources") or []:
+            resource_kind = str(resource.get("kind") or "").strip()
+            resource_id = str(resource.get("id") or "").strip()
+            if (resource_kind, resource_id) in wanted:
+                return job, {"kind": resource_kind, "id": resource_id}
+    return None
+
+
+
+def _refresh_job_locks_locked(job: Dict[str, Any], now_ts: float) -> None:
+    locks = job.get("locks")
+    if not isinstance(locks, dict) or not locks.get("active"):
+        return
+    ttl_seconds = max(1, int(locks.get("ttl_seconds") or JOB_LOCK_TTL_SECONDS))
+    locks["heartbeat_at"] = _utc_iso_from_ts(now_ts)
+    locks["heartbeat_ts"] = now_ts
+    locks["expires_at"] = _utc_iso_from_ts(now_ts + ttl_seconds)
+    locks["expires_ts"] = now_ts + ttl_seconds
+
+
+
+def _release_job_locks_locked(job: Dict[str, Any], now_ts: float) -> None:
+    locks = job.get("locks")
+    if not isinstance(locks, dict) or not locks.get("active"):
+        return
+    resources = copy.deepcopy(locks.get("resources") or [])
+    locks["active"] = False
+    locks["expires_at"] = None
+    locks["expires_ts"] = None
+    locks["released_at"] = _utc_iso_from_ts(now_ts)
+    locks["released_ts"] = now_ts
+    locks["released_reason"] = "job_finished"
+    if resources:
+        _append_job_log_locked(
+            job,
+            level="info",
+            event="job.lock_released",
+            message="Released job resource lock",
+            progress=_clamp_progress(job.get("progress", 0.0)),
+            data={"resources": resources},
+        )
+
+
+
+def _job_locks_payload(locks: Any) -> Dict[str, Any]:
+    locks_dict = locks if isinstance(locks, dict) else {}
+    resources = locks_dict.get("resources") if isinstance(locks_dict.get("resources"), list) else []
+    return {
+        "active": bool(locks_dict.get("active")),
+        "resources": copy.deepcopy(resources),
+        "heartbeat_at": locks_dict.get("heartbeat_at"),
+        "expires_at": locks_dict.get("expires_at"),
+        "released_at": locks_dict.get("released_at"),
+        "released_reason": locks_dict.get("released_reason"),
+        "ttl_seconds": int(locks_dict.get("ttl_seconds") or JOB_LOCK_TTL_SECONDS),
+    }
+
+
 
 def _create_job(
     job_type: str,
@@ -2491,8 +2651,38 @@ def _create_job(
     normalized_status = str(initial_status or "running").strip().lower() or "running"
     if normalized_status not in {"queued", "running"}:
         normalized_status = "running"
+    resources = _job_lock_resources(job_type, metadata)
 
     with _jobs_lock:
+        conflict = _find_job_resource_conflict_locked(resources, now_ts=now_ts)
+        if conflict is not None:
+            holder_job, resource = conflict
+            raise JobResourceConflictError(
+                resource_kind=str(resource.get("kind") or "resource"),
+                resource_id=str(resource.get("id") or ""),
+                holder_job_id=str(holder_job.get("jobId") or ""),
+                holder_job_type=str(holder_job.get("type") or "unknown"),
+                holder_status=str(holder_job.get("status") or "running"),
+            )
+
+        locks_payload = {
+            "active": bool(resources),
+            "resources": copy.deepcopy(resources),
+            "heartbeat_at": None,
+            "heartbeat_ts": None,
+            "expires_at": None,
+            "expires_ts": None,
+            "released_at": None,
+            "released_ts": None,
+            "released_reason": None,
+            "ttl_seconds": JOB_LOCK_TTL_SECONDS,
+        }
+        if resources:
+            locks_payload["heartbeat_at"] = now_iso
+            locks_payload["heartbeat_ts"] = now_ts
+            locks_payload["expires_at"] = _utc_iso_from_ts(now_ts + JOB_LOCK_TTL_SECONDS)
+            locks_payload["expires_ts"] = now_ts + JOB_LOCK_TTL_SECONDS
+
         job: Dict[str, Any] = {
             "jobId": job_id,
             "type": str(job_type),
@@ -2511,11 +2701,7 @@ def _create_job(
             "updated_ts": now_ts,
             "completed_ts": None,
             "meta": copy.deepcopy(metadata or {}),
-            "locks": {
-                "expires_at": None,
-                "heartbeat_at": None,
-                "ttl_seconds": JOB_LOCK_TTL_SECONDS,
-            },
+            "locks": locks_payload,
             "logs": [],
         }
         _append_job_log_locked(
@@ -2530,6 +2716,15 @@ def _create_job(
                 "meta": copy.deepcopy(metadata or {}),
             },
         )
+        if resources:
+            _append_job_log_locked(
+                job,
+                level="info",
+                event="job.lock_acquired",
+                message="Acquired job resource lock",
+                progress=0.0,
+                data={"resources": copy.deepcopy(resources)},
+            )
         _jobs[job_id] = job
 
     return job_id
@@ -2657,8 +2852,9 @@ def _set_job_running(job_id: str, message: Optional[str] = None) -> None:
             return
         now_ts = time.time()
         job["status"] = "running"
-        job["updated_at"] = _utc_now_iso()
+        job["updated_at"] = _utc_iso_from_ts(now_ts)
         job["updated_ts"] = now_ts
+        _refresh_job_locks_locked(job, now_ts)
         if message is not None:
             job["message"] = str(message)
         _append_job_log_locked(
@@ -2688,8 +2884,9 @@ def _set_job_progress(
         previous_progress = _clamp_progress(job.get("progress", 0.0))
         current_progress = _clamp_progress(progress)
         job["progress"] = current_progress
-        job["updated_at"] = _utc_now_iso()
+        job["updated_at"] = _utc_iso_from_ts(now_ts)
         job["updated_ts"] = now_ts
+        _refresh_job_locks_locked(job, now_ts)
 
         if message is not None:
             job["message"] = str(message)
@@ -2741,14 +2938,15 @@ def _set_job_complete(
             return
 
         now_ts = time.time()
+        now_iso = _utc_iso_from_ts(now_ts)
         job["status"] = "complete"
         job["progress"] = 100.0
         job["result"] = copy.deepcopy(result)
         job["error"] = None
         job["error_code"] = None
-        job["updated_at"] = _utc_now_iso()
+        job["updated_at"] = now_iso
         job["updated_ts"] = now_ts
-        job["completed_at"] = _utc_now_iso()
+        job["completed_at"] = now_iso
         job["completed_ts"] = now_ts
         if message is not None:
             job["message"] = str(message)
@@ -2762,6 +2960,7 @@ def _set_job_complete(
                 job["totalSegments"] = max(0, int(total_segments))
             except (TypeError, ValueError):
                 pass
+        _release_job_locks_locked(job, now_ts)
         _append_job_log_locked(
             job,
             level="info",
@@ -2787,15 +2986,17 @@ def _set_job_error(
             return
 
         now_ts = time.time()
+        now_iso = _utc_iso_from_ts(now_ts)
         job["status"] = "error"
         job["error"] = str(error_message)
         if traceback_str:
             job["traceback"] = str(traceback_str)
         job["error_code"] = _infer_job_error_code(error_message)
-        job["updated_at"] = _utc_now_iso()
+        job["updated_at"] = now_iso
         job["updated_ts"] = now_ts
-        job["completed_at"] = _utc_now_iso()
+        job["completed_at"] = now_iso
         job["completed_ts"] = now_ts
+        _release_job_locks_locked(job, now_ts)
         _append_job_log_locked(
             job,
             level="error",
@@ -2834,6 +3035,7 @@ def _job_detail_payload(job: Dict[str, Any], *, include_logs: bool = False) -> D
     payload["updatedAt"] = job.get("updated_at")
     payload["completedAt"] = job.get("completed_at")
     payload["meta"] = copy.deepcopy(job.get("meta") if isinstance(job.get("meta"), dict) else {})
+    payload["locks"] = _job_locks_payload(job.get("locks"))
     logs = job.get("logs") if isinstance(job.get("logs"), list) else []
     payload["logCount"] = len(logs)
     if include_logs:
@@ -2915,6 +3117,7 @@ def _job_response_payload(job: Dict[str, Any]) -> Dict[str, Any]:
 
     payload["segmentsProcessed"] = int(job.get("segmentsProcessed", 0) or 0)
     payload["totalSegments"] = int(job.get("totalSegments", 0) or 0)
+    payload["locks"] = _job_locks_payload(job.get("locks"))
     if job.get("error_code"):
         payload["errorCode"] = str(job.get("error_code"))
 
@@ -5881,14 +6084,17 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             csv_dest.write_bytes(csv_data)
 
         # Create background job
-        job_id = _create_job(
-            "onboard:speaker",
-            {
-                "speaker": speaker,
-                "wavPath": str(wav_dest.relative_to(_project_root())),
-                "csvPath": str(csv_dest.relative_to(_project_root())) if csv_dest else None,
-            },
-        )
+        try:
+            job_id = _create_job(
+                "onboard:speaker",
+                {
+                    "speaker": speaker,
+                    "wavPath": str(wav_dest.relative_to(_project_root())),
+                    "csvPath": str(csv_dest.relative_to(_project_root())) if csv_dest else None,
+                },
+            )
+        except JobResourceConflictError as exc:
+            raise ApiError(HTTPStatus.CONFLICT, str(exc))
 
         thread = threading.Thread(
             target=_run_onboard_speaker_job,
@@ -5931,13 +6137,16 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
                 "No source audio found for speaker '{0}'. Provide sourceWav explicitly.".format(speaker),
             )
 
-        job_id = _create_job(
-            "normalize",
-            {
-                "speaker": speaker,
-                "sourceWav": source_wav,
-            },
-        )
+        try:
+            job_id = _create_job(
+                "normalize",
+                {
+                    "speaker": speaker,
+                    "sourceWav": source_wav,
+                },
+            )
+        except JobResourceConflictError as exc:
+            raise ApiError(HTTPStatus.CONFLICT, str(exc))
 
         thread = threading.Thread(
             target=_run_normalize_job,
@@ -6271,14 +6480,17 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         if not source_wav:
             raise ApiError(HTTPStatus.BAD_REQUEST, "sourceWav is required")
 
-        job_id = _create_job(
-            "stt",
-            {
-                "speaker": speaker,
-                "sourceWav": source_wav,
-                "language": language,
-            },
-        )
+        try:
+            job_id = _create_job(
+                "stt",
+                {
+                    "speaker": speaker,
+                    "sourceWav": source_wav,
+                    "language": language,
+                },
+            )
+        except JobResourceConflictError as exc:
+            raise ApiError(HTTPStatus.CONFLICT, str(exc))
 
         _launch_compute_runner(
             job_id, "stt",
@@ -6436,13 +6648,21 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         body = self._read_json_body(required=False)
         body_obj = self._expect_object(body or {}, "Request body")
 
-        job_id = _create_job(
-            "compute:{0}".format(normalized_type),
-            {
-                "computeType": normalized_type,
-                "payload": body_obj,
-            },
-        )
+        speaker = str(body_obj.get("speaker") or "").strip() or None
+        job_metadata = {
+            "computeType": normalized_type,
+            "payload": body_obj,
+        }
+        if speaker:
+            job_metadata["speaker"] = speaker
+
+        try:
+            job_id = _create_job(
+                "compute:{0}".format(normalized_type),
+                job_metadata,
+            )
+        except JobResourceConflictError as exc:
+            raise ApiError(HTTPStatus.CONFLICT, str(exc))
 
         _launch_compute_runner(job_id, normalized_type, body_obj)
 

--- a/python/server.py
+++ b/python/server.py
@@ -36,6 +36,7 @@ except Exception:
 HOST = "0.0.0.0"
 PORT = 8766
 JOB_RETENTION_SECONDS = 60 * 60
+JOB_LOG_MAX_ENTRIES = 200
 CONFIG_SCHEMA_VERSION = 1
 
 CORS_HEADERS = {
@@ -1710,6 +1711,27 @@ def _chat_get_job_snapshot(job_id: str) -> Optional[Dict[str, Any]]:
     return _get_job_snapshot(job_id)
 
 
+
+def _chat_list_jobs(filters: Dict[str, Any]) -> Dict[str, Any]:
+    filters_obj = dict(filters or {})
+    rows = _list_jobs_snapshots(
+        statuses=filters_obj.get("statuses") or [],
+        job_types=filters_obj.get("types") or [],
+        speaker=filters_obj.get("speaker"),
+        limit=int(filters_obj.get("limit") or 100),
+    )
+    return {"jobs": rows, "count": len(rows)}
+
+
+
+def _chat_get_job_logs(job_id: str, offset: int, limit: int) -> Dict[str, Any]:
+    job = _get_job_snapshot(job_id)
+    if job is None:
+        return {"jobId": job_id, "count": 0, "offset": offset, "limit": limit, "logs": []}
+    return _job_logs_payload(job, offset=offset, limit=limit)
+
+
+
 def _chat_pipeline_state(speaker: str) -> Dict[str, Any]:
     """Thin wrapper so ParseChatTools can reach the preflight probe."""
     return _pipeline_state_for_speaker(speaker)
@@ -2270,6 +2292,8 @@ def _get_chat_runtime() -> Tuple[ParseChatTools, ChatOrchestrator]:
                 docs_root=_chat_docs_root(),
                 start_stt_job=_chat_start_stt_job,
                 get_job_snapshot=_chat_get_job_snapshot,
+                list_jobs=_chat_list_jobs,
+                get_job_logs=_chat_get_job_logs,
                 external_read_roots=_chat_external_read_roots(),
                 memory_path=_chat_memory_path(),
                 onboard_speaker=_chat_onboard_speaker,
@@ -2364,14 +2388,68 @@ def _cleanup_old_jobs() -> None:
             _jobs.pop(job_id, None)
 
 
+def _job_log_entry(
+    *,
+    level: str,
+    event: str,
+    message: str,
+    source: str = "job_registry",
+    progress: Optional[float] = None,
+    data: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    entry: Dict[str, Any] = {
+        "ts": _utc_now_iso(),
+        "level": str(level or "info"),
+        "event": str(event or "job.event"),
+        "message": str(message or ""),
+        "source": str(source or "job_registry"),
+    }
+    if progress is not None:
+        entry["progress"] = _clamp_progress(progress)
+    if isinstance(data, dict) and data:
+        entry["data"] = copy.deepcopy(data)
+    return entry
+
+
+
+def _append_job_log_locked(
+    job: Dict[str, Any],
+    *,
+    level: str,
+    event: str,
+    message: str,
+    source: str = "job_registry",
+    progress: Optional[float] = None,
+    data: Optional[Dict[str, Any]] = None,
+) -> None:
+    logs = job.get("logs")
+    if not isinstance(logs, list):
+        logs = []
+        job["logs"] = logs
+    logs.append(
+        _job_log_entry(
+            level=level,
+            event=event,
+            message=message,
+            source=source,
+            progress=progress,
+            data=data,
+        )
+    )
+    if len(logs) > JOB_LOG_MAX_ENTRIES:
+        del logs[:-JOB_LOG_MAX_ENTRIES]
+
+
+
 def _create_job(job_type: str, metadata: Optional[Dict[str, Any]] = None) -> str:
     _cleanup_old_jobs()
 
     job_id = str(uuid.uuid4())
     now_ts = time.time()
+    now_iso = _utc_now_iso()
 
     with _jobs_lock:
-        _jobs[job_id] = {
+        job: Dict[str, Any] = {
             "jobId": job_id,
             "type": str(job_type),
             "status": "running",
@@ -2381,14 +2459,28 @@ def _create_job(job_type: str, metadata: Optional[Dict[str, Any]] = None) -> str
             "message": None,
             "segmentsProcessed": 0,
             "totalSegments": 0,
-            "created_at": _utc_now_iso(),
-            "updated_at": _utc_now_iso(),
+            "created_at": now_iso,
+            "updated_at": now_iso,
             "completed_at": None,
             "created_ts": now_ts,
             "updated_ts": now_ts,
             "completed_ts": None,
             "meta": copy.deepcopy(metadata or {}),
+            "logs": [],
         }
+        _append_job_log_locked(
+            job,
+            level="info",
+            event="job.created",
+            message="Job created",
+            progress=0.0,
+            data={
+                "jobId": job_id,
+                "type": str(job_type),
+                "meta": copy.deepcopy(metadata or {}),
+            },
+        )
+        _jobs[job_id] = job
 
     return job_id
 
@@ -2506,7 +2598,6 @@ def _compute_checkpoint(label: str, **kv: Any) -> None:
         # If the log file is unreachable the compute continues.
         pass
 
-
 def _set_job_progress(
     job_id: str,
     progress: float,
@@ -2520,7 +2611,10 @@ def _set_job_progress(
             return
 
         now_ts = time.time()
-        job["progress"] = _clamp_progress(progress)
+        previous_message = str(job.get("message") or "")
+        previous_progress = _clamp_progress(job.get("progress", 0.0))
+        current_progress = _clamp_progress(progress)
+        job["progress"] = current_progress
         job["updated_at"] = _utc_now_iso()
         job["updated_ts"] = now_ts
 
@@ -2536,6 +2630,29 @@ def _set_job_progress(
                 job["totalSegments"] = max(0, int(total_segments))
             except (TypeError, ValueError):
                 job["totalSegments"] = 0
+
+        current_message = str(job.get("message") or "")
+        if current_message and current_message != previous_message:
+            _append_job_log_locked(
+                job,
+                level="info",
+                event="job.progress",
+                message=current_message,
+                progress=current_progress,
+                data={
+                    "segmentsProcessed": int(job.get("segmentsProcessed", 0) or 0),
+                    "totalSegments": int(job.get("totalSegments", 0) or 0),
+                },
+            )
+        elif current_progress != previous_progress and abs(current_progress - previous_progress) >= 25.0:
+            _append_job_log_locked(
+                job,
+                level="info",
+                event="job.progress",
+                message="Progress updated",
+                progress=current_progress,
+            )
+
 
 
 def _set_job_complete(
@@ -2571,6 +2688,14 @@ def _set_job_complete(
                 job["totalSegments"] = max(0, int(total_segments))
             except (TypeError, ValueError):
                 pass
+        _append_job_log_locked(
+            job,
+            level="info",
+            event="job.completed",
+            message=str(job.get("message") or "Job complete"),
+            progress=100.0,
+        )
+
 
 
 def _set_job_error(
@@ -2596,7 +2721,13 @@ def _set_job_error(
         job["updated_ts"] = now_ts
         job["completed_at"] = _utc_now_iso()
         job["completed_ts"] = now_ts
-
+        _append_job_log_locked(
+            job,
+            level="error",
+            event="job.failed",
+            message=str(error_message),
+            progress=_clamp_progress(job.get("progress", 0.0)),
+        )
 
 def _get_job_snapshot(job_id: str) -> Optional[Dict[str, Any]]:
     with _jobs_lock:
@@ -2604,6 +2735,80 @@ def _get_job_snapshot(job_id: str) -> Optional[Dict[str, Any]]:
         if job is None:
             return None
         return copy.deepcopy(job)
+
+
+
+def _job_logs_payload(job: Dict[str, Any], *, offset: int = 0, limit: int = JOB_LOG_MAX_ENTRIES) -> Dict[str, Any]:
+    logs = job.get("logs") if isinstance(job.get("logs"), list) else []
+    safe_offset = max(0, int(offset or 0))
+    safe_limit = max(1, min(int(limit or JOB_LOG_MAX_ENTRIES), JOB_LOG_MAX_ENTRIES))
+    sliced = copy.deepcopy(logs[safe_offset:safe_offset + safe_limit])
+    return {
+        "jobId": str(job.get("jobId") or ""),
+        "count": len(logs),
+        "offset": safe_offset,
+        "limit": safe_limit,
+        "logs": sliced,
+    }
+
+
+
+def _job_detail_payload(job: Dict[str, Any], *, include_logs: bool = False) -> Dict[str, Any]:
+    payload = _job_response_payload(job)
+    payload["createdAt"] = job.get("created_at")
+    payload["updatedAt"] = job.get("updated_at")
+    payload["completedAt"] = job.get("completed_at")
+    payload["meta"] = copy.deepcopy(job.get("meta") if isinstance(job.get("meta"), dict) else {})
+    logs = job.get("logs") if isinstance(job.get("logs"), list) else []
+    payload["logCount"] = len(logs)
+    if include_logs:
+        payload["logs"] = copy.deepcopy(logs)
+    return payload
+
+
+
+def _list_jobs_snapshots(
+    *,
+    statuses: Optional[Sequence[str]] = None,
+    job_types: Optional[Sequence[str]] = None,
+    speaker: Optional[str] = None,
+    limit: int = 100,
+) -> List[Dict[str, Any]]:
+    normalized_statuses = {
+        str(value or "").strip().lower()
+        for value in (statuses or [])
+        if str(value or "").strip()
+    }
+    normalized_types = {
+        str(value or "").strip()
+        for value in (job_types or [])
+        if str(value or "").strip()
+    }
+    speaker_filter = str(speaker or "").strip()
+    safe_limit = max(1, min(int(limit or 100), 500))
+
+    rows: List[Dict[str, Any]] = []
+    with _jobs_lock:
+        jobs_sorted = sorted(
+            _jobs.values(),
+            key=lambda item: float(item.get("created_ts") or 0.0),
+            reverse=True,
+        )
+        for job in jobs_sorted:
+            job_status = str(job.get("status") or "").strip().lower()
+            if normalized_statuses and job_status not in normalized_statuses:
+                continue
+            job_type = str(job.get("type") or "").strip()
+            if normalized_types and job_type not in normalized_types:
+                continue
+            meta = job.get("meta") if isinstance(job.get("meta"), dict) else {}
+            if speaker_filter and str(meta.get("speaker") or "").strip() != speaker_filter:
+                continue
+            rows.append(_job_detail_payload(job))
+            if len(rows) >= safe_limit:
+                break
+    return rows
+
 
 
 def _job_response_payload(job: Dict[str, Any]) -> Dict[str, Any]:
@@ -5246,19 +5451,21 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             self._api_get_chat_session(parts[3])
             return
 
+        if request_path == "/api/jobs":
+            self._api_get_jobs()
+            return
+
         if request_path == "/api/jobs/active":
             self._api_get_jobs_active()
             return
 
-        if (
-            len(parts) == 4
-            and parts[0] == "api"
-            and parts[1] == "jobs"
-            and parts[3] == "logs"
-        ):
+        if len(parts) == 4 and parts[0] == "api" and parts[1] == "jobs" and parts[3] == "logs":
             self._api_get_job_logs(parts[2])
             return
 
+        if len(parts) == 3 and parts[0] == "api" and parts[1] == "jobs":
+            self._api_get_job(parts[2])
+            return
         if request_path == "/api/enrichments":
             self._api_get_enrichments()
             return
@@ -5821,6 +6028,67 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             raise ApiError(HTTPStatus.BAD_REQUEST, "job_id is not a normalize job")
 
         self._send_json(HTTPStatus.OK, _job_response_payload(job))
+
+    def _api_get_jobs(self) -> None:
+        query = urlparse(self.path).query
+        params = {}
+        for piece in query.split("&"):
+            if not piece or "=" not in piece:
+                continue
+            key, value = piece.split("=", 1)
+            params.setdefault(key, []).append(unquote(value))
+
+        statuses = params.get("status") or params.get("statuses")
+        job_types = params.get("type") or params.get("types")
+        speaker = (params.get("speaker") or [None])[0]
+        limit_raw = (params.get("limit") or ["100"])[0]
+        try:
+            limit = int(limit_raw)
+        except (TypeError, ValueError):
+            limit = 100
+
+        rows = _list_jobs_snapshots(
+            statuses=statuses,
+            job_types=job_types,
+            speaker=speaker,
+            limit=limit,
+        )
+        self._send_json(HTTPStatus.OK, {"jobs": rows, "count": len(rows)})
+
+    def _api_get_job(self, job_id_part: str) -> None:
+        job_id = str(job_id_part or "").strip()
+        if not job_id:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "jobId is required")
+        job = _get_job_snapshot(job_id)
+        if job is None:
+            raise ApiError(HTTPStatus.NOT_FOUND, "Unknown jobId")
+        self._send_json(HTTPStatus.OK, _job_detail_payload(job))
+
+    def _api_get_job_logs(self, job_id_part: str) -> None:
+        job_id = str(job_id_part or "").strip()
+        if not job_id:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "jobId is required")
+        job = _get_job_snapshot(job_id)
+        if job is None:
+            raise ApiError(HTTPStatus.NOT_FOUND, "Unknown jobId")
+        query = urlparse(self.path).query
+        offset = 0
+        limit = JOB_LOG_MAX_ENTRIES
+        for piece in query.split("&"):
+            if not piece or "=" not in piece:
+                continue
+            key, value = piece.split("=", 1)
+            if key == "offset":
+                try:
+                    offset = int(unquote(value))
+                except (TypeError, ValueError):
+                    offset = 0
+            elif key == "limit":
+                try:
+                    limit = int(unquote(value))
+                except (TypeError, ValueError):
+                    limit = JOB_LOG_MAX_ENTRIES
+        self._send_json(HTTPStatus.OK, _job_logs_payload(job, offset=offset, limit=limit))
 
     def _api_get_jobs_active(self) -> None:
         """Return a list of currently-running jobs so the UI can rehydrate

--- a/python/server.py
+++ b/python/server.py
@@ -37,6 +37,7 @@ HOST = "0.0.0.0"
 PORT = 8766
 JOB_RETENTION_SECONDS = 60 * 60
 JOB_LOG_MAX_ENTRIES = 200
+JOB_LOCK_TTL_SECONDS = 10 * 60
 CONFIG_SCHEMA_VERSION = 1
 
 CORS_HEADERS = {
@@ -2388,6 +2389,40 @@ def _cleanup_old_jobs() -> None:
             _jobs.pop(job_id, None)
 
 
+def _job_log_limit() -> int:
+    raw = str(os.environ.get("PARSE_JOB_LOG_MAX_ENTRIES") or "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = JOB_LOG_MAX_ENTRIES
+        return max(10, min(parsed, 1000))
+    return JOB_LOG_MAX_ENTRIES
+
+
+
+def _infer_job_error_code(error_message: Any) -> str:
+    text = str(error_message or "").strip().lower()
+    if not text:
+        return "job_failed"
+    if "unknown jobid" in text or "unknown job_id" in text:
+        return "job_not_found"
+    if "not a" in text and "job" in text:
+        return "invalid_job_type"
+    if "timeout" in text:
+        return "timeout"
+    if "ffmpeg" in text:
+        return "ffmpeg_failed"
+    if "provider init failed" in text or "loading model" in text:
+        return "model_init_failed"
+    if "cuda" in text or "cublas" in text:
+        return "cuda_runtime_error"
+    if "validation" in text or "required" in text:
+        return "validation_error"
+    return "job_failed"
+
+
+
 def _job_log_entry(
     *,
     level: str,
@@ -2436,26 +2471,36 @@ def _append_job_log_locked(
             data=data,
         )
     )
-    if len(logs) > JOB_LOG_MAX_ENTRIES:
-        del logs[:-JOB_LOG_MAX_ENTRIES]
+    log_limit = _job_log_limit()
+    if len(logs) > log_limit:
+        del logs[:-log_limit]
 
 
 
-def _create_job(job_type: str, metadata: Optional[Dict[str, Any]] = None) -> str:
+def _create_job(
+    job_type: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    *,
+    initial_status: str = "running",
+) -> str:
     _cleanup_old_jobs()
 
     job_id = str(uuid.uuid4())
     now_ts = time.time()
     now_iso = _utc_now_iso()
+    normalized_status = str(initial_status or "running").strip().lower() or "running"
+    if normalized_status not in {"queued", "running"}:
+        normalized_status = "running"
 
     with _jobs_lock:
         job: Dict[str, Any] = {
             "jobId": job_id,
             "type": str(job_type),
-            "status": "running",
+            "status": normalized_status,
             "progress": 0.0,
             "result": None,
             "error": None,
+            "error_code": None,
             "message": None,
             "segmentsProcessed": 0,
             "totalSegments": 0,
@@ -2466,13 +2511,18 @@ def _create_job(job_type: str, metadata: Optional[Dict[str, Any]] = None) -> str
             "updated_ts": now_ts,
             "completed_ts": None,
             "meta": copy.deepcopy(metadata or {}),
+            "locks": {
+                "expires_at": None,
+                "heartbeat_at": None,
+                "ttl_seconds": JOB_LOCK_TTL_SECONDS,
+            },
             "logs": [],
         }
         _append_job_log_locked(
             job,
             level="info",
-            event="job.created",
-            message="Job created",
+            event="job.queued" if normalized_status == "queued" else "job.created",
+            message="Job queued" if normalized_status == "queued" else "Job created",
             progress=0.0,
             data={
                 "jobId": job_id,
@@ -2598,6 +2648,29 @@ def _compute_checkpoint(label: str, **kv: Any) -> None:
         # If the log file is unreachable the compute continues.
         pass
 
+def _set_job_running(job_id: str, message: Optional[str] = None) -> None:
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+        if job is None:
+            return
+        if str(job.get("status") or "") == "running":
+            return
+        now_ts = time.time()
+        job["status"] = "running"
+        job["updated_at"] = _utc_now_iso()
+        job["updated_ts"] = now_ts
+        if message is not None:
+            job["message"] = str(message)
+        _append_job_log_locked(
+            job,
+            level="info",
+            event="job.started",
+            message=str(job.get("message") or message or "Job started"),
+            progress=_clamp_progress(job.get("progress", 0.0)),
+        )
+
+
+
 def _set_job_progress(
     job_id: str,
     progress: float,
@@ -2672,6 +2745,7 @@ def _set_job_complete(
         job["progress"] = 100.0
         job["result"] = copy.deepcopy(result)
         job["error"] = None
+        job["error_code"] = None
         job["updated_at"] = _utc_now_iso()
         job["updated_ts"] = now_ts
         job["completed_at"] = _utc_now_iso()
@@ -2717,6 +2791,7 @@ def _set_job_error(
         job["error"] = str(error_message)
         if traceback_str:
             job["traceback"] = str(traceback_str)
+        job["error_code"] = _infer_job_error_code(error_message)
         job["updated_at"] = _utc_now_iso()
         job["updated_ts"] = now_ts
         job["completed_at"] = _utc_now_iso()
@@ -2741,7 +2816,7 @@ def _get_job_snapshot(job_id: str) -> Optional[Dict[str, Any]]:
 def _job_logs_payload(job: Dict[str, Any], *, offset: int = 0, limit: int = JOB_LOG_MAX_ENTRIES) -> Dict[str, Any]:
     logs = job.get("logs") if isinstance(job.get("logs"), list) else []
     safe_offset = max(0, int(offset or 0))
-    safe_limit = max(1, min(int(limit or JOB_LOG_MAX_ENTRIES), JOB_LOG_MAX_ENTRIES))
+    safe_limit = max(1, min(int(limit or _job_log_limit()), _job_log_limit()))
     sliced = copy.deepcopy(logs[safe_offset:safe_offset + safe_limit])
     return {
         "jobId": str(job.get("jobId") or ""),
@@ -2840,6 +2915,8 @@ def _job_response_payload(job: Dict[str, Any]) -> Dict[str, Any]:
 
     payload["segmentsProcessed"] = int(job.get("segmentsProcessed", 0) or 0)
     payload["totalSegments"] = int(job.get("totalSegments", 0) or 0)
+    if job.get("error_code"):
+        payload["errorCode"] = str(job.get("error_code"))
 
     if job_type == "chat:run":
         payload["runId"] = job_id
@@ -6073,7 +6150,7 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             raise ApiError(HTTPStatus.NOT_FOUND, "Unknown jobId")
         query = urlparse(self.path).query
         offset = 0
-        limit = JOB_LOG_MAX_ENTRIES
+        limit = _job_log_limit()
         for piece in query.split("&"):
             if not piece or "=" not in piece:
                 continue

--- a/python/test_server_job_observability.py
+++ b/python/test_server_job_observability.py
@@ -108,6 +108,58 @@ def test_speaker_resource_lock_blocks_concurrent_mutating_jobs_and_releases_on_c
     assert second_snapshot["locks"]["resources"] == [{"kind": "speaker", "id": "Fail01"}]
 
 
+def test_job_completion_dispatches_callback_payload(monkeypatch) -> None:
+    server._jobs.clear()
+    delivered = []
+
+    def fake_post(url: str, payload: dict) -> None:
+        delivered.append((url, payload))
+
+    monkeypatch.setattr(server, "_post_job_callback", fake_post)
+    monkeypatch.setattr(server, "_dispatch_job_callback_async", lambda snapshot: server._dispatch_job_callback(snapshot))
+
+    job_id = server._create_job(
+        "stt",
+        {"speaker": "Fail01", "callbackUrl": "https://example.test/hooks/job"},
+    )
+    server._set_job_complete(job_id, {"segments": 12}, message="STT complete")
+
+    assert len(delivered) == 1
+    callback_url, payload = delivered[0]
+    assert callback_url == "https://example.test/hooks/job"
+    assert payload["jobId"] == job_id
+    assert payload["status"] == "complete"
+    assert payload["result"] == {"segments": 12}
+    assert payload["meta"]["speaker"] == "Fail01"
+
+
+
+def test_job_error_dispatches_callback_payload(monkeypatch) -> None:
+    server._jobs.clear()
+    delivered = []
+
+    def fake_post(url: str, payload: dict) -> None:
+        delivered.append((url, payload))
+
+    monkeypatch.setattr(server, "_post_job_callback", fake_post)
+    monkeypatch.setattr(server, "_dispatch_job_callback_async", lambda snapshot: server._dispatch_job_callback(snapshot))
+
+    job_id = server._create_job(
+        "normalize",
+        {"speaker": "Fail02", "callbackUrl": "https://example.test/hooks/job"},
+    )
+    server._set_job_error(job_id, "ffmpeg failed with exit code 1")
+
+    assert len(delivered) == 1
+    callback_url, payload = delivered[0]
+    assert callback_url == "https://example.test/hooks/job"
+    assert payload["jobId"] == job_id
+    assert payload["status"] == "error"
+    assert payload["errorCode"] == "ffmpeg_failed"
+    assert payload["meta"]["speaker"] == "Fail02"
+
+
+
 def test_api_get_jobs_and_job_logs_return_generic_observability_payloads() -> None:
     server._jobs.clear()
 
@@ -184,3 +236,18 @@ def test_api_rejects_conflicting_speaker_mutation_jobs_with_409() -> None:
     assert exc_info.value.status == HTTPStatus.CONFLICT
     assert lock_job in exc_info.value.message
     assert "Fail01" in exc_info.value.message
+
+
+
+def test_api_rejects_invalid_callback_url() -> None:
+    server._jobs.clear()
+    handler = _HandlerHarness(
+        "/api/stt",
+        {"speaker": "Fail01", "sourceWav": "audio/Fail01.wav", "callbackUrl": "ftp://example.test/hook"},
+    )
+
+    with pytest.raises(server.ApiError) as exc_info:
+        handler._api_post_stt_start()
+
+    assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+    assert "callbackUrl" in exc_info.value.message

--- a/python/test_server_job_observability.py
+++ b/python/test_server_job_observability.py
@@ -2,6 +2,8 @@ import pathlib
 import sys
 from http import HTTPStatus
 
+import pytest
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import server
 
@@ -33,8 +35,9 @@ def test_job_logs_capture_lifecycle_and_progress() -> None:
     assert isinstance(logs, list)
     assert len(logs) >= 4
     assert logs[0]["event"] == "job.created"
-    assert logs[1]["message"] == "Scanning loudness (pass 1)"
-    assert logs[2]["message"] == "Normalizing audio (pass 2)"
+    assert any(entry["event"] == "job.lock_acquired" for entry in logs)
+    assert any(entry["message"] == "Scanning loudness (pass 1)" for entry in logs)
+    assert any(entry["message"] == "Normalizing audio (pass 2)" for entry in logs)
     assert logs[-1]["event"] == "job.completed"
     assert logs[-1]["message"] == "Normalize complete"
 
@@ -53,7 +56,9 @@ def test_job_lifecycle_supports_queued_running_and_error_states(monkeypatch) -> 
     assert snapshot["status"] == "error"
     assert snapshot["error_code"] == "ffmpeg_failed"
     events = [entry["event"] for entry in snapshot["logs"]]
-    assert events[:2] == ["job.queued", "job.started"]
+    assert events[0] == "job.queued"
+    assert "job.lock_acquired" in events
+    assert "job.started" in events
     assert events[-1] == "job.failed"
 
 
@@ -69,6 +74,38 @@ def test_job_log_ring_buffer_size_is_configurable(monkeypatch) -> None:
     assert snapshot is not None
     assert len(snapshot["logs"]) == 10
     assert snapshot["logs"][-1]["message"] == "step-19"
+
+
+def test_speaker_resource_lock_blocks_concurrent_mutating_jobs_and_releases_on_completion() -> None:
+    server._jobs.clear()
+
+    first_job = server._create_job("normalize", {"speaker": "Fail01", "sourceWav": "audio/Fail01.wav"})
+    first_snapshot = server._get_job_snapshot(first_job)
+    assert first_snapshot is not None
+    assert first_snapshot["locks"]["active"] is True
+    assert first_snapshot["locks"]["resources"] == [{"kind": "speaker", "id": "Fail01"}]
+
+    with pytest.raises(server.JobResourceConflictError) as exc_info:
+        server._create_job("stt", {"speaker": "Fail01", "sourceWav": "audio/Fail01.wav"})
+
+    assert exc_info.value.resource_kind == "speaker"
+    assert exc_info.value.resource_id == "Fail01"
+    assert exc_info.value.holder_job_id == first_job
+
+    probe_job = server._create_job("compute:offset_detect", {"speaker": "Fail01"})
+    assert isinstance(probe_job, str)
+
+    server._set_job_complete(first_job, {"ok": True}, message="Normalize complete")
+    finished_snapshot = server._get_job_snapshot(first_job)
+    assert finished_snapshot is not None
+    assert finished_snapshot["locks"]["active"] is False
+    assert finished_snapshot["locks"]["released_at"] is not None
+
+    second_job = server._create_job("stt", {"speaker": "Fail01", "sourceWav": "audio/Fail01.wav"})
+    second_snapshot = server._get_job_snapshot(second_job)
+    assert second_snapshot is not None
+    assert second_snapshot["locks"]["active"] is True
+    assert second_snapshot["locks"]["resources"] == [{"kind": "speaker", "id": "Fail01"}]
 
 
 def test_api_get_jobs_and_job_logs_return_generic_observability_payloads() -> None:
@@ -95,6 +132,8 @@ def test_api_get_jobs_and_job_logs_return_generic_observability_payloads() -> No
     assert payload["jobId"] == running_job
     assert payload["type"] == "stt"
     assert payload["meta"]["speaker"] == "Fail01"
+    assert payload["locks"]["active"] is True
+    assert payload["locks"]["resources"] == [{"kind": "speaker", "id": "Fail01"}]
 
     handler.path = "/api/jobs/{0}/logs".format(running_job)
     handler._api_get_job_logs(running_job)
@@ -127,3 +166,21 @@ def test_backward_compatible_status_endpoints_still_return_job_payloads() -> Non
     assert payload["jobId"] == normalize_job
     assert payload["status"] == "error"
     assert payload["errorCode"] == "ffmpeg_failed"
+
+
+
+def test_api_rejects_conflicting_speaker_mutation_jobs_with_409() -> None:
+    server._jobs.clear()
+    lock_job = server._create_job("normalize", {"speaker": "Fail01", "sourceWav": "audio/Fail01.wav"})
+
+    handler = _HandlerHarness(
+        "/api/stt",
+        {"speaker": "Fail01", "sourceWav": "audio/Fail01.wav"},
+    )
+
+    with pytest.raises(server.ApiError) as exc_info:
+        handler._api_post_stt_start()
+
+    assert exc_info.value.status == HTTPStatus.CONFLICT
+    assert lock_job in exc_info.value.message
+    assert "Fail01" in exc_info.value.message

--- a/python/test_server_job_observability.py
+++ b/python/test_server_job_observability.py
@@ -7,9 +7,13 @@ import server
 
 
 class _HandlerHarness(server.RangeRequestHandler):
-    def __init__(self, path: str = "/api/jobs"):
+    def __init__(self, path: str = "/api/jobs", body=None):
         self.path = path
+        self._body = body or {}
         self.sent = []
+
+    def _read_json_body(self, required: bool = True):
+        return self._body
 
     def _send_json(self, status, payload):
         self.sent.append((status, payload))
@@ -33,6 +37,38 @@ def test_job_logs_capture_lifecycle_and_progress() -> None:
     assert logs[2]["message"] == "Normalizing audio (pass 2)"
     assert logs[-1]["event"] == "job.completed"
     assert logs[-1]["message"] == "Normalize complete"
+
+
+def test_job_lifecycle_supports_queued_running_and_error_states(monkeypatch) -> None:
+    server._jobs.clear()
+    monkeypatch.setenv("PARSE_JOB_LOG_MAX_ENTRIES", "20")
+
+    job_id = server._create_job("compute:full_pipeline", {"speaker": "Fail03"}, initial_status="queued")
+    server._set_job_running(job_id, message="Dequeued for execution")
+    server._set_job_progress(job_id, 15.0, message="Running pipeline")
+    server._set_job_error(job_id, "ffmpeg failed with exit code 1")
+
+    snapshot = server._get_job_snapshot(job_id)
+    assert snapshot is not None
+    assert snapshot["status"] == "error"
+    assert snapshot["error_code"] == "ffmpeg_failed"
+    events = [entry["event"] for entry in snapshot["logs"]]
+    assert events[:2] == ["job.queued", "job.started"]
+    assert events[-1] == "job.failed"
+
+
+def test_job_log_ring_buffer_size_is_configurable(monkeypatch) -> None:
+    server._jobs.clear()
+    monkeypatch.setenv("PARSE_JOB_LOG_MAX_ENTRIES", "10")
+
+    job_id = server._create_job("stt", {"speaker": "Fail04"})
+    for idx in range(20):
+        server._set_job_progress(job_id, float(idx), message="step-{0}".format(idx))
+
+    snapshot = server._get_job_snapshot(job_id)
+    assert snapshot is not None
+    assert len(snapshot["logs"]) == 10
+    assert snapshot["logs"][-1]["message"] == "step-19"
 
 
 def test_api_get_jobs_and_job_logs_return_generic_observability_payloads() -> None:
@@ -67,3 +103,27 @@ def test_api_get_jobs_and_job_logs_return_generic_observability_payloads() -> No
     assert payload["jobId"] == running_job
     assert payload["count"] >= 2
     assert payload["logs"][-1]["message"] == "Transcribing"
+
+
+def test_backward_compatible_status_endpoints_still_return_job_payloads() -> None:
+    server._jobs.clear()
+
+    stt_job = server._create_job("stt", {"speaker": "Fail01"})
+    normalize_job = server._create_job("normalize", {"speaker": "Fail02"})
+    server._set_job_progress(stt_job, 35.0, message="Transcribing")
+    server._set_job_error(normalize_job, "ffmpeg failed with exit code 1")
+
+    stt_handler = _HandlerHarness("/api/stt/status", {"jobId": stt_job})
+    stt_handler._api_post_stt_status()
+    status, payload = stt_handler.sent[-1]
+    assert status == HTTPStatus.OK
+    assert payload["jobId"] == stt_job
+    assert payload["status"] == "running"
+
+    normalize_handler = _HandlerHarness("/api/normalize/status", {"jobId": normalize_job})
+    normalize_handler._api_post_normalize_status()
+    status, payload = normalize_handler.sent[-1]
+    assert status == HTTPStatus.OK
+    assert payload["jobId"] == normalize_job
+    assert payload["status"] == "error"
+    assert payload["errorCode"] == "ffmpeg_failed"

--- a/python/test_server_job_observability.py
+++ b/python/test_server_job_observability.py
@@ -1,0 +1,69 @@
+import pathlib
+import sys
+from http import HTTPStatus
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+class _HandlerHarness(server.RangeRequestHandler):
+    def __init__(self, path: str = "/api/jobs"):
+        self.path = path
+        self.sent = []
+
+    def _send_json(self, status, payload):
+        self.sent.append((status, payload))
+
+
+def test_job_logs_capture_lifecycle_and_progress() -> None:
+    server._jobs.clear()
+
+    job_id = server._create_job("normalize", {"speaker": "Fail01"})
+    server._set_job_progress(job_id, 10.0, message="Scanning loudness (pass 1)")
+    server._set_job_progress(job_id, 40.0, message="Normalizing audio (pass 2)")
+    server._set_job_complete(job_id, {"speaker": "Fail01"}, message="Normalize complete")
+
+    snapshot = server._get_job_snapshot(job_id)
+    assert snapshot is not None
+    logs = snapshot.get("logs")
+    assert isinstance(logs, list)
+    assert len(logs) >= 4
+    assert logs[0]["event"] == "job.created"
+    assert logs[1]["message"] == "Scanning loudness (pass 1)"
+    assert logs[2]["message"] == "Normalizing audio (pass 2)"
+    assert logs[-1]["event"] == "job.completed"
+    assert logs[-1]["message"] == "Normalize complete"
+
+
+def test_api_get_jobs_and_job_logs_return_generic_observability_payloads() -> None:
+    server._jobs.clear()
+
+    running_job = server._create_job("stt", {"speaker": "Fail01"})
+    finished_job = server._create_job("normalize", {"speaker": "Fail02"})
+    server._set_job_progress(running_job, 25.0, message="Transcribing")
+    server._set_job_complete(finished_job, {"speaker": "Fail02"}, message="Normalize complete")
+
+    handler = _HandlerHarness("/api/jobs")
+    handler._api_get_jobs()
+    status, payload = handler.sent[-1]
+    assert status == HTTPStatus.OK
+    assert payload["count"] == 2
+    by_id = {job["jobId"]: job for job in payload["jobs"]}
+    assert by_id[running_job]["status"] == "running"
+    assert by_id[finished_job]["status"] == "complete"
+    assert by_id[running_job]["logCount"] >= 2
+
+    handler._api_get_job(running_job)
+    status, payload = handler.sent[-1]
+    assert status == HTTPStatus.OK
+    assert payload["jobId"] == running_job
+    assert payload["type"] == "stt"
+    assert payload["meta"]["speaker"] == "Fail01"
+
+    handler.path = "/api/jobs/{0}/logs".format(running_job)
+    handler._api_get_job_logs(running_job)
+    status, payload = handler.sent[-1]
+    assert status == HTTPStatus.OK
+    assert payload["jobId"] == running_job
+    assert payload["count"] >= 2
+    assert payload["logs"][-1]["message"] == "Transcribing"


### PR DESCRIPTION
## Summary
- add generic job observability HTTP endpoints and MCP tools (`jobs_list`, `job_status`, `job_logs`)
- store structured per-job log entries in the shared `_jobs` registry with configurable ring-buffer size
- add machine-readable `errorCode`, queued→running lifecycle helpers, and AGENTS.md usage docs
- expand regression coverage for lifecycle logs, generic endpoints, ring-buffer config, and backward-compatible status endpoints

## Test Plan
- `python -m pytest python/test_server_job_observability.py -q`
- `python -m pytest python/adapters/test_mcp_adapter.py python/ai/test_pipeline_chat_tools.py -q`
- `python -m py_compile python/server.py python/ai/chat_tools.py python/adapters/mcp_adapter.py python/test_server_job_observability.py`

## Notes
- Phase 1 only: webhook payload enrichment is intentionally deferred to the Phase 3 webhook implementation.
- Added lock TTL metadata scaffolding (`JOB_LOCK_TTL_SECONDS`, per-job `locks` block) to keep Phase 2 speaker locking cleaner without changing lock behavior yet.
