### PR TITLE
fix(offset): lock detect modal + persist header status + crash-log viewer

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -1905,10 +1905,8 @@ def _launch_compute_subprocess(
             )
         else:
             err = str(payload_out.get("error") or "Compute subprocess reported failure")
-            tb = str(payload_out.get("traceback") or "")
-            if tb:
-                err = "{0}\n{1}".format(err, tb)
-            _set_job_error(job_id, err)
+            tb = str(payload_out.get("traceback") or "") or None
+            _set_job_error(job_id, err, traceback_str=tb)
 
     monitor = threading.Thread(
         target=_monitor,
@@ -2426,6 +2424,37 @@ _COMPUTE_CHECKPOINT_FD: Optional[int] = None
 _COMPUTE_CHECKPOINT_LOCK = threading.Lock()
 
 
+def _tail_log_file(path: str, max_lines: int = 200, max_bytes: int = 256 * 1024) -> Optional[str]:
+    """Return the last ``max_lines`` lines of ``path``, capped at ``max_bytes``.
+
+    Best-effort: returns None if the file is missing, unreadable, or empty.
+    Used by ``_api_get_job_logs`` to surface worker stderr tails without
+    pulling the whole file. Bytes cap protects against a multi-MB log
+    ending up in a JSON response body.
+    """
+    try:
+        with open(path, "rb") as fh:
+            try:
+                fh.seek(0, os.SEEK_END)
+                size = fh.tell()
+            except OSError:
+                size = 0
+            if size <= 0:
+                return None
+            start = max(0, size - max_bytes)
+            fh.seek(start)
+            chunk = fh.read()
+    except (OSError, FileNotFoundError):
+        return None
+    if not chunk:
+        return None
+    text = chunk.decode("utf-8", errors="replace")
+    lines = text.splitlines()
+    if len(lines) > max_lines:
+        lines = lines[-max_lines:]
+    return "\n".join(lines) if lines else None
+
+
 def _compute_checkpoint_path() -> str:
     global _COMPUTE_CHECKPOINT_LOG_PATH
     if _COMPUTE_CHECKPOINT_LOG_PATH is None:
@@ -2544,7 +2573,15 @@ def _set_job_complete(
                 pass
 
 
-def _set_job_error(job_id: str, error_message: str) -> None:
+def _set_job_error(
+    job_id: str,
+    error_message: str,
+    traceback_str: Optional[str] = None,
+) -> None:
+    """Mark a job as errored. ``traceback_str`` is stored separately from
+    the short error message so the UI's crash-log modal can render the
+    one-line reason on top and the full Python traceback below without
+    having to split-on-newline."""
     with _jobs_lock:
         job = _jobs.get(job_id)
         if job is None:
@@ -2553,6 +2590,8 @@ def _set_job_error(job_id: str, error_message: str) -> None:
         now_ts = time.time()
         job["status"] = "error"
         job["error"] = str(error_message)
+        if traceback_str:
+            job["traceback"] = str(traceback_str)
         job["updated_at"] = _utc_now_iso()
         job["updated_ts"] = now_ts
         job["completed_at"] = _utc_now_iso()
@@ -2591,6 +2630,8 @@ def _job_response_payload(job: Dict[str, Any]) -> Dict[str, Any]:
         payload["message"] = job.get("message")
     if job.get("error"):
         payload["error"] = str(job.get("error"))
+    if job.get("traceback"):
+        payload["traceback"] = str(job.get("traceback"))
 
     payload["segmentsProcessed"] = int(job.get("segmentsProcessed", 0) or 0)
     payload["totalSegments"] = int(job.get("totalSegments", 0) or 0)
@@ -4717,6 +4758,43 @@ def _reset_job_to_running(job_id: str) -> None:
 
 
 
+_OFFSET_DETECT_TIMEOUT_SEC_DEFAULT = 600.0
+
+
+def _offset_detect_timeout_sec() -> float:
+    """Hard cap on offset-detection runtime. Defaults to 10 minutes.
+    Override via ``PARSE_OFFSET_DETECT_TIMEOUT_SEC``. Covers both
+    ``offset_detect`` and ``offset_detect_from_pair`` — the manual path
+    is normally sub-second but shares the guard for consistency."""
+    try:
+        raw = os.environ.get("PARSE_OFFSET_DETECT_TIMEOUT_SEC", "").strip()
+        if not raw:
+            return _OFFSET_DETECT_TIMEOUT_SEC_DEFAULT
+        val = float(raw)
+        if val <= 0 or not math.isfinite(val):
+            return _OFFSET_DETECT_TIMEOUT_SEC_DEFAULT
+        return val
+    except (TypeError, ValueError):
+        return _OFFSET_DETECT_TIMEOUT_SEC_DEFAULT
+
+
+def _enforce_offset_deadline(deadline: float, label: str) -> None:
+    """Raise TimeoutError if ``deadline`` (monotonic sec) has passed.
+
+    Called at progress checkpoints inside the offset compute functions.
+    Doesn't interrupt in-flight work on its own — Python can't kill a
+    thread mid-numerics — but guarantees the UI gets a clean "timed out"
+    error with the full traceback instead of an indefinite detecting
+    modal. The compute worker survives the TimeoutError like any other
+    raised exception (worker_main's try/except captures + emits it)."""
+    if time.monotonic() > deadline:
+        raise TimeoutError(
+            "Offset detection exceeded {0:.0f}s hard timeout at stage '{1}'. "
+            "Raise PARSE_OFFSET_DETECT_TIMEOUT_SEC if your corpus legitimately "
+            "needs more time.".format(_offset_detect_timeout_sec(), label)
+        )
+
+
 def _compute_offset_detect(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     """Compute-dispatcher adapter for timestamp offset detection.
 
@@ -4724,6 +4802,7 @@ def _compute_offset_detect(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
     header progress bar appears while annotation and STT data are correlated.
     No GPU work — intentionally CPU-only.
     """
+    deadline = time.monotonic() + _offset_detect_timeout_sec()
     speaker = str(payload.get("speaker") or "").strip()
     if not speaker:
         raise ValueError("offset_detect payload missing 'speaker'")
@@ -4808,6 +4887,7 @@ def _compute_offset_detect(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
     if not segments:
         raise ValueError("STT input contained no usable segments")
 
+    _enforce_offset_deadline(deadline, "pre-match")
     _set_job_progress(job_id, 75, message="Computing timestamp offset")
     try:
         detailed = _detect_offset_detailed(
@@ -4820,6 +4900,7 @@ def _compute_offset_detect(job_id: str, payload: Dict[str, Any]) -> Dict[str, An
     except ValueError as exc:
         raise ValueError("Offset detection failed: {0}".format(exc)) from exc
 
+    _enforce_offset_deadline(deadline, "post-match")
     _set_job_progress(job_id, 92, message="Finalizing result")
     return _offset_detect_payload(
         speaker=speaker,
@@ -4841,6 +4922,7 @@ def _compute_offset_detect_from_pair(job_id: str, payload: Dict[str, Any]) -> Di
     Accepts one or more (audioTimeSec, csvTimeSec/conceptId) pairs and returns
     the median offset. Pure arithmetic — no STT or GPU work.
     """
+    deadline = time.monotonic() + _offset_detect_timeout_sec()
     speaker = str(payload.get("speaker") or "").strip()
     if not speaker:
         raise ValueError("offset_detect_from_pair payload missing 'speaker'")
@@ -4929,6 +5011,7 @@ def _compute_offset_detect_from_pair(job_id: str, payload: Dict[str, Any]) -> Di
             }
         )
 
+    _enforce_offset_deadline(deadline, "pre-median")
     _set_job_progress(job_id, 75, message="Computing median offset")
     import statistics as _statistics
 
@@ -5165,6 +5248,15 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         if request_path == "/api/jobs/active":
             self._api_get_jobs_active()
+            return
+
+        if (
+            len(parts) == 4
+            and parts[0] == "api"
+            and parts[1] == "jobs"
+            and parts[3] == "logs"
+        ):
+            self._api_get_job_logs(parts[2])
             return
 
         if request_path == "/api/enrichments":
@@ -5734,6 +5826,53 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         """Return a list of currently-running jobs so the UI can rehydrate
         progress after a page reload. See ``_list_active_jobs_snapshots``."""
         self._send_json(HTTPStatus.OK, {"jobs": _list_active_jobs_snapshots()})
+
+    def _api_get_job_logs(self, job_id: str) -> None:
+        """Return the error, traceback, and tail of any stderr log files
+        associated with a job. Powers the UI's "View crash log" modal.
+
+        Reads from two places:
+          1. The in-memory job record — ``error`` (short reason) and
+             ``traceback`` (full Python traceback), when the job failed.
+          2. The per-job stderr log written by ``_compute_subprocess_entry``
+             at ``/tmp/parse-compute-<job_id>.stderr.log`` and the shared
+             persistent-worker log at ``/tmp/parse-compute-worker.stderr.log``.
+             Only the last ~200 lines of each are returned so a runaway
+             log doesn't bloat the response.
+
+        Response shape: ``{jobId, status, type, error?, traceback?,
+        message?, stderrLog?, workerStderrLog?}``. All log fields are
+        omitted when unavailable — the UI renders whatever is present.
+        """
+        snapshot = _get_job_snapshot(job_id)
+        if snapshot is None:
+            raise ApiError(HTTPStatus.NOT_FOUND, "Unknown job_id")
+
+        payload: Dict[str, Any] = {
+            "jobId": job_id,
+            "status": str(snapshot.get("status") or ""),
+            "type": str(snapshot.get("type") or ""),
+        }
+        if snapshot.get("error"):
+            payload["error"] = str(snapshot.get("error"))
+        if snapshot.get("traceback"):
+            payload["traceback"] = str(snapshot.get("traceback"))
+        if snapshot.get("message"):
+            payload["message"] = str(snapshot.get("message"))
+
+        job_stderr = _tail_log_file(
+            "/tmp/parse-compute-{0}.stderr.log".format(job_id), max_lines=200
+        )
+        if job_stderr:
+            payload["stderrLog"] = job_stderr
+
+        worker_stderr = _tail_log_file(
+            "/tmp/parse-compute-worker.stderr.log", max_lines=200
+        )
+        if worker_stderr:
+            payload["workerStderrLog"] = worker_stderr
+
+        self._send_json(HTTPStatus.OK, payload)
 
     def _api_get_worker_status(self) -> None:
         """Health check for the persistent compute worker.

--- a/python/test_offset_job_failure_paths.py
+++ b/python/test_offset_job_failure_paths.py
@@ -1,0 +1,94 @@
+"""Failure-path tests for the async offset-detect compute job.
+
+These complement test_offset_detect_monotonic + test_offset_manual_pairs
+by covering the *error reporting* surface introduced in the Beta
+stability PR: traceback-preserving job state, /api/jobs/<id>/logs tail
+reader, and the offset-specific 600 s hard deadline.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import server
+
+
+def _reset_job(job_id: str, status: str = "running") -> None:
+    with server._jobs_lock:
+        server._jobs[job_id] = {
+            "jobId": job_id,
+            "status": status,
+            "progress": 0.0,
+            "result": None,
+            "error": None,
+            "updated_at": "",
+            "updated_ts": time.time(),
+        }
+
+
+def test_set_job_error_stores_traceback_separately_from_reason():
+    """The short reason and full traceback must land in distinct fields
+    so the UI's crash-log modal renders them separately instead of
+    splitting a concatenated blob on newlines."""
+    job_id = "fail-job-1"
+    _reset_job(job_id)
+    server._set_job_error(
+        job_id,
+        "Offset detection failed: STT missing",
+        traceback_str="Traceback (most recent call last):\n  File …\nValueError: STT missing",
+    )
+
+    snap = server._get_job_snapshot(job_id)
+    assert snap is not None
+    assert snap["status"] == "error"
+    assert snap["error"] == "Offset detection failed: STT missing"
+    assert snap["traceback"].startswith("Traceback (most recent call last)")
+    # The short reason must NOT be polluted by the traceback — regressions
+    # here would re-introduce the "wall of stderr in a toast" UX.
+    assert "Traceback" not in snap["error"]
+
+
+def test_job_response_payload_exposes_traceback_to_http_clients():
+    job_id = "fail-job-2"
+    _reset_job(job_id)
+    server._set_job_error(
+        job_id,
+        "BOOM",
+        traceback_str="Traceback\n  File\nRuntimeError: BOOM",
+    )
+    snap = server._get_job_snapshot(job_id)
+    payload = server._job_response_payload(snap)
+    assert payload["error"] == "BOOM"
+    assert payload["traceback"].startswith("Traceback")
+
+
+def test_tail_log_file_handles_missing_and_empty(tmp_path):
+    missing = tmp_path / "does-not-exist.log"
+    assert server._tail_log_file(str(missing)) is None
+
+    empty = tmp_path / "empty.log"
+    empty.write_text("")
+    assert server._tail_log_file(str(empty)) is None
+
+    populated = tmp_path / "pop.log"
+    populated.write_text("line1\nline2\nline3\n")
+    result = server._tail_log_file(str(populated), max_lines=2)
+    assert result is not None
+    assert result.splitlines() == ["line2", "line3"]
+
+
+def test_enforce_offset_deadline_passes_before_expiry():
+    # Deadline 10s in the future — must not raise.
+    server._enforce_offset_deadline(time.monotonic() + 10.0, "test")
+
+
+def test_enforce_offset_deadline_raises_after_expiry():
+    with pytest.raises(TimeoutError) as excinfo:
+        server._enforce_offset_deadline(time.monotonic() - 1.0, "pre-match")
+    assert "pre-match" in str(excinfo.value)
+    assert "PARSE_OFFSET_DETECT_TIMEOUT_SEC" in str(excinfo.value)

--- a/python/workers/compute_worker.py
+++ b/python/workers/compute_worker.py
@@ -216,10 +216,16 @@ class WorkerHandle:
                 elif kind == "error":
                     self._in_flight.pop(job_id, None)
                     err = str(event.get("error") or "Unknown worker error")
-                    tb = str(event.get("traceback") or "")
-                    if tb:
-                        err = "{0}\n{1}".format(err, tb)
-                    self._on_error(job_id, err)
+                    tb = str(event.get("traceback") or "") or None
+                    # Prefer the keyword form so the parent's
+                    # _set_job_error can persist the traceback separately
+                    # from the short reason. Fall back to the positional
+                    # form for older parents that don't accept it.
+                    try:
+                        self._on_error(job_id, err, traceback_str=tb)
+                    except TypeError:
+                        combined = err if not tb else "{0}\n{1}".format(err, tb)
+                        self._on_error(job_id, combined)
             except Exception as exc:
                 print(
                     "[WORKER] monitor handler failed ({0}): {1}".format(kind, exc),
@@ -294,8 +300,14 @@ def _install_parent_emitters(event_queue: Any) -> None:
             total_segments=total_segments,
         )
 
-    def _patched_error(job_id, error_message):
-        _emit(event_queue, "error", job_id=job_id, error=str(error_message))
+    def _patched_error(job_id, error_message, traceback_str=None):
+        _emit(
+            event_queue,
+            "error",
+            job_id=job_id,
+            error=str(error_message),
+            traceback=str(traceback_str) if traceback_str else "",
+        )
 
     server_mod._set_job_progress = _patched_progress
     server_mod._set_job_complete = _patched_complete

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -12,7 +12,8 @@ import {
   Sun, Moon, XCircle
 } from 'lucide-react';
 import type { AnnotationInterval, AnnotationRecord, Tag as StoreTag } from './api/types';
-import { getLingPyExport, saveApiKey, getAuthStatus, pollAuth, startAuthFlow, startCompute, pollCompute, importTagCsv, detectTimestampOffset, detectTimestampOffsetFromPairs, applyTimestampOffset, searchLexeme, pollOffsetDetectJob } from './api/client';
+import { getLingPyExport, saveApiKey, getAuthStatus, pollAuth, startAuthFlow, startCompute, pollCompute, importTagCsv, detectTimestampOffset, detectTimestampOffsetFromPairs, applyTimestampOffset, searchLexeme, pollOffsetDetectJob, OffsetJobError, getJobLogs } from './api/client';
+import type { JobLogsPayload } from './api/client';
 import type { OffsetDetectResult, OffsetPair, LexemeSearchCandidate } from './api/client';
 import { useChatSession, type UseChatSessionResult } from './hooks/useChatSession';
 import { compareSurveyKeys, surveyBadgePrefix } from './lib/surveySort';
@@ -2119,15 +2120,26 @@ export function ParseUI() {
 
   const [importModalOpen, setImportModalOpen] = useState(false);
 
+  // The ``detecting`` / ``applying`` phases now carry the backend job id
+  // and the worker's latest progress checkpoint so the header chip can
+  // mirror what the worker is doing in real time. The ``error`` phase
+  // keeps ``jobId`` so the "View crash log" button can call
+  // ``GET /api/jobs/<id>/logs`` for the full stderr tail + Python
+  // traceback.
   const [offsetState, setOffsetState] = useState<
     | { phase: 'idle' }
-    | { phase: 'detecting' }
+    | { phase: 'detecting'; jobId: string | null; progress: number; progressMessage?: string; origin: 'auto' | 'manual' }
     | { phase: 'detected'; result: OffsetDetectResult }
     | { phase: 'manual' }
     | { phase: 'applying'; result: OffsetDetectResult }
     | { phase: 'applied'; result: OffsetDetectResult; shifted: number }
-    | { phase: 'error'; message: string }
+    | { phase: 'error'; message: string; traceback?: string; jobId?: string }
   >({ phase: 'idle' });
+
+  // Modal for viewing a failed compute job's error + traceback +
+  // worker stderr tail. Reachable from the offset header chip's "View
+  // crash log" button and from the inline error panel.
+  const [jobLogsOpen, setJobLogsOpen] = useState<string | null>(null);
 
   // Manual-pair anchors live at parent scope so the playback-bar capture
   // button (Annotate mode) and the modal share the same list. Each anchor
@@ -2259,17 +2271,28 @@ export function ParseUI() {
       setOffsetState({ phase: 'error', message: 'Select a speaker first.' });
       return;
     }
-    setOffsetState({ phase: 'detecting' });
+    setOffsetState({ phase: 'detecting', jobId: null, progress: 0, origin: 'auto' });
+    let submittedJobId: string | null = null;
     try {
       const { jobId } = await detectTimestampOffset(activeActionSpeaker);
       if (!jobId) throw new Error('Server did not return a job ID for offset detection');
-      const result = await pollOffsetDetectJob(jobId, 'offset_detect');
+      submittedJobId = jobId;
+      setOffsetState({ phase: 'detecting', jobId, progress: 0, origin: 'auto' });
+      const result = await pollOffsetDetectJob(jobId, 'offset_detect', {
+        onProgress: ({ progress, message }) => {
+          setOffsetState((prev) =>
+            prev.phase === 'detecting'
+              ? { ...prev, progress, progressMessage: message }
+              : prev,
+          );
+        },
+      });
       setOffsetState({ phase: 'detected', result });
     } catch (err) {
-      setOffsetState({
-        phase: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      });
+      const message = err instanceof Error ? err.message : String(err);
+      const traceback = err instanceof OffsetJobError ? err.traceback : undefined;
+      const jobId = err instanceof OffsetJobError ? err.jobId : submittedJobId ?? undefined;
+      setOffsetState({ phase: 'error', message, traceback, jobId });
     }
   };
 
@@ -2302,6 +2325,7 @@ export function ParseUI() {
       return;
     }
     setManualBusy(true);
+    let submittedJobId: string | null = null;
     try {
       const pairs: OffsetPair[] = manualAnchors.map((a) => ({
         audioTimeSec: a.audioTimeSec,
@@ -2309,13 +2333,23 @@ export function ParseUI() {
       }));
       const { jobId } = await detectTimestampOffsetFromPairs(activeActionSpeaker, pairs);
       if (!jobId) throw new Error('Server did not return a job ID');
-      const result = await pollOffsetDetectJob(jobId, 'offset_detect_from_pair');
+      submittedJobId = jobId;
+      setOffsetState({ phase: 'detecting', jobId, progress: 0, origin: 'manual' });
+      const result = await pollOffsetDetectJob(jobId, 'offset_detect_from_pair', {
+        onProgress: ({ progress, message }) => {
+          setOffsetState((prev) =>
+            prev.phase === 'detecting'
+              ? { ...prev, progress, progressMessage: message }
+              : prev,
+          );
+        },
+      });
       setOffsetState({ phase: 'detected', result });
     } catch (err) {
-      setOffsetState({
-        phase: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      });
+      const message = err instanceof Error ? err.message : String(err);
+      const traceback = err instanceof OffsetJobError ? err.traceback : undefined;
+      const jobId = err instanceof OffsetJobError ? err.jobId : submittedJobId ?? undefined;
+      setOffsetState({ phase: 'error', message, traceback, jobId });
     } finally {
       setManualBusy(false);
     }
@@ -2696,6 +2730,68 @@ export function ParseUI() {
               )}
             </div>
           )}
+          {/* Persistent offset-job status chip. Survives modal dismissal
+              (even though we now lock the modal while the job runs, a
+              separate header indicator matters for the applying phase
+              and gives the user a single "what is PARSE doing" glance).
+              Idle state → renders nothing. Error state → click re-opens
+              the modal so the traceback + crash log are one click away. */}
+          {offsetState.phase !== 'idle' && (offsetState.phase === 'detecting' || offsetState.phase === 'applying' || offsetState.phase === 'error') && (() => {
+            const isError = offsetState.phase === 'error';
+            const isApplying = offsetState.phase === 'applying';
+            const isDetecting = offsetState.phase === 'detecting';
+            const label = isError
+              ? 'Offset failed'
+              : isApplying
+              ? 'Applying offset…'
+              : (offsetState.phase === 'detecting' && offsetState.progressMessage) || 'Detecting offset…';
+            return (
+              <div
+                className={`flex items-center gap-2 rounded-md border px-2.5 py-1 ${
+                  isError
+                    ? 'border-rose-200 bg-rose-50'
+                    : 'border-indigo-200 bg-indigo-50'
+                }`}
+                data-testid="topbar-offset-status"
+              >
+                {isError ? (
+                  <AlertCircle className="h-3 w-3 shrink-0 text-rose-600"/>
+                ) : (
+                  <Loader2 className="h-3 w-3 shrink-0 animate-spin text-indigo-600"/>
+                )}
+                <span className={`max-w-[200px] truncate text-[11px] font-medium ${isError ? 'text-rose-900' : 'text-indigo-900'}`} title={isError ? offsetState.message : label}>
+                  {label}
+                </span>
+                {isDetecting && (
+                  <div className="h-1.5 w-12 shrink-0 overflow-hidden rounded-full bg-indigo-100">
+                    <div
+                      className="h-full rounded-full bg-indigo-500 transition-all duration-300"
+                      style={{ width: `${Math.max(3, Math.round(offsetState.progress))}%` }}
+                    />
+                  </div>
+                )}
+                {isError && offsetState.jobId && (
+                  <button
+                    onClick={() => setJobLogsOpen(offsetState.jobId!)}
+                    className="rounded px-1.5 py-0.5 text-[11px] font-semibold text-rose-700 underline hover:text-rose-800"
+                    data-testid="topbar-offset-view-log"
+                  >
+                    View crash log
+                  </button>
+                )}
+                {isError && (
+                  <button
+                    onClick={() => setOffsetState({ phase: 'idle' })}
+                    className="rounded px-1 text-[11px] text-slate-500 hover:text-slate-700"
+                    aria-label="Dismiss offset status"
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+            );
+          })()}
+
           {batch.state.status === 'complete' && !reportOpen && (
             <div
               className={`flex items-center gap-2 rounded-md border px-2.5 py-1 ${
@@ -2856,6 +2952,16 @@ export function ParseUI() {
                     >
                       <Anchor className="h-3.5 w-3.5 text-slate-400"/>
                       {offsetState.phase === 'detecting' ? 'Detecting offset…' : 'Detect Timestamp Offset'}
+                    </button>
+                    <button
+                      onClick={() => { setActionsMenuOpen(false); setOffsetState({ phase: 'manual' }); }}
+                      disabled={!activeActionSpeaker || offsetState.phase === 'detecting' || offsetState.phase === 'applying'}
+                      data-testid="actions-detect-offset-manual"
+                      title="Skip auto-detect and anchor the offset from captured lexeme pairs directly."
+                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Anchor className="h-3.5 w-3.5 text-slate-400"/>
+                      Detect offset (manual anchors)
                     </button>
                     <div className="my-1 border-t border-slate-100"/>
                     <button
@@ -3808,11 +3914,35 @@ export function ParseUI() {
         open={offsetState.phase !== 'idle'}
         onClose={() => setOffsetState({ phase: 'idle' })}
         title="Timestamp Offset"
+        // While the async job is actually running, lock the modal. A
+        // stray click on the backdrop or the Escape key used to drop
+        // the user out of the flow while the worker kept computing —
+        // the progress was also invisible because nothing persisted in
+        // the header. The header chip now covers the "I want to dismiss
+        // this and come back" case, so blocking dismissal here is safe.
+        dismissible={offsetState.phase !== 'detecting' && offsetState.phase !== 'applying'}
       >
         <div className="space-y-3 text-sm" data-testid="offset-modal">
           {offsetState.phase === 'detecting' && (
-            <div className="flex items-center gap-2 text-slate-600">
-              <Loader2 className="h-4 w-4 animate-spin"/> Detecting offset…
+            <div className="space-y-2" data-testid="offset-detecting">
+              <div className="flex items-center gap-2 text-slate-600">
+                <Loader2 className="h-4 w-4 animate-spin"/>
+                <span>{offsetState.progressMessage ?? 'Detecting offset…'}</span>
+                <span className="ml-auto font-mono text-[11px] tabular-nums text-slate-400">
+                  {Math.round(offsetState.progress)}%
+                </span>
+              </div>
+              <div className="h-1 w-full overflow-hidden rounded-full bg-slate-100">
+                <div
+                  className="h-full rounded-full bg-indigo-500 transition-all"
+                  style={{ width: `${Math.max(2, Math.round(offsetState.progress))}%` }}
+                />
+              </div>
+              <p className="text-[11px] text-slate-400">
+                This window stays open while the worker is running — a
+                single click used to dismiss it silently and lose the
+                progress indicator. The header also mirrors the status.
+              </p>
             </div>
           )}
           {offsetState.phase === 'manual' && (() => {
@@ -4078,6 +4208,19 @@ export function ParseUI() {
                 <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0"/>
                 <span data-testid="offset-error">{offsetState.message}</span>
               </div>
+              {offsetState.jobId && (
+                <div className="text-[11px] text-slate-500">
+                  Job <span className="font-mono text-slate-700">{offsetState.jobId}</span>
+                  {' — '}
+                  <button
+                    className="font-semibold text-indigo-700 underline hover:text-indigo-800"
+                    onClick={() => setJobLogsOpen(offsetState.jobId!)}
+                    data-testid="offset-error-view-log"
+                  >
+                    View crash log
+                  </button>
+                </div>
+              )}
               <div className="flex justify-end gap-2">
                 <button
                   className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-50"
@@ -4096,6 +4239,10 @@ export function ParseUI() {
           )}
         </div>
       </Modal>
+      <JobLogsModal
+        jobId={jobLogsOpen}
+        onClose={() => setJobLogsOpen(null)}
+      />
       <Modal open={commentsImportOpen} onClose={() => setCommentsImportOpen(false)} title="Import Audition Comments">
         <CommentsImport onImportComplete={() => setCommentsImportOpen(false)} />
       </Modal>
@@ -4118,6 +4265,111 @@ export function ParseUI() {
         }}
       />
     </div>
+  );
+}
+
+// Crash-log modal. Fetches the worker error + traceback + stderr tail
+// for a given job id via /api/jobs/<id>/logs and renders it in a
+// scrollable <pre>. Rendered as null when no job id is selected so it
+// shares one mount point.
+function JobLogsModal({ jobId, onClose }: { jobId: string | null; onClose: () => void }) {
+  const [payload, setPayload] = useState<JobLogsPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!jobId) {
+      setPayload(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setPayload(null);
+    void (async () => {
+      try {
+        const data = await getJobLogs(jobId);
+        if (!cancelled) setPayload(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [jobId]);
+
+  return (
+    <Modal open={jobId !== null} onClose={onClose} title="Job Crash Log">
+      <div className="space-y-3 text-sm" data-testid="job-logs-modal">
+        {jobId && (
+          <div className="text-[11px] text-slate-500">
+            Job <span className="font-mono text-slate-700">{jobId}</span>
+          </div>
+        )}
+        {loading && (
+          <div className="flex items-center gap-2 text-slate-600">
+            <Loader2 className="h-4 w-4 animate-spin"/> Fetching logs…
+          </div>
+        )}
+        {error && (
+          <div className="rounded-md border border-rose-200 bg-rose-50 p-2 text-xs text-rose-800">
+            Failed to load logs: {error}
+          </div>
+        )}
+        {payload && (
+          <div className="space-y-3">
+            {payload.error && (
+              <div className="rounded-md border border-rose-200 bg-rose-50 p-2 text-xs text-rose-900">
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-rose-700">Error</div>
+                <div className="whitespace-pre-wrap break-words">{payload.error}</div>
+              </div>
+            )}
+            {payload.traceback && (
+              <details className="rounded-md border border-slate-200" open>
+                <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-600">
+                  Python traceback
+                </summary>
+                <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words border-t border-slate-200 bg-slate-50 p-2 font-mono text-[11px] text-slate-800" data-testid="job-logs-traceback">{payload.traceback}</pre>
+              </details>
+            )}
+            {payload.stderrLog && (
+              <details className="rounded-md border border-slate-200">
+                <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-600">
+                  Per-job stderr
+                </summary>
+                <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words border-t border-slate-200 bg-slate-50 p-2 font-mono text-[11px] text-slate-800">{payload.stderrLog}</pre>
+              </details>
+            )}
+            {payload.workerStderrLog && (
+              <details className="rounded-md border border-slate-200">
+                <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-600">
+                  Worker stderr tail
+                </summary>
+                <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words border-t border-slate-200 bg-slate-50 p-2 font-mono text-[11px] text-slate-800">{payload.workerStderrLog}</pre>
+              </details>
+            )}
+            {!payload.error && !payload.traceback && !payload.stderrLog && !payload.workerStderrLog && (
+              <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-xs text-slate-500">
+                No crash log captured for this job. The worker may have
+                exited cleanly, or the stderr log was not written yet.
+              </div>
+            )}
+          </div>
+        )}
+        <div className="flex justify-end">
+          <button
+            onClick={onClose}
+            className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-50"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </Modal>
   );
 }
 

--- a/src/__tests__/pollOffsetDetectJob.test.ts
+++ b/src/__tests__/pollOffsetDetectJob.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// The client uses a bare ``fetch`` wrapper. Mock the global fetch so
+// each polling iteration resolves against a scripted queue of /api
+// responses. That way we exercise the full pollOffsetDetectJob branch
+// surface — progress callback, success, error-with-traceback — without
+// standing up a server.
+
+import { pollOffsetDetectJob, OffsetJobError } from "../api/client";
+
+type ScriptedResponse = {
+  status: number;
+  body: unknown;
+};
+
+function queueResponses(responses: ScriptedResponse[]): () => void {
+  const queue = [...responses];
+  const impl = vi.fn(async () => {
+    const next = queue.shift();
+    if (!next) {
+      throw new Error("fetch called more times than scripted");
+    }
+    return new Response(JSON.stringify(next.body), {
+      status: next.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  const original = globalThis.fetch;
+  (globalThis as { fetch: typeof fetch }).fetch = impl as unknown as typeof fetch;
+  return () => {
+    (globalThis as { fetch: typeof fetch }).fetch = original;
+  };
+}
+
+describe("pollOffsetDetectJob", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves with the backend OffsetDetectResult on complete and fires onProgress for each poll", async () => {
+    const cleanup = queueResponses([
+      { status: 200, body: { status: "running", progress: 30, message: "Selecting anchors" } },
+      {
+        status: 200,
+        body: {
+          status: "complete",
+          progress: 100,
+          result: {
+            speaker: "Fail02",
+            offsetSec: -1.23,
+            confidence: 0.9,
+            nAnchors: 5,
+            totalAnchors: 6,
+            totalSegments: 200,
+            method: "monotonic",
+          },
+        },
+      },
+    ]);
+    try {
+      const progressCalls: Array<{ progress: number; message?: string }> = [];
+      const promise = pollOffsetDetectJob("job-1", "offset_detect", {
+        intervalMs: 10,
+        onProgress: (p) => progressCalls.push(p),
+      });
+      // Two polls → two 10ms waits → advance the fake clock enough.
+      await vi.advanceTimersByTimeAsync(25);
+      const result = await promise;
+      expect(result.offsetSec).toBe(-1.23);
+      expect(progressCalls.length).toBeGreaterThanOrEqual(1);
+      expect(progressCalls[0]?.message).toBe("Selecting anchors");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("throws OffsetJobError carrying the backend traceback when status=error", async () => {
+    const cleanup = queueResponses([
+      {
+        status: 200,
+        body: {
+          status: "error",
+          progress: 55,
+          error: "No STT segments available.",
+          traceback: "Traceback (most recent call last):\n  File server.py, line 4850\nValueError: No STT segments available.",
+        },
+      },
+    ]);
+    try {
+      // Swallow the rejection exactly once — chaining .catch on the
+      // same promise we later assert on would count as a second
+      // settlement and trigger an unhandled-rejection warning in
+      // vitest.
+      const settled: Promise<unknown> = pollOffsetDetectJob("job-2", "offset_detect", {
+        intervalMs: 5,
+      }).then(
+        () => {
+          throw new Error("expected rejection");
+        },
+        (err) => err,
+      );
+      await vi.advanceTimersByTimeAsync(15);
+      const caught = await settled;
+      expect(caught).toBeInstanceOf(OffsetJobError);
+      const oe = caught as OffsetJobError;
+      expect(oe.jobId).toBe("job-2");
+      expect(oe.message).toContain("No STT segments");
+      expect(oe.traceback).toContain("Traceback");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -481,25 +481,60 @@ export async function detectTimestampOffsetFromPairs(
   return { job_id: resolveJobId(payload), jobId: resolveJobId(payload) };
 }
 
+/** Thrown when pollOffsetDetectJob sees the server mark the job as errored.
+ *  Carries the backend traceback so the UI can render it in a crash-log
+ *  modal instead of losing it inside a bare Error.message. */
+export class OffsetJobError extends Error {
+  readonly jobId: string;
+  readonly traceback?: string;
+  constructor(jobId: string, message: string, traceback?: string) {
+    super(message);
+    this.name = "OffsetJobError";
+    this.jobId = jobId;
+    if (traceback) this.traceback = traceback;
+  }
+}
+
 /** Poll until an offset detect job completes and return the OffsetDetectResult.
- *  Throws on job error or timeout. */
+ *  Throws ``OffsetJobError`` on job error (with backend traceback attached)
+ *  or a plain Error on client-side timeout. ``onProgress`` is invoked on
+ *  every successful poll — callers can mirror the live backend
+ *  ``message`` into a header chip so the user sees what the worker is
+ *  doing mid-flight.
+ *
+ *  The default timeout is 10 minutes, matching the backend's hard
+ *  ``PARSE_OFFSET_DETECT_TIMEOUT_SEC`` cap. The former 60 s budget was
+ *  wired for the old synchronous path; on real thesis-sized WAVs the
+ *  async job legitimately takes several minutes. */
 export async function pollOffsetDetectJob(
   jobId: string,
   computeType: "offset_detect" | "offset_detect_from_pair" = "offset_detect",
-  { intervalMs = 500, timeoutMs = 60_000 }: { intervalMs?: number; timeoutMs?: number } = {},
+  {
+    intervalMs = 500,
+    timeoutMs = 600_000,
+    onProgress,
+  }: {
+    intervalMs?: number;
+    timeoutMs?: number;
+    onProgress?: (p: { progress: number; message?: string }) => void;
+  } = {},
 ): Promise<OffsetDetectResult> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     await new Promise<void>((r) => setTimeout(r, intervalMs));
     const status = await pollCompute(computeType, jobId);
+    if (onProgress) {
+      onProgress({ progress: status.progress, message: status.message });
+    }
     if (status.status === "complete") {
       return status.result as OffsetDetectResult;
     }
     if (status.status === "error") {
-      throw new Error(status.error ?? status.message ?? "Offset detection failed");
+      const reason = status.error ?? status.message ?? "Offset detection failed";
+      throw new OffsetJobError(jobId, reason, status.traceback);
     }
   }
-  throw new Error("Offset detection timed out");
+  throw new OffsetJobError(jobId, "Offset detection timed out (client-side deadline)");
 }
 
 export async function applyTimestampOffset(
@@ -640,6 +675,10 @@ export async function pollCompute(computeType: string, jobId: string): Promise<C
           ? payload.error
           : undefined,
     error: typeof payload.error === "string" ? payload.error : undefined,
+    // Forward the backend's Python traceback when the job failed. The
+    // UI's crash-log modal renders it as a scrollable ``<pre>`` so the
+    // user can grab it for a bug report without SSH-ing into the box.
+    ...(typeof payload.traceback === "string" ? { traceback: payload.traceback } : {}),
     // Forward the backend's opaque ``result`` field. ``full_pipeline``
     // returns its per-step results here; ``useBatchPipelineJob`` reads
     // this to populate the BatchReportModal. Previously this field was
@@ -649,6 +688,38 @@ export async function pollCompute(computeType: string, jobId: string): Promise<C
     // their expected compute-specific shape.
     result: payload.result,
   };
+}
+
+// Job logs — pulls the server's error, traceback, and tail of per-job
+// and worker stderr logs for a given job id. Powers the UI's
+// "View crash log" modal.
+export interface JobLogsPayload {
+  jobId: string;
+  status: string;
+  type?: string;
+  error?: string;
+  traceback?: string;
+  message?: string;
+  stderrLog?: string;
+  workerStderrLog?: string;
+}
+
+export async function getJobLogs(jobId: string): Promise<JobLogsPayload> {
+  const payload = await apiFetch<unknown>(`/api/jobs/${encodeURIComponent(jobId)}/logs`);
+  if (!isRecord(payload)) {
+    throw new Error("Invalid job logs payload");
+  }
+  const out: JobLogsPayload = {
+    jobId: typeof payload.jobId === "string" ? payload.jobId : jobId,
+    status: typeof payload.status === "string" ? payload.status : "",
+  };
+  if (typeof payload.type === "string") out.type = payload.type;
+  if (typeof payload.error === "string") out.error = payload.error;
+  if (typeof payload.traceback === "string") out.traceback = payload.traceback;
+  if (typeof payload.message === "string") out.message = payload.message;
+  if (typeof payload.stderrLog === "string") out.stderrLog = payload.stderrLog;
+  if (typeof payload.workerStderrLog === "string") out.workerStderrLog = payload.workerStderrLog;
+  return out;
 }
 
 // Export — returns Blob (file download, not JSON)

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -154,6 +154,10 @@ export interface ComputeStatus {
   progress: number;
   message?: string;
   error?: string;
+  /** Full Python traceback captured by the worker when the job errored.
+   *  Present on terminal-error snapshots only; the UI renders it in the
+   *  crash-log modal alongside the short ``error`` message. */
+  traceback?: string;
   /** Opaque result payload the backend attaches when a compute job
    *  completes (e.g. full_pipeline returns its per-step results here).
    *  Callers cast this to the specific type they expect for their

--- a/src/components/shared/Modal.tsx
+++ b/src/components/shared/Modal.tsx
@@ -5,23 +5,28 @@ interface ModalProps {
   onClose: () => void;
   title?: string;
   children: React.ReactNode;
+  /** When false, backdrop clicks and the Escape key are no-ops. Use this
+   * for phases that must run to completion (e.g. an async offset-detect
+   * job) so a stray click doesn't silently drop the user out of the flow
+   * while work continues in the background. Default: true. */
+  dismissible?: boolean;
 }
 
-export function Modal({ open, onClose, title, children }: ModalProps) {
+export function Modal({ open, onClose, title, children, dismissible = true }: ModalProps) {
   useEffect(() => {
-    if (!open) return;
+    if (!open || !dismissible) return;
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
     }
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [open, onClose]);
+  }, [open, onClose, dismissible]);
 
   if (!open) return null;
 
   return (
     <div
-      onClick={onClose}
+      onClick={dismissible ? onClose : undefined}
       style={{
         position: "fixed",
         inset: 0,


### PR DESCRIPTION
## Summary
- Fixes three regressions from PR #190's async offset-detect rollout: modal dismissal losing state, no header persistence, and crashes disappearing into the ether.
- Modal gains a `dismissible` prop; the offset modal is locked while `detecting` / `applying`, and the top bar grows an offset status chip (spinner + live worker message + progress bar; rose variant with "View crash log" on failure).
- Worker crashes now flow a full Python traceback end-to-end (stored on the job record, surfaced via new `GET /api/jobs/<id>/logs`) and render in a new `JobLogsModal` alongside the per-job + worker stderr tails.
- Actions dropdown gets a second "Detect offset (manual anchors)" entry so users can skip auto-detect entirely on speakers with noisy STT.
- Offset compute functions enforce a 10 min hard cap (`PARSE_OFFSET_DETECT_TIMEOUT_SEC`) checked at progress checkpoints; the client poll deadline tracks it.

## Changes
- `src/components/shared/Modal.tsx` — `dismissible` prop; backdrop + ESC become no-ops when `false`.
- `src/api/client.ts` + `src/api/types.ts` — `pollOffsetDetectJob` gets an `onProgress` callback and 10 min timeout; throws typed `OffsetJobError` carrying the backend traceback; `getJobLogs` + `JobLogsPayload` for the new endpoint; `ComputeStatus.traceback` forwarded.
- `src/ParseUI.tsx` — `offsetState` union carries `jobId` / `progress` / `progressMessage` during detecting and `traceback` / `jobId` on error; new top-bar offset chip; Actions menu second entry; error panel + chip have "View crash log" buttons; `JobLogsModal` component.
- `python/server.py` — `_set_job_error(traceback_str=...)` stores it separately; `_job_response_payload` forwards it; `_tail_log_file` + `_api_get_job_logs` + `/api/jobs/<id>/logs` route; `_enforce_offset_deadline` + `_offset_detect_timeout_sec` guard both offset compute paths.
- `python/workers/compute_worker.py` — monitor forwards traceback via keyword arg (backward-compatible); child-side `_patched_error` emits traceback on the event.

## Known limitations
- The offset timeout is a best-effort checkpoint guard — Python can't kill a thread mid-numerics, so a genuinely wedged `_detect_offset_detailed` wouldn't be interrupted between progress calls. In practice that function is bounded O(anchors × segments) pure Python; the guard exists to surface a clean UI error instead of an indefinite spinner if an input pathology is ever found.
- Preview verification skipped — the running vite preview is rooted at `/Users/lucasardelean/PARSE` (the 2025-04 UI mockup), not `/tmp/PARSE-audit`. Real-dataset validation should happen against Fa102 on the PC once this merges.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 224/224 pass, including new `src/__tests__/pollOffsetDetectJob.test.ts`
- [x] `pytest python/test_offset_job_failure_paths.py python/test_offset_detect_monotonic.py python/test_offset_manual_pairs.py` — 19/19
- [ ] Manual: trigger "Detect Timestamp Offset" on Fa102, click backdrop during detection — modal stays up, header chip mirrors progress
- [ ] Manual: trigger on a speaker without STT segments — error state persists, "View crash log" reveals the ValueError + traceback
- [ ] Manual: "Detect offset (manual anchors)" opens the modal straight in manual mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)