### PR TITLE
feat: standardize PARSE external API surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # Python
 python/__pycache__/
 *.pyc
+*.egg-info/
+build/
 .venv-ortho/
 config/auth_tokens.json
 config/ai_config.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,16 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
   - `export_complete_lingpy_dataset`
 - For backward compatibility, root-level `mcp_config.json` is also accepted when `config/mcp_config.json` is absent.
 - `ChatToolSpec` is the MCP metadata source of truth. MCP tools should forward the strict schema from `spec.parameters`, standard MCP annotations from `spec.mcp_annotations_payload()`, and PARSE-specific safety metadata from `meta["x-parse"] = spec.mcp_meta_payload()`.
+- Task 5 adds a parallel **HTTP MCP bridge** in `python/server.py`:
+  - `GET /api/mcp/exposure`
+  - `GET /api/mcp/tools`
+  - `GET /api/mcp/tools/{toolName}`
+  - `POST /api/mcp/tools/{toolName}`
+- Task 5 also adds OpenAPI docs served directly by `python/server.py`:
+  - `GET /openapi.json`
+  - `GET /docs`
+  - `GET /redoc`
+- Official external wrappers now live in `python/packages/parse_mcp/`.
 - Mutability meanings:
   - `read_only` — inspection only; no writes or background jobs
   - `stateful_job` — starts or manages a background job that can later mutate project artifacts

--- a/README.md
+++ b/README.md
@@ -85,21 +85,69 @@ This assistant is not a generic chatbot. It operates through `ParseChatTools` an
 
 Supported LLM backends currently include **xAI (Grok)** and **OpenAI**. Local speech and alignment work is handled separately through faster-whisper, Razhan, Silero VAD, and wav2vec2.
 
-### MCP Server Mode
+### MCP & External API
 
-PARSE can also run as an **MCP (Model Context Protocol) server**.
+PARSE exposes three machine-facing integration surfaces:
+
+1. **HTTP API** on `http://localhost:8766`
+2. **HTTP MCP bridge** on the same server for schema discovery + tool execution
+3. **stdio MCP adapter** in `python/adapters/mcp_adapter.py`
 
 That means external agent clients such as Claude Code, Cursor, Cline, Hermes, Windsurf, Codex, or other MCP-capable tools can call a curated subset of PARSE functions programmatically, without going through the browser UI.
 
-The MCP adapter currently exposes **32 task tools** drawn from the broader in-app PARSE tool surface, plus read-only `mcp_get_exposure_mode` for self-inspection.
+Current counts:
+- **47** built-in `ParseChatTools`
+- **3** workflow macros in `python/ai/workflow_tools.py`
+- **32** default MCP task tools
+- **33** total default MCP adapter tools including read-only `mcp_get_exposure_mode`
+- **51** total MCP adapter tools with `config/mcp_config.json` → `{ "expose_all_tools": true }`
+
+#### OpenAPI and interactive docs
+
+- `GET /openapi.json` — full OpenAPI 3.1 spec
+- `GET /docs` — Swagger UI
+- `GET /redoc` — ReDoc
+
+#### HTTP MCP bridge
+
+- `GET /api/mcp/exposure`
+- `GET /api/mcp/tools`
+- `GET /api/mcp/tools/{toolName}`
+- `POST /api/mcp/tools/{toolName}`
+
+These endpoints expose the MCP schema, strict parameter JSON schemas, and PARSE-specific safety metadata (`meta.x-parse`) over plain HTTP.
+
+#### Authentication model
+
+- The local PARSE HTTP server is **not bearer-protected**; it is intended for local workstation use.
+- Provider credentials are managed separately through `/api/auth/*` and stored locally in `config/auth_tokens.json`.
+- Supported auth methods currently include:
+  - direct API keys via `POST /api/auth/key`
+  - OpenAI device/OAuth flow via `POST /api/auth/start` + `POST /api/auth/poll`
+
+#### Python package
+
+Task 5 also adds the official publishable package scaffold:
+
+- `python/packages/parse_mcp/`
+- package name: **`parse-mcp`**
+
+It provides:
+- schema discovery from a running PARSE server
+- HTTP tool execution against the MCP bridge
+- framework wrappers for:
+  - LangChain
+  - LlamaIndex
+  - CrewAI
 
 ## 📚 Documentation
 
 - [Getting Started](docs/getting-started.md) — installation, launch paths, requirements, environment variables, `ai_config.json`, GPU notes, and troubleshooting
 - [User Guide](docs/user-guide.md) — detailed Annotate/Compare workflows, CLEF usage, Lexical Anchor Alignment, and workspace hydration
 - [AI Integration](docs/ai-integration.md) — provider routing, model roles, configuration, external dependencies, the full 47-tool chat surface, and MCP workflow macros
-- [API Reference](docs/api-reference.md) — HTTP endpoints, compute routes, examples, and the full 32-tool MCP task surface
-- [Architecture](docs/architecture.md) — unified shell, backend/data design, Lexical Anchor Alignment scoring, and CLEF provider registry
+- [API Reference](docs/api-reference.md) — HTTP endpoints, OpenAPI docs, MCP bridge routes, examples, and the full 32-tool MCP task surface
+- [MCP Schema](docs/mcp-schema.md) — MCP schema shape, HTTP bridge endpoints, exposure modes, and authentication model
+- [Architecture](docs/architecture.md) — unified shell, backend/data design, OpenAPI/MCP standardization points, and CLEF provider registry
 - [Developer Guide](docs/developer-guide.md) — project structure, tech stack, local development flow, and extension points for chat tools, MCP tools, and endpoints
 - [Research Context](docs/research-context.md) — thesis background, citation guidance, and research-software framing
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -319,4 +319,12 @@ Not every in-app chat tool is exported over MCP, and MCP also exposes 3 workflow
 - **Default MCP adapter surface including `mcp_get_exposure_mode`**: 33
 - **Full MCP adapter surface with `expose_all_tools=true`**: 51
 
+Task 5 adds an HTTP MCP bridge on top of that same schema surface:
+- `GET /api/mcp/exposure`
+- `GET /api/mcp/tools`
+- `GET /api/mcp/tools/{toolName}`
+- `POST /api/mcp/tools/{toolName}`
+
+That bridge reuses `ChatToolSpec` metadata (`parameters`, MCP annotations, and `meta.x-parse`) so external Python wrappers can discover the same tool contracts without spawning the stdio adapter.
+
 For the exact MCP subset, startup instructions, and usage examples, see [API Reference](./api-reference.md).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -302,9 +302,59 @@ GET /api/export/nexus
 
 Both endpoints return downloadable file content rather than JSON.
 
+## OpenAPI 3.1 and interactive API docs
+
+PARSE now serves a machine-readable OpenAPI 3.1 document directly from `python/server.py`.
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /openapi.json` | Full OpenAPI 3.1 spec for the HTTP API + HTTP MCP bridge |
+| `GET /docs` | Swagger UI |
+| `GET /redoc` | ReDoc |
+
+The OpenAPI document intentionally describes the HTTP workstation API and the HTTP MCP bridge. The stdio MCP adapter remains documented separately below because it is a process transport, not an HTTP route.
+
+## HTTP MCP bridge
+
+Task 5 adds a discovery/execution bridge so external Python tooling can use the PARSE MCP schema without spawning the stdio adapter.
+
+| Endpoint | Purpose | Notes |
+|---|---|---|
+| `GET /api/mcp/exposure` | Read active MCP exposure configuration | Supports `mode=active|default|all` |
+| `GET /api/mcp/tools` | List MCP-visible tool schemas | Returns `parameters`, `annotations`, and `meta.x-parse` |
+| `GET /api/mcp/tools/{toolName}` | Read one MCP tool schema | 404 if hidden in the selected mode |
+| `POST /api/mcp/tools/{toolName}` | Execute one MCP-visible tool over HTTP | Uses the same validation + execution layer as the PARSE tool runtime |
+
+### Exposure modes
+
+`mode` query parameter accepts:
+- `active` — obey `config/mcp_config.json` (or fallback root `mcp_config.json`)
+- `default` — force the curated MCP subset
+- `all` — force the full tool surface
+
+### Tool schema payload
+
+Each tool entry returned by the bridge includes:
+- `name`
+- `family`
+  - `adapter`
+  - `chat`
+  - `workflow`
+- `description`
+- `parameters`
+- `annotations`
+- `meta.x-parse`
+
+`meta.x-parse` remains the key safety payload for agents. It includes:
+- `mutability`
+- `supports_dry_run`
+- `dry_run_parameter`
+- `preconditions`
+- `postconditions`
+
 ## MCP server mode
 
-PARSE can run as an MCP server by exposing a curated subset of `ParseChatTools` through `python/adapters/mcp_adapter.py`.
+PARSE can also run as a stdio MCP server by exposing a curated subset of `ParseChatTools` plus the 3 workflow macros through `python/adapters/mcp_adapter.py`.
 
 ### Start the adapter
 
@@ -340,7 +390,7 @@ pip install 'mcp[cli]'
 
 If no explicit environment block is passed, the adapter also reads repo-local overrides from `.parse-env`.
 
-## Full MCP tool surface (32 tools)
+## Full MCP task surface (32 task tools + `mcp_get_exposure_mode`)
 
 ### Inspection / preview / preflight
 
@@ -399,12 +449,47 @@ If no explicit environment block is passed, the adapter also reads repo-local ov
 | `prepare_compare_mode` | Resolve a concept slice across speakers and return a compare-ready preview bundle |
 | `export_complete_lingpy_dataset` | Export LingPy TSV + NEXUS, optionally refreshing contact lexeme references first |
 
+## `parse-mcp` Python package
+
+Task 5 adds the official package scaffold under:
+
+- `python/packages/parse_mcp/`
+- package name: **`parse-mcp`**
+
+It provides:
+- `ParseMcpClient` for discovery + execution against the HTTP MCP bridge
+- `build_langchain_tools(...)`
+- `build_llamaindex_tools(...)`
+- `build_crewai_tools(...)`
+
+## Authentication model
+
+### HTTP transport auth
+PARSE's local HTTP surface is not bearer-protected today. It is intended for a local workstation deployment on `localhost` / `127.0.0.1`.
+
+### Provider credentials
+Provider credentials are managed locally through:
+- `GET /api/auth/status`
+- `POST /api/auth/key`
+- `POST /api/auth/start`
+- `POST /api/auth/poll`
+- `POST /api/auth/logout`
+
+Credentials are stored in local `config/auth_tokens.json`.
+
+### MCP process auth
+The stdio MCP adapter does not add a separate network auth layer. Access is governed by the local process launch context and environment variables such as:
+- `PARSE_PROJECT_ROOT`
+- `PARSE_EXTERNAL_READ_ROOTS`
+- `PARSE_CHAT_MEMORY_PATH`
+- `PARSE_API_PORT`
+- `PARSE_PORT`
+
 ## MCP usage notes
 
 The MCP surface is a curated subset of the low-level chat tools plus 3 high-level workflow macros.
 
-A few operational rules remain important:
-
+Operational rules that remain important:
 - use `dryRun=true` first for gated mutating tools such as `contact_lexeme_lookup`, `onboard_speaker_import`, and timestamp/application workflows
 - prefer `full_coverage` rather than bare `done` when making automation decisions about whether a tier really covers the full recording
 - onboarding remains **one speaker at a time**
@@ -414,3 +499,4 @@ A few operational rules remain important:
 - Provider and model overview: [AI Integration](./ai-integration.md)
 - User-facing workflow context: [User Guide](./user-guide.md)
 - Data model and system design: [Architecture](./architecture.md)
+- Schema/auth details: [MCP Schema](./mcp-schema.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,9 @@ flowchart LR
     Server --> ChatTools[python/ai/chat_tools.py\n47 PARSE-specific tools]
     Server --> Compare[python/compare/*\ncognates + CLEF providers]
     Server --> Models[local & remote AI providers\nfaster-whisper / wav2vec2 / OpenAI / xAI]
+    Server --> External[OpenAPI 3.1 + HTTP MCP bridge\n/openapi.json + /api/mcp/*]
     ChatTools --> MCP[python/adapters/mcp_adapter.py\n32-task MCP surface + workflow macros]
+    External --> PyPkg[python/packages/parse_mcp\nLangChain / LlamaIndex / CrewAI wrappers]
     Compare --> Exports[LingPy TSV + NEXUS]
 ```
 
@@ -70,7 +72,10 @@ python/
   adapters/
     mcp_adapter.py      -- MCP adapter
   ai/                   -- AI provider layer and chat tools
+  external_api/         -- OpenAPI generation + HTTP MCP bridge catalog helpers
   compare/              -- Compare pipeline and CLEF providers
+  packages/
+    parse_mcp/          -- Publishable Python client/wrapper package
 config/
   ai_config.example.json
   ai_config.json
@@ -93,6 +98,7 @@ It is responsible for:
 - coordinating STT / normalization / compute endpoints
 - exposing chat and auth routes
 - generating exports
+- serving the OpenAPI 3.1 document and HTTP MCP bridge
 - serving the built frontend for non-dev/local-server usage
 
 The backend is not just a thin file server. It is the orchestration layer for PARSE's workflow-specific automation.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -43,9 +43,12 @@ python/
     stt_pipeline.py
     forced_align.py
     ipa_transcribe.py
+  external_api/         -- OpenAPI generation + HTTP MCP bridge helpers
   compare/
     providers/          -- CLEF provider registry and adapters
   shared/               -- Shared Python utilities
+  packages/
+    parse_mcp/          -- Publishable Python client/wrapper package
 config/
   ai_config.example.json -- tracked template
   ai_config.json         -- machine-local config (gitignored)
@@ -72,6 +75,8 @@ dist/                   -- build output
 
 - Python 3.10–3.12
 - local HTTP server in `python/server.py`
+- OpenAPI 3.1 generation + interactive docs (`/openapi.json`, `/docs`, `/redoc`)
+- HTTP MCP bridge for schema discovery + tool execution (`/api/mcp/*`)
 - background job orchestration for STT / normalize / compute / chat
 - JSON-file persistence for runtime state
 
@@ -272,6 +277,26 @@ To expose a tool over MCP:
 4. Re-check the exported-tool count and update docs if the MCP subset changed
 
 The adapter is intentionally a curated PARSE tool surface. Low-level browser/chat tools live in `ParseChatTools`; high-level agent workflow macros live in `WorkflowTools`.
+
+## External API standardization points
+
+Task 5 adds two more extension surfaces that matter for contributors:
+
+1. **OpenAPI builder** — `python/external_api/openapi.py`
+   - keep the served `/openapi.json` spec aligned with real routes in `python/server.py`
+   - when adding HTTP routes, update the OpenAPI path table in the same PR
+2. **HTTP MCP bridge** — `python/external_api/catalog.py` + `python/server.py`
+   - exposes MCP tool schemas over HTTP
+   - executes MCP-visible tools over `POST /api/mcp/tools/{toolName}`
+   - should reuse existing `ChatToolSpec` metadata rather than inventing parallel schemas
+3. **Publishable wrapper package** — `python/packages/parse_mcp/`
+   - keep discovery/execution behavior aligned with the HTTP MCP bridge
+   - framework wrappers should remain thin adapters over the discovered tool schema
+
+When adding or renaming MCP-visible tools, update all three layers together:
+- stdio adapter
+- HTTP MCP bridge
+- `parse-mcp` package docs/tests
 
 ## How to add or extend a CLEF provider
 

--- a/docs/mcp-schema.md
+++ b/docs/mcp-schema.md
@@ -1,0 +1,97 @@
+# MCP schema and authentication model
+
+This document describes the standardized external-agent surface added in Task 5.
+
+## External surfaces
+
+PARSE now exposes three closely related machine-facing surfaces:
+
+1. **HTTP API** on port `8766`
+   - browser workstation backend
+   - documented via OpenAPI 3.1
+2. **HTTP MCP bridge** on the same server
+   - schema discovery and tool execution for Python wrappers
+3. **stdio MCP adapter**
+   - `python/adapters/mcp_adapter.py`
+   - for Claude Code, Cursor, Codex, Cline, Hermes, Windsurf, and other MCP-capable clients
+
+## OpenAPI endpoints
+
+- `GET /openapi.json`
+- `GET /docs`
+- `GET /redoc`
+
+## HTTP MCP bridge endpoints
+
+- `GET /api/mcp/exposure`
+  - returns the active exposure configuration and tool counts
+- `GET /api/mcp/tools`
+  - returns the active tool catalog with full parameter schemas, annotations, and `x-parse` safety metadata
+- `GET /api/mcp/tools/{toolName}`
+  - returns one tool schema
+- `POST /api/mcp/tools/{toolName}`
+  - executes one MCP-visible PARSE tool via HTTP
+
+### Exposure modes
+
+`mode` query parameter accepts:
+- `active` — obey `config/mcp_config.json` / `mcp_config.json`
+- `default` — use the curated MCP subset
+- `all` — expose the full tool surface
+
+## Tool schema shape
+
+Each listed tool includes:
+- `name`
+- `family`
+  - `adapter`
+  - `chat`
+  - `workflow`
+- `description`
+- `parameters`
+  - strict JSON schema derived from `ChatToolSpec.parameters`
+- `annotations`
+  - standard MCP hints such as `readOnlyHint`
+- `meta.x-parse`
+  - PARSE-specific safety metadata:
+    - `mutability`
+    - `supports_dry_run`
+    - `dry_run_parameter`
+    - `preconditions`
+    - `postconditions`
+
+## Authentication model
+
+### HTTP API transport auth
+PARSE's local HTTP API is **not bearer-protected** today. It is designed for local workstation use on `127.0.0.1:8766` / `localhost:8766` with permissive CORS for the browser UI and local automation.
+
+### Provider credential auth
+Provider credentials are managed locally through:
+- `GET /api/auth/status`
+- `POST /api/auth/key`
+- `POST /api/auth/start`
+- `POST /api/auth/poll`
+- `POST /api/auth/logout`
+
+Supported auth methods currently include:
+- direct API-key storage for xAI/OpenAI-style providers
+- OpenAI device/OAuth flow
+
+Credentials are stored in local `config/auth_tokens.json` and mirrored into the live process environment when needed.
+
+### MCP auth
+The stdio MCP adapter does not add a separate network auth layer. Access is controlled by the local process launch context and environment, especially:
+- `PARSE_PROJECT_ROOT`
+- `PARSE_EXTERNAL_READ_ROOTS`
+- `PARSE_CHAT_MEMORY_PATH`
+- `PARSE_API_PORT`
+- `PARSE_PORT`
+
+## Recommended external-agent workflow
+
+1. Read `GET /api/mcp/exposure`
+2. Discover tools from `GET /api/mcp/tools`
+3. Inspect `meta.x-parse.preconditions` and `supports_dry_run`
+4. Prefer `dryRun=true` for mutating tools when available
+5. Execute via `POST /api/mcp/tools/{toolName}`
+6. Use normal HTTP endpoints or MCP-specific polling/status helpers as needed

--- a/docs/mcp_agent_roadmap.md
+++ b/docs/mcp_agent_roadmap.md
@@ -67,9 +67,30 @@ Critical for long-running agent jobs:
 
 ## 5. Standardize the external API surface
 
-- Generate and serve a full **OpenAPI 3.1 spec** for the HTTP API (port 8766).
-- Publish official **LangChain / LlamaIndex / CrewAI** tool wrappers as a `parse-mcp` Python package.
-- Document the MCP schema and authentication model clearly in the README.
+**Status:** ✅ Complete
+
+**Shipped:**
+- `python/server.py` now serves a full **OpenAPI 3.1** document at `GET /openapi.json` plus interactive docs at `GET /docs` and `GET /redoc`.
+- Added a read/write **HTTP MCP bridge** on the same server:
+  - `GET /api/mcp/exposure`
+  - `GET /api/mcp/tools`
+  - `GET /api/mcp/tools/{toolName}`
+  - `POST /api/mcp/tools/{toolName}`
+- Added shared schema/discovery helpers under `python/external_api/` so the HTTP MCP bridge and stdio adapter reuse the same MCP metadata source of truth.
+- Added the official publishable **`parse-mcp`** package scaffold under `python/packages/parse_mcp/` with:
+  - `ParseMcpClient`
+  - LangChain wrappers
+  - LlamaIndex wrappers
+  - CrewAI wrappers
+- Added `docs/mcp-schema.md` and expanded `README.md` / `docs/api-reference.md` to document:
+  - the MCP schema
+  - exposure modes
+  - the local authentication model
+  - the OpenAPI endpoints
+
+**Notes:**
+- Existing HTTP and MCP tool behavior remains unchanged; Task 5 standardizes discoverability, schemas, and packaging around the current surface.
+- The local PARSE HTTP API remains workstation-local and is **not bearer-protected**. Provider credentials continue to be managed separately via `/api/auth/*` and local `config/auth_tokens.json`.
 
 ---
 

--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -61,8 +61,6 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("parse.mcp_adapter")
 
-MCP_CONFIG_FILENAME = "mcp_config.json"
-
 # ---------------------------------------------------------------------------
 # Ensure the python/ package is importable
 # ---------------------------------------------------------------------------
@@ -72,8 +70,13 @@ _PYTHON_DIR = _ADAPTER_DIR.parent
 if str(_PYTHON_DIR) not in sys.path:
     sys.path.insert(0, str(_PYTHON_DIR))
 
-from ai.chat_tools import DEFAULT_MCP_TOOL_NAMES
 from ai.workflow_tools import DEFAULT_MCP_WORKFLOW_TOOL_NAMES
+from external_api.catalog import (
+    load_mcp_config as _shared_load_mcp_config,
+    mcp_exposure_payload as _shared_mcp_exposure_payload,
+    resolve_mcp_config_path as _shared_resolve_mcp_config_path,
+    selected_mcp_tool_names as _shared_selected_mcp_tool_names,
+)
 
 # ---------------------------------------------------------------------------
 # Lazy MCP SDK import
@@ -108,52 +111,18 @@ def _resolve_project_root(cli_root: Optional[str] = None) -> Path:
 
 
 def _resolve_mcp_config_path(project_root_path: Path) -> Optional[Path]:
-    """Return the preferred mcp_config.json path if one exists.
-
-    Preferred location is config/mcp_config.json for consistency with the
-    other PARSE config files. For backward compatibility, also accept a
-    project-root mcp_config.json fallback.
-    """
-    candidates = [
-        project_root_path / "config" / MCP_CONFIG_FILENAME,
-        project_root_path / MCP_CONFIG_FILENAME,
-    ]
-    for candidate in candidates:
-        if candidate.exists() and candidate.is_file():
-            return candidate
-    return None
+    """Return the preferred mcp_config.json path if one exists."""
+    return _shared_resolve_mcp_config_path(project_root_path)
 
 
 def _load_mcp_config(project_root_path: Path) -> Dict[str, Any]:
-    """Load MCP adapter config, defaulting to the legacy 29-tool surface."""
-    config_path = _resolve_mcp_config_path(project_root_path)
-    if config_path is None:
-        return {"expose_all_tools": False}
-    try:
-        payload = json.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("Failed to read %s: %s. Falling back to expose_all_tools=false.", config_path, exc)
-        return {"expose_all_tools": False}
-    if not isinstance(payload, dict):
-        logger.warning("Ignoring non-object MCP config at %s. Falling back to expose_all_tools=false.", config_path)
-        return {"expose_all_tools": False}
-    expose_all_tools_raw = payload.get("expose_all_tools", False)
-    if not isinstance(expose_all_tools_raw, bool):
-        logger.warning(
-            "Ignoring non-boolean expose_all_tools=%r at %s. Falling back to expose_all_tools=false.",
-            expose_all_tools_raw,
-            config_path,
-        )
-        expose_all_tools_raw = False
-    return {"expose_all_tools": expose_all_tools_raw, "config_path": str(config_path)}
+    """Load MCP adapter config, defaulting to the legacy curated surface."""
+    return _shared_load_mcp_config(project_root_path)
 
 
 def _selected_mcp_tool_names(all_tool_names: List[str], expose_all_tools: bool) -> List[str]:
     """Return the MCP tool surface for this server instance."""
-    if expose_all_tools:
-        return list(all_tool_names)
-    available_names = set(all_tool_names)
-    return [name for name in DEFAULT_MCP_TOOL_NAMES if name in available_names]
+    return _shared_selected_mcp_tool_names(all_tool_names, expose_all_tools)
 
 
 def _mcp_exposure_payload(
@@ -165,22 +134,13 @@ def _mcp_exposure_payload(
     mcp_tool_count: int,
 ) -> Dict[str, Any]:
     """Build a read-only MCP payload describing the active exposure mode."""
-    return {
-        "tool": "mcp_get_exposure_mode",
-        "ok": True,
-        "result": {
-            "readOnly": True,
-            "previewOnly": True,
-            "mode": "read-only",
-            "exposeAllTools": expose_all_tools,
-            "configSource": config_source,
-            "parseChatToolCount": parse_chat_tool_count,
-            "workflowToolCount": workflow_tool_count,
-            "mcpToolCount": mcp_tool_count,
-            "defaultParseMcpToolCount": len(DEFAULT_MCP_TOOL_NAMES),
-            "defaultWorkflowMcpToolCount": len(DEFAULT_MCP_WORKFLOW_TOOL_NAMES),
-        },
-    }
+    return _shared_mcp_exposure_payload(
+        expose_all_tools=expose_all_tools,
+        config_source=config_source,
+        parse_chat_tool_count=parse_chat_tool_count,
+        workflow_tool_count=workflow_tool_count,
+        mcp_tool_count=mcp_tool_count,
+    )
 
 
 def _load_repo_parse_env(project_root_path: Path) -> Dict[str, str]:

--- a/python/external_api/__init__.py
+++ b/python/external_api/__init__.py
@@ -1,0 +1,27 @@
+"""External API helpers for PARSE HTTP/OpenAPI/MCP standardization."""
+
+from .catalog import (
+    build_mcp_http_catalog,
+    build_mcp_tool_entry,
+    get_mcp_tool_entry,
+    load_mcp_config,
+    mcp_exposure_payload,
+    resolve_catalog_mode,
+    resolve_mcp_config_path,
+    selected_mcp_tool_names,
+)
+from .openapi import build_openapi_document, render_redoc_html, render_swagger_ui_html
+
+__all__ = [
+    "build_mcp_http_catalog",
+    "build_mcp_tool_entry",
+    "build_openapi_document",
+    "get_mcp_tool_entry",
+    "load_mcp_config",
+    "mcp_exposure_payload",
+    "render_redoc_html",
+    "render_swagger_ui_html",
+    "resolve_catalog_mode",
+    "resolve_mcp_config_path",
+    "selected_mcp_tool_names",
+]

--- a/python/external_api/catalog.py
+++ b/python/external_api/catalog.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ai.chat_tools import ChatToolSpec, DEFAULT_MCP_TOOL_NAMES, ParseChatTools
+from ai.workflow_tools import DEFAULT_MCP_WORKFLOW_TOOL_NAMES, WorkflowTools
+
+MCP_CONFIG_FILENAME = "mcp_config.json"
+CATALOG_MODES = {"active", "default", "all"}
+
+
+def resolve_mcp_config_path(project_root_path: Path) -> Optional[Path]:
+    project_root = Path(project_root_path).expanduser().resolve()
+    candidates = [
+        project_root / "config" / MCP_CONFIG_FILENAME,
+        project_root / MCP_CONFIG_FILENAME,
+    ]
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    return None
+
+
+def load_mcp_config(project_root_path: Path) -> Dict[str, Any]:
+    config_path = resolve_mcp_config_path(project_root_path)
+    if config_path is None:
+        return {"expose_all_tools": False, "config_path": None}
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"expose_all_tools": False, "config_path": str(config_path)}
+    if not isinstance(payload, dict):
+        return {"expose_all_tools": False, "config_path": str(config_path)}
+    expose_all_tools = payload.get("expose_all_tools", False)
+    if not isinstance(expose_all_tools, bool):
+        expose_all_tools = False
+    return {"expose_all_tools": expose_all_tools, "config_path": str(config_path)}
+
+
+def resolve_catalog_mode(raw_mode: Optional[str]) -> str:
+    mode = str(raw_mode or "active").strip().lower()
+    if mode not in CATALOG_MODES:
+        raise ValueError("mode must be one of: active, default, all")
+    return mode
+
+
+def selected_mcp_tool_names(all_tool_names: List[str], expose_all_tools: bool) -> List[str]:
+    if expose_all_tools:
+        return list(all_tool_names)
+    available_names = set(all_tool_names)
+    return [name for name in DEFAULT_MCP_TOOL_NAMES if name in available_names]
+
+
+def mcp_exposure_payload(
+    *,
+    expose_all_tools: bool,
+    config_source: Optional[str],
+    parse_chat_tool_count: int,
+    workflow_tool_count: int,
+    mcp_tool_count: int,
+) -> Dict[str, Any]:
+    return {
+        "tool": "mcp_get_exposure_mode",
+        "ok": True,
+        "result": {
+            "readOnly": True,
+            "previewOnly": True,
+            "mode": "read-only",
+            "exposeAllTools": expose_all_tools,
+            "configSource": config_source,
+            "parseChatToolCount": parse_chat_tool_count,
+            "workflowToolCount": workflow_tool_count,
+            "mcpToolCount": mcp_tool_count,
+            "defaultParseMcpToolCount": len(DEFAULT_MCP_TOOL_NAMES),
+            "defaultWorkflowMcpToolCount": len(DEFAULT_MCP_WORKFLOW_TOOL_NAMES),
+        },
+    }
+
+
+def _adapter_tool_entry(exposure_payload: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "name": "mcp_get_exposure_mode",
+        "family": "adapter",
+        "description": "Read the active MCP exposure mode, config source, and tool counts.",
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {},
+        },
+        "annotations": {
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "openWorldHint": False,
+            "idempotentHint": True,
+        },
+        "meta": {
+            "x-parse": {
+                "mutability": "read_only",
+                "supports_dry_run": False,
+                "dry_run_parameter": None,
+                "preconditions": [],
+                "postconditions": [
+                    {
+                        "id": "mcp_exposure_reported",
+                        "description": "The active MCP exposure mode, config source, and tool counts are returned.",
+                        "severity": "required",
+                        "kind": "reporting",
+                    }
+                ],
+            }
+        },
+        "result": exposure_payload["result"],
+    }
+
+
+def build_mcp_tool_entry(spec: ChatToolSpec, family: str) -> Dict[str, Any]:
+    return {
+        "name": spec.name,
+        "family": family,
+        "description": spec.description,
+        "parameters": json.loads(json.dumps(spec.parameters)),
+        "annotations": spec.mcp_annotations_payload(),
+        "meta": {"x-parse": spec.mcp_meta_payload()},
+    }
+
+
+def build_mcp_http_catalog(
+    *,
+    project_root: Path,
+    mode: str = "active",
+    parse_tools: Optional[ParseChatTools] = None,
+    workflow_tools: Optional[WorkflowTools] = None,
+) -> Dict[str, Any]:
+    resolved_mode = resolve_catalog_mode(mode)
+    project_root = Path(project_root).expanduser().resolve()
+    parse_tools = parse_tools or ParseChatTools(project_root=project_root)
+    workflow_tools = workflow_tools or WorkflowTools(project_root=project_root)
+
+    config = load_mcp_config(project_root)
+    if resolved_mode == "all":
+        expose_all_tools = True
+        config_source = config.get("config_path")
+    elif resolved_mode == "default":
+        expose_all_tools = False
+        config_source = config.get("config_path")
+    else:
+        expose_all_tools = bool(config.get("expose_all_tools", False))
+        config_source = config.get("config_path")
+
+    all_parse_tool_names = parse_tools.tool_names()
+    selected_parse_names = selected_mcp_tool_names(all_parse_tool_names, expose_all_tools)
+    selected_workflow_names = list(DEFAULT_MCP_WORKFLOW_TOOL_NAMES)
+    mcp_tool_count = len(selected_parse_names) + len(selected_workflow_names) + 1
+    exposure = mcp_exposure_payload(
+        expose_all_tools=expose_all_tools,
+        config_source=config_source,
+        parse_chat_tool_count=len(all_parse_tool_names),
+        workflow_tool_count=len(selected_workflow_names),
+        mcp_tool_count=mcp_tool_count,
+    )
+
+    tools: List[Dict[str, Any]] = []
+    tools.append(_adapter_tool_entry(exposure))
+    for name in selected_parse_names:
+        tools.append(build_mcp_tool_entry(parse_tools.tool_spec(name), family="chat"))
+    for name in selected_workflow_names:
+        tools.append(build_mcp_tool_entry(workflow_tools.tool_spec(name), family="workflow"))
+
+    tools.sort(key=lambda item: item["name"])
+    return {
+        "mode": resolved_mode,
+        "count": len(tools),
+        "exposure": exposure["result"],
+        "tools": tools,
+    }
+
+
+def get_mcp_tool_entry(
+    tool_name: str,
+    *,
+    project_root: Path,
+    mode: str = "active",
+    parse_tools: Optional[ParseChatTools] = None,
+    workflow_tools: Optional[WorkflowTools] = None,
+) -> Optional[Dict[str, Any]]:
+    catalog = build_mcp_http_catalog(
+        project_root=project_root,
+        mode=mode,
+        parse_tools=parse_tools,
+        workflow_tools=workflow_tools,
+    )
+    target = str(tool_name or "").strip()
+    for tool in catalog["tools"]:
+        if tool["name"] == target:
+            return tool
+    return None

--- a/python/external_api/openapi.py
+++ b/python/external_api/openapi.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def _schema_ref(name: str) -> Dict[str, Any]:
+    return {"$ref": "#/components/schemas/{0}".format(name)}
+
+
+def _json_content(schema: Dict[str, Any]) -> Dict[str, Any]:
+    return {"application/json": {"schema": schema}}
+
+
+def _binary_content(content_type: str) -> Dict[str, Any]:
+    return {content_type: {"schema": {"type": "string", "format": "binary"}}}
+
+
+def _response(description: str, schema: Optional[Dict[str, Any]] = None, *, content_type: str = "application/json") -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"description": description}
+    if schema is not None:
+        payload["content"] = _json_content(schema) if content_type == "application/json" else {content_type: {"schema": schema}}
+    return payload
+
+
+def _parameter(name: str, where: str, schema: Dict[str, Any], *, required: bool = False, description: str = "") -> Dict[str, Any]:
+    return {
+        "name": name,
+        "in": where,
+        "required": required,
+        "description": description,
+        "schema": schema,
+    }
+
+
+def build_openapi_document(base_url: str = "http://127.0.0.1:8766") -> Dict[str, Any]:
+    info_description = (
+        "PARSE HTTP API for the browser workstation, local automation, and external agents. "
+        "The general HTTP surface is local-trust and not bearer-protected; provider credentials are managed "
+        "through /api/auth/* and stored locally in config/auth_tokens.json. The /api/mcp/* bridge publishes "
+        "the PARSE MCP schema and exposes the active tool surface for external wrappers."
+    )
+    components = {
+        "schemas": {
+            "GenericObject": {"type": "object", "additionalProperties": True},
+            "ErrorResponse": {
+                "type": "object",
+                "required": ["error"],
+                "properties": {"error": {"type": "string"}},
+                "additionalProperties": True,
+            },
+            "GenericJobResponse": {
+                "type": "object",
+                "properties": {
+                    "jobId": {"type": "string"},
+                    "job_id": {"type": "string"},
+                    "status": {"type": "string"},
+                    "progress": {"type": "number"},
+                    "message": {"type": ["string", "null"]},
+                    "result": {"type": ["object", "array", "string", "number", "boolean", "null"], "additionalProperties": True},
+                    "error": {"type": ["string", "null"]},
+                },
+                "additionalProperties": True,
+            },
+            "AuthStatus": {
+                "type": "object",
+                "properties": {
+                    "authenticated": {"type": "boolean"},
+                    "flow_active": {"type": "boolean"},
+                    "method": {"type": "string"},
+                    "provider": {"type": "string"},
+                    "user_code": {"type": "string"},
+                    "verification_uri": {"type": "string"},
+                    "expires_in": {"type": ["integer", "null"]},
+                },
+                "additionalProperties": True,
+            },
+            "ToolAnnotations": {
+                "type": "object",
+                "properties": {
+                    "readOnlyHint": {"type": "boolean"},
+                    "destructiveHint": {"type": "boolean"},
+                    "openWorldHint": {"type": "boolean"},
+                    "idempotentHint": {"type": "boolean"},
+                },
+                "additionalProperties": True,
+            },
+            "ToolMeta": {
+                "type": "object",
+                "properties": {
+                    "x-parse": {"type": "object", "additionalProperties": True},
+                },
+                "additionalProperties": True,
+            },
+            "ToolSpec": {
+                "type": "object",
+                "required": ["name", "family", "description", "parameters", "annotations", "meta"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "family": {"type": "string", "enum": ["adapter", "chat", "workflow"]},
+                    "description": {"type": "string"},
+                    "parameters": {"type": "object", "additionalProperties": True},
+                    "annotations": _schema_ref("ToolAnnotations"),
+                    "meta": _schema_ref("ToolMeta"),
+                },
+                "additionalProperties": True,
+            },
+            "McpToolCatalog": {
+                "type": "object",
+                "required": ["mode", "count", "exposure", "tools"],
+                "properties": {
+                    "mode": {"type": "string", "enum": ["active", "default", "all"]},
+                    "count": {"type": "integer"},
+                    "exposure": {"type": "object", "additionalProperties": True},
+                    "tools": {"type": "array", "items": _schema_ref("ToolSpec")},
+                },
+                "additionalProperties": True,
+            },
+            "ToolExecutionResponse": {
+                "type": "object",
+                "properties": {
+                    "tool": {"type": "string"},
+                    "ok": {"type": "boolean"},
+                    "result": {"type": ["object", "array", "string", "number", "boolean", "null"], "additionalProperties": True},
+                    "error": {"type": ["string", "null"]},
+                },
+                "additionalProperties": True,
+            },
+        }
+    }
+
+    paths: Dict[str, Any] = {
+        "/api/config": {
+            "get": {"tags": ["Config"], "summary": "Read project configuration", "operationId": "getConfig", "responses": {"200": _response("Project configuration", _schema_ref("GenericObject")), "500": _response("Server error", _schema_ref("ErrorResponse"))}},
+            "post": {"tags": ["Config"], "summary": "Update project configuration", "operationId": "postConfig", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Updated project configuration", _schema_ref("GenericObject")), "400": _response("Validation error", _schema_ref("ErrorResponse"))}},
+            "put": {"tags": ["Config"], "summary": "Update project configuration", "operationId": "putConfig", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Updated project configuration", _schema_ref("GenericObject")), "400": _response("Validation error", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/annotations/{speaker}": {
+            "get": {"tags": ["Annotations"], "summary": "Read one speaker annotation record", "operationId": "getAnnotation", "parameters": [_parameter("speaker", "path", {"type": "string"}, required=True)], "responses": {"200": _response("Normalized annotation payload", _schema_ref("GenericObject")), "400": _response("Invalid speaker", _schema_ref("ErrorResponse")), "404": _response("Missing annotation", _schema_ref("ErrorResponse"))}},
+            "post": {"tags": ["Annotations"], "summary": "Save one speaker annotation record", "operationId": "saveAnnotation", "parameters": [_parameter("speaker", "path", {"type": "string"}, required=True)], "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Saved annotation payload", _schema_ref("GenericObject")), "400": _response("Validation error", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/stt-segments/{speaker}": {
+            "get": {"tags": ["STT"], "summary": "Read cached STT segments", "operationId": "getSttSegments", "parameters": [_parameter("speaker", "path", {"type": "string"}, required=True)], "responses": {"200": _response("Cached STT segments", _schema_ref("GenericObject"))}},
+        },
+        "/api/pipeline/state/{speaker}": {
+            "get": {"tags": ["Pipeline"], "summary": "Read coverage-aware pipeline state", "operationId": "getPipelineState", "parameters": [_parameter("speaker", "path", {"type": "string"}, required=True)], "responses": {"200": _response("Pipeline coverage state", _schema_ref("GenericObject"))}},
+        },
+        "/api/chat/session/{sessionId}": {
+            "get": {"tags": ["Chat"], "summary": "Read one chat session", "operationId": "getChatSession", "parameters": [_parameter("sessionId", "path", {"type": "string"}, required=True)], "responses": {"200": _response("Chat session payload", _schema_ref("GenericObject")), "404": _response("Unknown chat session", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/jobs": {
+            "get": {"tags": ["Jobs"], "summary": "List jobs from the PARSE job registry", "operationId": "listJobs", "parameters": [_parameter("statuses", "query", {"type": "string"}), _parameter("types", "query", {"type": "string"}), _parameter("speaker", "query", {"type": "string"}), _parameter("limit", "query", {"type": "integer"})], "responses": {"200": _response("Active and recent jobs", _schema_ref("GenericObject"))}},
+        },
+        "/api/jobs/active": {
+            "get": {"tags": ["Jobs"], "summary": "List currently running jobs", "operationId": "listActiveJobs", "responses": {"200": _response("Running jobs", _schema_ref("GenericObject"))}},
+        },
+        "/api/jobs/{jobId}": {
+            "get": {"tags": ["Jobs"], "summary": "Read one job snapshot", "operationId": "getJob", "parameters": [_parameter("jobId", "path", {"type": "string"}, required=True)], "responses": {"200": _response("Job snapshot", _schema_ref("GenericJobResponse")), "404": _response("Unknown job", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/jobs/{jobId}/logs": {
+            "get": {"tags": ["Jobs"], "summary": "Read crash/log payloads for one job", "operationId": "getJobLogs", "parameters": [_parameter("jobId", "path", {"type": "string"}, required=True), _parameter("offset", "query", {"type": "integer"}), _parameter("limit", "query", {"type": "integer"})], "responses": {"200": _response("Structured job logs", _schema_ref("GenericObject")), "404": _response("Unknown job", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/enrichments": {
+            "get": {"tags": ["Compare"], "summary": "Read comparative enrichments", "operationId": "getEnrichments", "responses": {"200": _response("Comparative enrichments", _schema_ref("GenericObject"))}},
+            "post": {"tags": ["Compare"], "summary": "Write comparative enrichments", "operationId": "saveEnrichments", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Saved enrichments", _schema_ref("GenericObject")), "400": _response("Validation error", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/auth/status": {
+            "get": {"tags": ["Auth"], "summary": "Read auth provider status", "operationId": "getAuthStatus", "responses": {"200": _response("Current auth state", _schema_ref("AuthStatus"))}},
+        },
+        "/api/auth/key": {
+            "post": {"tags": ["Auth"], "summary": "Save a direct API key", "operationId": "saveApiKey", "requestBody": {"required": True, "content": _json_content({"type": "object", "properties": {"key": {"type": "string"}, "provider": {"type": "string"}}, "required": ["key"], "additionalProperties": False})}, "responses": {"200": _response("Updated auth status", _schema_ref("AuthStatus")), "400": _response("Validation error", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/auth/start": {
+            "post": {"tags": ["Auth"], "summary": "Start OAuth/device auth flow", "operationId": "startAuthFlow", "responses": {"200": _response("Started auth flow", _schema_ref("GenericObject"))}},
+        },
+        "/api/auth/poll": {
+            "post": {"tags": ["Auth"], "summary": "Poll OAuth/device auth flow", "operationId": "pollAuthFlow", "responses": {"200": _response("Auth poll result", _schema_ref("GenericObject"))}},
+        },
+        "/api/auth/logout": {
+            "post": {"tags": ["Auth"], "summary": "Clear auth credentials", "operationId": "logoutAuth", "responses": {"200": _response("Logout result", _schema_ref("GenericObject"))}},
+        },
+        "/api/worker/status": {
+            "get": {"tags": ["Jobs"], "summary": "Read persistent worker health", "operationId": "getWorkerStatus", "responses": {"200": _response("Worker status", _schema_ref("GenericObject"))}},
+        },
+        "/api/export/lingpy": {
+            "get": {"tags": ["Export"], "summary": "Download LingPy TSV export", "operationId": "downloadLingPyExport", "responses": {"200": {"description": "LingPy TSV export", "content": _binary_content("text/tab-separated-values")}}},
+        },
+        "/api/export/nexus": {
+            "get": {"tags": ["Export"], "summary": "Download NEXUS export", "operationId": "downloadNexusExport", "responses": {"200": {"description": "NEXUS export", "content": _binary_content("application/octet-stream")}}},
+        },
+        "/api/contact-lexemes/coverage": {
+            "get": {"tags": ["Compare"], "summary": "Read CLEF provider coverage", "operationId": "getContactLexemeCoverage", "responses": {"200": _response("CLEF coverage payload", _schema_ref("GenericObject"))}},
+        },
+        "/api/tags": {
+            "get": {"tags": ["Tags"], "summary": "Read tag definitions and assignments", "operationId": "getTags", "responses": {"200": _response("Tags payload", _schema_ref("GenericObject"))}},
+        },
+        "/api/spectrogram": {
+            "get": {"tags": ["Media"], "summary": "Generate or read spectrogram PNG", "operationId": "getSpectrogram", "parameters": [_parameter("speaker", "query", {"type": "string"}), _parameter("start", "query", {"type": "number"}), _parameter("end", "query", {"type": "number"})], "responses": {"200": {"description": "Spectrogram image", "content": _binary_content("image/png")}}},
+        },
+        "/api/lexeme/search": {
+            "get": {"tags": ["Search"], "summary": "Search lexeme/concept candidates", "operationId": "searchLexemeCandidates", "parameters": [_parameter("speaker", "query", {"type": "string"}), _parameter("variants", "query", {"type": "string"}), _parameter("concept_id", "query", {"type": "string"}), _parameter("tiers", "query", {"type": "string"}), _parameter("limit", "query", {"type": "integer"})], "responses": {"200": _response("Candidate ranges", _schema_ref("GenericObject"))}},
+        },
+        "/api/onboard/speaker": {
+            "post": {"tags": ["Onboarding"], "summary": "Upload raw audio and optional CSV for one speaker", "operationId": "onboardSpeaker", "requestBody": {"required": True, "content": {"multipart/form-data": {"schema": {"type": "object", "properties": {"speaker": {"type": "string"}, "wav": {"type": "string", "format": "binary"}, "csv": {"type": "string", "format": "binary"}}, "required": ["speaker", "wav"], "additionalProperties": True}}}}, "responses": {"200": _response("Onboarding job started", _schema_ref("GenericJobResponse")), "400": _response("Validation error", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/onboard/speaker/status": {
+            "post": {"tags": ["Onboarding"], "summary": "Poll onboarding job status", "operationId": "pollOnboardSpeaker", "requestBody": {"required": True, "content": _json_content({"type": "object", "properties": {"jobId": {"type": "string"}, "job_id": {"type": "string"}}, "additionalProperties": False})}, "responses": {"200": _response("Onboarding job status", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/normalize": {
+            "post": {"tags": ["Audio"], "summary": "Start audio normalization", "operationId": "startNormalize", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Normalization job started", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/normalize/status": {
+            "post": {"tags": ["Audio"], "summary": "Poll normalization status", "operationId": "pollNormalize", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Normalization status", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/stt": {
+            "post": {"tags": ["STT"], "summary": "Start STT", "operationId": "startStt", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("STT job started", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/stt/status": {
+            "post": {"tags": ["STT"], "summary": "Poll STT status", "operationId": "pollStt", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("STT status", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/suggest": {
+            "post": {"tags": ["Annotations"], "summary": "Request annotation suggestions", "operationId": "requestSuggestions", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Suggestion payload", _schema_ref("GenericObject"))}},
+        },
+        "/api/chat/session": {
+            "post": {"tags": ["Chat"], "summary": "Create or resume a chat session", "operationId": "startChatSession", "requestBody": {"required": False, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Chat session payload", _schema_ref("GenericObject"))}},
+        },
+        "/api/chat/run": {
+            "post": {"tags": ["Chat"], "summary": "Start a chat run", "operationId": "runChat", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Chat job started", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/chat/run/status": {
+            "post": {"tags": ["Chat"], "summary": "Poll chat run status", "operationId": "pollChat", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Chat job status", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/tags/merge": {
+            "post": {"tags": ["Tags"], "summary": "Merge tag definitions", "operationId": "mergeTags", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Merged tags", _schema_ref("GenericObject"))}},
+        },
+        "/api/concepts/import": {
+            "post": {"tags": ["Annotations"], "summary": "Import concepts CSV", "operationId": "importConcepts", "requestBody": {"required": True, "content": {"multipart/form-data": {"schema": {"type": "object", "properties": {"file": {"type": "string", "format": "binary"}}, "required": ["file"]}}}}, "responses": {"200": _response("Imported concepts summary", _schema_ref("GenericObject"))}},
+        },
+        "/api/tags/import": {
+            "post": {"tags": ["Tags"], "summary": "Import tags from CSV", "operationId": "importTags", "requestBody": {"required": True, "content": {"multipart/form-data": {"schema": {"type": "object", "properties": {"file": {"type": "string", "format": "binary"}}, "required": ["file"]}}}}, "responses": {"200": _response("Imported tags summary", _schema_ref("GenericObject"))}},
+        },
+        "/api/lexeme-notes": {
+            "post": {"tags": ["Compare"], "summary": "Write or delete a lexeme note", "operationId": "writeLexemeNote", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Lexeme notes result", _schema_ref("GenericObject"))}},
+        },
+        "/api/lexeme-notes/import": {
+            "post": {"tags": ["Compare"], "summary": "Import lexeme notes from CSV", "operationId": "importLexemeNotes", "requestBody": {"required": True, "content": {"multipart/form-data": {"schema": {"type": "object", "properties": {"file": {"type": "string", "format": "binary"}}, "required": ["file"]}}}}, "responses": {"200": _response("Imported lexeme notes summary", _schema_ref("GenericObject"))}},
+        },
+        "/api/offset/detect": {
+            "post": {"tags": ["Offsets"], "summary": "Detect a constant timestamp offset", "operationId": "detectTimestampOffset", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Offset-detect job started or result payload", _schema_ref("GenericObject"))}},
+        },
+        "/api/offset/detect-from-pair": {
+            "post": {"tags": ["Offsets"], "summary": "Detect a timestamp offset from trusted anchor pairs", "operationId": "detectTimestampOffsetFromPair", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Offset-detect-from-pair job started or result payload", _schema_ref("GenericObject"))}},
+        },
+        "/api/offset/apply": {
+            "post": {"tags": ["Offsets"], "summary": "Apply a constant timestamp shift", "operationId": "applyTimestampOffset", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Timestamp shift result", _schema_ref("GenericObject"))}},
+        },
+        "/api/compute/status": {
+            "post": {"tags": ["Compute"], "summary": "Poll any compute job by job ID", "operationId": "pollComputeAny", "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Compute job status", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/compute/{computeType}": {
+            "post": {"tags": ["Compute"], "summary": "Start a compute job", "operationId": "startCompute", "parameters": [_parameter("computeType", "path", {"type": "string"}, required=True)], "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Compute job started", _schema_ref("GenericJobResponse")), "400": _response("Unknown or invalid compute type", _schema_ref("ErrorResponse"))}},
+        },
+        "/api/compute/{computeType}/status": {
+            "post": {"tags": ["Compute"], "summary": "Poll a typed compute job", "operationId": "pollComputeTyped", "parameters": [_parameter("computeType", "path", {"type": "string"}, required=True)], "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Typed compute job status", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/{computeType}/status": {
+            "post": {"tags": ["Compute"], "summary": "Compatibility alias for compute status", "operationId": "pollComputeCompatStatus", "parameters": [_parameter("computeType", "path", {"type": "string"}, required=True)], "requestBody": {"required": True, "content": _json_content(_schema_ref("GenericObject"))}, "responses": {"200": _response("Compatibility compute job status", _schema_ref("GenericJobResponse"))}},
+        },
+        "/api/mcp/exposure": {
+            "get": {"tags": ["MCP"], "summary": "Read the active MCP exposure configuration", "operationId": "getMcpExposure", "parameters": [_parameter("mode", "query", {"type": "string", "enum": ["active", "default", "all"]}, description="Exposure mode override.")], "responses": {"200": _response("MCP exposure payload", _schema_ref("GenericObject"))}},
+        },
+        "/api/mcp/tools": {
+            "get": {"tags": ["MCP"], "summary": "List MCP tool schemas exposed by PARSE", "operationId": "listMcpTools", "parameters": [_parameter("mode", "query", {"type": "string", "enum": ["active", "default", "all"]}, description="Exposure mode override.")], "responses": {"200": _response("MCP tool catalog", _schema_ref("McpToolCatalog"))}},
+        },
+        "/api/mcp/tools/{toolName}": {
+            "get": {"tags": ["MCP"], "summary": "Read one MCP tool schema", "operationId": "getMcpTool", "parameters": [_parameter("toolName", "path", {"type": "string"}, required=True), _parameter("mode", "query", {"type": "string", "enum": ["active", "default", "all"]})], "responses": {"200": _response("MCP tool schema", _schema_ref("ToolSpec")), "404": _response("Unknown or hidden tool", _schema_ref("ErrorResponse"))}},
+            "post": {"tags": ["MCP"], "summary": "Execute one MCP-visible tool over HTTP", "operationId": "executeMcpTool", "parameters": [_parameter("toolName", "path", {"type": "string"}, required=True), _parameter("mode", "query", {"type": "string", "enum": ["active", "default", "all"]})], "requestBody": {"required": True, "content": _json_content({"type": "object", "additionalProperties": True})}, "responses": {"200": _response("Tool execution result", _schema_ref("ToolExecutionResponse")), "400": _response("Validation or execution error", _schema_ref("ErrorResponse")), "404": _response("Unknown or hidden tool", _schema_ref("ErrorResponse"))}},
+        },
+    }
+
+    return {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "PARSE HTTP API",
+            "version": "0.1.0",
+            "description": info_description,
+        },
+        "servers": [{"url": base_url}],
+        "tags": [
+            {"name": "Annotations"},
+            {"name": "Audio"},
+            {"name": "Auth"},
+            {"name": "Chat"},
+            {"name": "Compare"},
+            {"name": "Compute"},
+            {"name": "Config"},
+            {"name": "Export"},
+            {"name": "Jobs"},
+            {"name": "MCP"},
+            {"name": "Media"},
+            {"name": "Offsets"},
+            {"name": "Onboarding"},
+            {"name": "Search"},
+            {"name": "STT"},
+            {"name": "Tags"},
+        ],
+        "paths": paths,
+        "components": components,
+        "x-parse-auth": {
+            "http_transport": "local-trust",
+            "general_api_auth": "none",
+            "provider_credentials": {
+                "status_endpoint": "/api/auth/status",
+                "api_key_endpoint": "/api/auth/key",
+                "oauth_start_endpoint": "/api/auth/start",
+                "oauth_poll_endpoint": "/api/auth/poll",
+                "logout_endpoint": "/api/auth/logout",
+                "storage": "config/auth_tokens.json",
+            },
+        },
+    }
+
+
+def render_swagger_ui_html(openapi_url: str = "/openapi.json") -> str:
+    return """<!doctype html>
+<html>
+  <head>
+    <meta charset=\"utf-8\" />
+    <title>PARSE API Docs</title>
+    <link rel=\"stylesheet\" href=\"https://unpkg.com/swagger-ui-dist@5/swagger-ui.css\" />
+  </head>
+  <body>
+    <div id=\"swagger-ui\"></div>
+    <script src=\"https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js\"></script>
+    <script>
+      window.ui = SwaggerUIBundle({ url: %s, dom_id: '#swagger-ui' });
+    </script>
+  </body>
+</html>
+""" % (repr(openapi_url),)
+
+
+def render_redoc_html(openapi_url: str = "/openapi.json") -> str:
+    return """<!doctype html>
+<html>
+  <head>
+    <meta charset=\"utf-8\" />
+    <title>PARSE API ReDoc</title>
+    <script src=\"https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js\"></script>
+  </head>
+  <body>
+    <div id=\"redoc-container\"></div>
+    <script>
+      Redoc.init(%s, {}, document.getElementById('redoc-container'));
+    </script>
+  </body>
+</html>
+""" % (repr(openapi_url),)

--- a/python/packages/parse_mcp/LICENSE
+++ b/python/packages/parse_mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lucas Ardelean
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/python/packages/parse_mcp/README.md
+++ b/python/packages/parse_mcp/README.md
@@ -1,0 +1,69 @@
+# parse-mcp
+
+Official Python client and agent-framework wrappers for the PARSE MCP surface.
+
+## What it does
+- discovers the active PARSE MCP tool schema from a running PARSE server
+- executes MCP-visible PARSE tools through the HTTP bridge
+- builds ready-to-use wrappers for:
+  - LangChain
+  - LlamaIndex
+  - CrewAI
+
+## Runtime requirements
+A running PARSE server on `http://127.0.0.1:8766` (or another configured base URL) with Task 5's external API endpoints enabled:
+- `GET /openapi.json`
+- `GET /api/mcp/exposure`
+- `GET /api/mcp/tools`
+- `GET /api/mcp/tools/{toolName}`
+- `POST /api/mcp/tools/{toolName}`
+
+## Install
+
+```bash
+pip install parse-mcp
+pip install 'parse-mcp[langchain]'
+pip install 'parse-mcp[llamaindex]'
+pip install 'parse-mcp[crewai]'
+pip install 'parse-mcp[all]'
+```
+
+## Basic usage
+
+```python
+from parse_mcp import ParseMcpClient
+
+client = ParseMcpClient(base_url="http://127.0.0.1:8766")
+for tool in client.list_tools():
+    print(tool.name, tool.family)
+
+result = client.call_tool("project_context_read", {"include": ["project", "source_index"]})
+print(result)
+```
+
+## LangChain
+
+```python
+from parse_mcp import ParseMcpClient, build_langchain_tools
+
+client = ParseMcpClient()
+tools = build_langchain_tools(client)
+```
+
+## LlamaIndex
+
+```python
+from parse_mcp import ParseMcpClient, build_llamaindex_tools
+
+client = ParseMcpClient()
+tools = build_llamaindex_tools(client)
+```
+
+## CrewAI
+
+```python
+from parse_mcp import ParseMcpClient, build_crewai_tools
+
+client = ParseMcpClient()
+tools = build_crewai_tools(client)
+```

--- a/python/packages/parse_mcp/pyproject.toml
+++ b/python/packages/parse_mcp/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "parse-mcp"
+version = "0.1.0"
+description = "Official PARSE MCP HTTP bridge client and agent-framework wrappers"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+authors = [
+  {name = "Lucas Ardelean"}
+]
+dependencies = [
+  "pydantic>=2.7,<3",
+]
+keywords = ["mcp", "linguistics", "fieldwork", "phonetics", "langchain", "llamaindex", "crewai"]
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Software Development :: Libraries",
+]
+
+[project.optional-dependencies]
+langchain = ["langchain-core>=0.2"]
+llamaindex = ["llama-index-core>=0.10"]
+crewai = ["crewai>=0.30"]
+all = [
+  "langchain-core>=0.2",
+  "llama-index-core>=0.10",
+  "crewai>=0.30",
+]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/python/packages/parse_mcp/src/parse_mcp/__init__.py
+++ b/python/packages/parse_mcp/src/parse_mcp/__init__.py
@@ -1,0 +1,15 @@
+from .client import ParseMcpClient
+from .crewai import build_crewai_tools
+from .langchain import build_langchain_tools
+from .llamaindex import build_llamaindex_tools
+from .models import ParseToolAnnotations, ParseToolMeta, ParseToolSpec
+
+__all__ = [
+    "ParseMcpClient",
+    "ParseToolAnnotations",
+    "ParseToolMeta",
+    "ParseToolSpec",
+    "build_crewai_tools",
+    "build_langchain_tools",
+    "build_llamaindex_tools",
+]

--- a/python/packages/parse_mcp/src/parse_mcp/_schema.py
+++ b/python/packages/parse_mcp/src/parse_mcp/_schema.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field, create_model
+
+
+def _json_type_to_annotation(schema: Dict[str, Any]) -> Any:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        non_null = [item for item in schema_type if item != "null"]
+        schema_type = non_null[0] if non_null else "object"
+    if schema_type == "string":
+        return str
+    if schema_type == "integer":
+        return int
+    if schema_type == "number":
+        return float
+    if schema_type == "boolean":
+        return bool
+    if schema_type == "array":
+        item_schema = schema.get("items") if isinstance(schema.get("items"), dict) else {}
+        return List[_json_type_to_annotation(item_schema)]
+    if schema_type == "object":
+        return Dict[str, Any]
+    return Any
+
+
+def build_args_model(model_name: str, schema: Dict[str, Any]):
+    properties = dict(schema.get("properties") or {})
+    required = set(schema.get("required") or [])
+    field_defs: Dict[str, Any] = {}
+    for field_name, field_schema in properties.items():
+        field_schema = field_schema if isinstance(field_schema, dict) else {}
+        annotation = _json_type_to_annotation(field_schema)
+        description = str(field_schema.get("description") or "") or None
+        default = ... if field_name in required else None
+        field_defs[field_name] = (annotation, Field(default=default, description=description))
+    return create_model(model_name, **field_defs)

--- a/python/packages/parse_mcp/src/parse_mcp/client.py
+++ b/python/packages/parse_mcp/src/parse_mcp/client.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+from .models import ParseToolSpec
+
+
+class ParseMcpClient:
+    def __init__(self, base_url: str = "http://127.0.0.1:8766", mode: str = "active") -> None:
+        self.base_url = str(base_url or "http://127.0.0.1:8766").rstrip("/")
+        self.mode = str(mode or "active").strip().lower() or "active"
+
+    def _request_json(self, method: str, path: str, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        data = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            url="{0}{1}".format(self.base_url, path),
+            data=data,
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            method=method,
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads((response.read() or b"{}").decode("utf-8"))
+
+    def get_exposure(self, mode: Optional[str] = None) -> Dict[str, Any]:
+        selected_mode = urllib.parse.quote(str(mode or self.mode), safe="")
+        return self._request_json("GET", "/api/mcp/exposure?mode={0}".format(selected_mode))
+
+    def list_tools(self, mode: Optional[str] = None) -> List[ParseToolSpec]:
+        selected_mode = urllib.parse.quote(str(mode or self.mode), safe="")
+        payload = self._request_json("GET", "/api/mcp/tools?mode={0}".format(selected_mode))
+        return [ParseToolSpec.from_payload(item) for item in list(payload.get("tools") or [])]
+
+    def get_tool(self, tool_name: str, mode: Optional[str] = None) -> ParseToolSpec:
+        safe_name = urllib.parse.quote(str(tool_name or "").strip(), safe="")
+        selected_mode = urllib.parse.quote(str(mode or self.mode), safe="")
+        payload = self._request_json("GET", "/api/mcp/tools/{0}?mode={1}".format(safe_name, selected_mode))
+        return ParseToolSpec.from_payload(payload)
+
+    def call_tool(self, tool_name: str, arguments: Optional[Dict[str, Any]] = None, mode: Optional[str] = None) -> Dict[str, Any]:
+        safe_name = urllib.parse.quote(str(tool_name or "").strip(), safe="")
+        path = "/api/mcp/tools/{0}".format(safe_name)
+        if mode is not None:
+            selected_mode = urllib.parse.quote(str(mode or self.mode), safe="")
+            path = "{0}?mode={1}".format(path, selected_mode)
+        return self._request_json("POST", path, payload=dict(arguments or {}))

--- a/python/packages/parse_mcp/src/parse_mcp/crewai.py
+++ b/python/packages/parse_mcp/src/parse_mcp/crewai.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ._schema import build_args_model
+from .models import ParseToolSpec
+
+
+def _tool_description(spec: ParseToolSpec) -> str:
+    x_parse = spec.meta.x_parse
+    mutability = str(x_parse.get("mutability") or "read_only")
+    supports_dry_run = bool(x_parse.get("supports_dry_run", False))
+    suffix = " Mutability: {0}.".format(mutability)
+    if supports_dry_run:
+        suffix += " Supports dry-run previews."
+    return spec.description + suffix
+
+
+def _build_crewai_tool(client, spec: ParseToolSpec, BaseTool):
+    args_model = build_args_model("{0}Args".format(spec.name.title().replace("_", "")), spec.parameters)
+
+    class ParseCrewAITool(BaseTool):
+        def _run(self, **kwargs):
+            return client.call_tool(spec.name, kwargs)
+
+    ParseCrewAITool.name = spec.name
+    ParseCrewAITool.description = _tool_description(spec)
+    ParseCrewAITool.args_schema = args_model
+    return ParseCrewAITool()
+
+
+def build_crewai_tools(client, mode: Optional[str] = None) -> List[object]:
+    try:
+        from crewai.tools import BaseTool
+    except ImportError as exc:  # pragma: no cover - exercised in real installs
+        raise ImportError("Install parse-mcp with the 'crewai' extra to build CrewAI tools.") from exc
+
+    return [_build_crewai_tool(client, spec, BaseTool) for spec in client.list_tools(mode=mode)]

--- a/python/packages/parse_mcp/src/parse_mcp/langchain.py
+++ b/python/packages/parse_mcp/src/parse_mcp/langchain.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ._schema import build_args_model
+from .models import ParseToolSpec
+
+
+def _tool_description(spec: ParseToolSpec) -> str:
+    x_parse = spec.meta.x_parse
+    mutability = str(x_parse.get("mutability") or "read_only")
+    supports_dry_run = bool(x_parse.get("supports_dry_run", False))
+    suffix = " Mutability: {0}.".format(mutability)
+    if supports_dry_run:
+        suffix += " Supports dry-run previews."
+    return spec.description + suffix
+
+
+def build_langchain_tools(client, mode: Optional[str] = None) -> List[object]:
+    try:
+        from langchain_core.tools import StructuredTool
+    except ImportError as exc:  # pragma: no cover - exercised in real installs
+        raise ImportError("Install parse-mcp with the 'langchain' extra to build LangChain tools.") from exc
+
+    tools = []
+    for spec in client.list_tools(mode=mode):
+        args_schema = build_args_model("{0}Args".format(spec.name.title().replace("_", "")), spec.parameters)
+
+        def _runner(_tool_name: str = spec.name, **kwargs):
+            return client.call_tool(_tool_name, kwargs)
+
+        tools.append(
+            StructuredTool.from_function(
+                func=_runner,
+                name=spec.name,
+                description=_tool_description(spec),
+                args_schema=args_schema,
+            )
+        )
+    return tools

--- a/python/packages/parse_mcp/src/parse_mcp/llamaindex.py
+++ b/python/packages/parse_mcp/src/parse_mcp/llamaindex.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ._schema import build_args_model
+from .models import ParseToolSpec
+
+
+def _tool_description(spec: ParseToolSpec) -> str:
+    x_parse = spec.meta.x_parse
+    mutability = str(x_parse.get("mutability") or "read_only")
+    supports_dry_run = bool(x_parse.get("supports_dry_run", False))
+    suffix = " Mutability: {0}.".format(mutability)
+    if supports_dry_run:
+        suffix += " Supports dry-run previews."
+    return spec.description + suffix
+
+
+def build_llamaindex_tools(client, mode: Optional[str] = None) -> List[object]:
+    try:
+        from llama_index.core.tools import FunctionTool
+    except ImportError as exc:  # pragma: no cover - exercised in real installs
+        raise ImportError("Install parse-mcp with the 'llamaindex' extra to build LlamaIndex tools.") from exc
+
+    tools = []
+    for spec in client.list_tools(mode=mode):
+        fn_schema = build_args_model("{0}Args".format(spec.name.title().replace("_", "")), spec.parameters)
+
+        def _runner(_tool_name: str = spec.name, **kwargs):
+            return client.call_tool(_tool_name, kwargs)
+
+        tools.append(
+            FunctionTool.from_defaults(
+                fn=_runner,
+                name=spec.name,
+                description=_tool_description(spec),
+                fn_schema=fn_schema,
+            )
+        )
+    return tools

--- a/python/packages/parse_mcp/src/parse_mcp/models.py
+++ b/python/packages/parse_mcp/src/parse_mcp/models.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class ParseToolAnnotations:
+    readOnlyHint: bool = False
+    destructiveHint: bool = False
+    openWorldHint: bool = False
+    idempotentHint: bool = False
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "ParseToolAnnotations":
+        return cls(**{key: value for key, value in (payload or {}).items() if key in {"readOnlyHint", "destructiveHint", "openWorldHint", "idempotentHint"}})
+
+
+@dataclass
+class ParseToolMeta:
+    x_parse: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "ParseToolMeta":
+        payload = payload or {}
+        return cls(x_parse=dict(payload.get("x-parse") or {}))
+
+
+@dataclass
+class ParseToolSpec:
+    name: str
+    family: str
+    description: str
+    parameters: Dict[str, Any]
+    annotations: ParseToolAnnotations
+    meta: ParseToolMeta
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "ParseToolSpec":
+        return cls(
+            name=str(payload.get("name") or ""),
+            family=str(payload.get("family") or "chat"),
+            description=str(payload.get("description") or ""),
+            parameters=dict(payload.get("parameters") or {}),
+            annotations=ParseToolAnnotations.from_payload(dict(payload.get("annotations") or {})),
+            meta=ParseToolMeta.from_payload(dict(payload.get("meta") or {})),
+        )

--- a/python/packages/parse_mcp/tests/test_client.py
+++ b/python/packages/parse_mcp/tests/test_client.py
@@ -1,0 +1,73 @@
+import io
+import json
+import pathlib
+import sys
+import urllib.request
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from parse_mcp.client import ParseMcpClient
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.headers = {"Content-Type": "application/json; charset=utf-8"}
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_client_lists_tools_via_http_bridge(monkeypatch) -> None:
+    seen = []
+
+    def fake_urlopen(request, timeout=0):
+        seen.append((request.full_url, request.get_method(), request.data))
+        return _FakeHttpResponse(
+            {
+                "mode": "active",
+                "tools": [
+                    {
+                        "name": "project_context_read",
+                        "family": "chat",
+                        "description": "Read PARSE project context.",
+                        "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+                        "annotations": {"readOnlyHint": True},
+                        "meta": {"x-parse": {"mutability": "read_only", "supports_dry_run": False, "preconditions": [], "postconditions": []}},
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = ParseMcpClient(base_url="http://127.0.0.1:8766")
+    tools = client.list_tools()
+
+    assert [tool.name for tool in tools] == ["project_context_read"]
+    assert seen[0][0].endswith("/api/mcp/tools?mode=active")
+    assert seen[0][1] == "GET"
+
+
+def test_client_executes_tool_via_http_bridge(monkeypatch) -> None:
+    seen = []
+
+    def fake_urlopen(request, timeout=0):
+        seen.append((request.full_url, request.get_method(), json.loads((request.data or b"{}").decode("utf-8"))))
+        return _FakeHttpResponse({"tool": "project_context_read", "ok": True, "result": {"readOnly": True}})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = ParseMcpClient(base_url="http://127.0.0.1:8766")
+    result = client.call_tool("project_context_read", {"include": ["project"]})
+
+    assert result["ok"] is True
+    assert seen[0][0].endswith("/api/mcp/tools/project_context_read")
+    assert seen[0][1] == "POST"
+    assert seen[0][2] == {"include": ["project"]}

--- a/python/packages/parse_mcp/tests/test_crewai.py
+++ b/python/packages/parse_mcp/tests/test_crewai.py
@@ -1,0 +1,67 @@
+import pathlib
+import sys
+import types
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from parse_mcp.models import ParseToolSpec, ParseToolAnnotations, ParseToolMeta
+
+
+class _FakeClient:
+    def __init__(self, spec):
+        self.spec = spec
+        self.calls = []
+
+    def list_tools(self, mode="active"):
+        return [self.spec]
+
+    def call_tool(self, tool_name, arguments=None):
+        self.calls.append((tool_name, arguments or {}))
+        return {"tool": tool_name, "ok": True, "arguments": arguments or {}}
+
+
+def test_build_crewai_tools_uses_discovery_schema_and_delegates_calls(monkeypatch) -> None:
+    fake_tools_mod = types.ModuleType("crewai.tools")
+
+    class FakeBaseTool:
+        name = ""
+        description = ""
+        args_schema = None
+
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    fake_tools_mod.BaseTool = FakeBaseTool
+    fake_root_mod = types.ModuleType("crewai")
+    fake_root_mod.tools = fake_tools_mod
+    monkeypatch.setitem(sys.modules, "crewai", fake_root_mod)
+    monkeypatch.setitem(sys.modules, "crewai.tools", fake_tools_mod)
+
+    from parse_mcp.crewai import build_crewai_tools
+
+    spec = ParseToolSpec(
+        name="project_context_read",
+        family="chat",
+        description="Read project context.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "include": {"type": "array", "items": {"type": "string"}},
+            },
+            "additionalProperties": False,
+        },
+        annotations=ParseToolAnnotations(readOnlyHint=True),
+        meta=ParseToolMeta(x_parse={"mutability": "read_only", "supports_dry_run": False, "preconditions": [], "postconditions": []}),
+    )
+    client = _FakeClient(spec)
+
+    tools = build_crewai_tools(client)
+
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool.name == "project_context_read"
+    assert tool.args_schema is not None
+    result = tool._run(include=["project"])
+    assert result["ok"] is True
+    assert client.calls == [("project_context_read", {"include": ["project"]})]

--- a/python/packages/parse_mcp/tests/test_langchain.py
+++ b/python/packages/parse_mcp/tests/test_langchain.py
@@ -1,0 +1,69 @@
+import pathlib
+import sys
+import types
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from parse_mcp.models import ParseToolSpec, ParseToolAnnotations, ParseToolMeta
+
+
+class _FakeClient:
+    def __init__(self, spec):
+        self.spec = spec
+        self.calls = []
+
+    def list_tools(self, mode="active"):
+        return [self.spec]
+
+    def call_tool(self, tool_name, arguments=None):
+        self.calls.append((tool_name, arguments or {}))
+        return {"tool": tool_name, "ok": True, "arguments": arguments or {}}
+
+
+def test_build_langchain_tools_uses_discovery_schema_and_delegates_calls(monkeypatch) -> None:
+    fake_tools_mod = types.ModuleType("langchain_core.tools")
+
+    class FakeStructuredTool:
+        def __init__(self, func, name, description, args_schema):
+            self.func = func
+            self.name = name
+            self.description = description
+            self.args_schema = args_schema
+
+        @classmethod
+        def from_function(cls, func=None, name=None, description=None, args_schema=None, coroutine=None):
+            return cls(func, name, description, args_schema)
+
+    fake_tools_mod.StructuredTool = FakeStructuredTool
+    fake_root_mod = types.ModuleType("langchain_core")
+    fake_root_mod.tools = fake_tools_mod
+    monkeypatch.setitem(sys.modules, "langchain_core", fake_root_mod)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", fake_tools_mod)
+
+    from parse_mcp.langchain import build_langchain_tools
+
+    spec = ParseToolSpec(
+        name="project_context_read",
+        family="chat",
+        description="Read project context.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "include": {"type": "array", "items": {"type": "string"}},
+            },
+            "additionalProperties": False,
+        },
+        annotations=ParseToolAnnotations(readOnlyHint=True),
+        meta=ParseToolMeta(x_parse={"mutability": "read_only", "supports_dry_run": False, "preconditions": [], "postconditions": []}),
+    )
+    client = _FakeClient(spec)
+
+    tools = build_langchain_tools(client)
+
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool.name == "project_context_read"
+    assert tool.args_schema is not None
+    result = tool.func(include=["project"])
+    assert result["ok"] is True
+    assert client.calls == [("project_context_read", {"include": ["project"]})]

--- a/python/packages/parse_mcp/tests/test_llamaindex.py
+++ b/python/packages/parse_mcp/tests/test_llamaindex.py
@@ -1,0 +1,71 @@
+import pathlib
+import sys
+import types
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from parse_mcp.models import ParseToolSpec, ParseToolAnnotations, ParseToolMeta
+
+
+class _FakeClient:
+    def __init__(self, spec):
+        self.spec = spec
+        self.calls = []
+
+    def list_tools(self, mode="active"):
+        return [self.spec]
+
+    def call_tool(self, tool_name, arguments=None):
+        self.calls.append((tool_name, arguments or {}))
+        return {"tool": tool_name, "ok": True, "arguments": arguments or {}}
+
+
+def test_build_llamaindex_tools_uses_discovery_schema_and_delegates_calls(monkeypatch) -> None:
+    fake_tools_mod = types.ModuleType("llama_index.core.tools")
+
+    class FakeFunctionTool:
+        def __init__(self, fn, name, description, fn_schema):
+            self.fn = fn
+            self.metadata = types.SimpleNamespace(name=name, description=description)
+            self.fn_schema = fn_schema
+
+        @classmethod
+        def from_defaults(cls, fn=None, name=None, description=None, fn_schema=None):
+            return cls(fn, name, description, fn_schema)
+
+    fake_tools_mod.FunctionTool = FakeFunctionTool
+    fake_core_mod = types.ModuleType("llama_index.core")
+    fake_core_mod.tools = fake_tools_mod
+    fake_root_mod = types.ModuleType("llama_index")
+    fake_root_mod.core = fake_core_mod
+    monkeypatch.setitem(sys.modules, "llama_index", fake_root_mod)
+    monkeypatch.setitem(sys.modules, "llama_index.core", fake_core_mod)
+    monkeypatch.setitem(sys.modules, "llama_index.core.tools", fake_tools_mod)
+
+    from parse_mcp.llamaindex import build_llamaindex_tools
+
+    spec = ParseToolSpec(
+        name="project_context_read",
+        family="chat",
+        description="Read project context.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "include": {"type": "array", "items": {"type": "string"}},
+            },
+            "additionalProperties": False,
+        },
+        annotations=ParseToolAnnotations(readOnlyHint=True),
+        meta=ParseToolMeta(x_parse={"mutability": "read_only", "supports_dry_run": False, "preconditions": [], "postconditions": []}),
+    )
+    client = _FakeClient(spec)
+
+    tools = build_llamaindex_tools(client)
+
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool.metadata.name == "project_context_read"
+    assert tool.fn_schema is not None
+    result = tool.fn(include=["project"])
+    assert result["ok"] is True
+    assert client.calls == [("project_context_read", {"include": ["project"]})]

--- a/python/packages/parse_mcp/tests/test_package_smoke.py
+++ b/python/packages/parse_mcp/tests/test_package_smoke.py
@@ -1,0 +1,13 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+import parse_mcp
+
+
+def test_package_exports_public_entrypoints() -> None:
+    assert hasattr(parse_mcp, "ParseMcpClient")
+    assert hasattr(parse_mcp, "build_langchain_tools")
+    assert hasattr(parse_mcp, "build_llamaindex_tools")
+    assert hasattr(parse_mcp, "build_crewai_tools")

--- a/python/server.py
+++ b/python/server.py
@@ -19,14 +19,17 @@ import uuid
 from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Sequence, Tuple
-from urllib.parse import unquote, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 from urllib.request import Request, urlopen
 
 from ai.chat_orchestrator import ChatOrchestrator, ChatOrchestratorError, READ_ONLY_NOTICE
-from ai.chat_tools import ParseChatTools
+from ai.chat_tools import ChatToolExecutionError, ChatToolValidationError, ParseChatTools
+from ai.workflow_tools import WorkflowTools
 from ai.provider import get_chat_config, get_llm_provider, get_ortho_provider, get_stt_provider, load_ai_config, resolve_context_window
 from ai.ipa_transcribe import transcribe_slice as _acoustic_transcribe_slice
 from audio_pipeline_paths import build_normalized_output_path
+from external_api.catalog import build_mcp_http_catalog, get_mcp_tool_entry, mcp_exposure_payload, resolve_catalog_mode
+from external_api.openapi import build_openapi_document, render_redoc_html, render_swagger_ui_html
 
 try:
     from compare import cognate_compute as cognate_compute_module
@@ -2358,6 +2361,60 @@ def _get_chat_runtime() -> Tuple[ParseChatTools, ChatOrchestrator]:
             )
 
         return _chat_tools_runtime, _chat_orchestrator_runtime
+
+
+def _build_workflow_runtime() -> WorkflowTools:
+    return WorkflowTools(
+        project_root=_project_root(),
+        config_path=_config_path(),
+        docs_root=_chat_docs_root(),
+        start_stt_job=_chat_start_stt_job,
+        get_job_snapshot=_chat_get_job_snapshot,
+        external_read_roots=_chat_external_read_roots(),
+        memory_path=_chat_memory_path(),
+        onboard_speaker=_chat_onboard_speaker,
+        start_compute_job=_chat_start_compute_job,
+        pipeline_state=_chat_pipeline_state,
+    )
+
+
+def _execute_mcp_http_tool(tool_name: str, raw_args: Dict[str, Any], mode: str = "active") -> Dict[str, Any]:
+    if not isinstance(raw_args, dict):
+        raise ApiError(HTTPStatus.BAD_REQUEST, "Tool arguments must be a JSON object")
+
+    parse_tools, _ = _get_chat_runtime()
+    workflow_tools = _build_workflow_runtime()
+    tool_entry = get_mcp_tool_entry(
+        tool_name,
+        project_root=_project_root(),
+        mode=mode,
+        parse_tools=parse_tools,
+        workflow_tools=workflow_tools,
+    )
+    if tool_entry is None:
+        raise ApiError(HTTPStatus.NOT_FOUND, "Unknown MCP tool: {0}".format(tool_name))
+
+    family = str(tool_entry.get("family") or "chat")
+    try:
+        if family == "adapter" and tool_name == "mcp_get_exposure_mode":
+            catalog = build_mcp_http_catalog(
+                project_root=_project_root(),
+                mode=mode,
+                parse_tools=parse_tools,
+                workflow_tools=workflow_tools,
+            )
+            return mcp_exposure_payload(
+                expose_all_tools=bool(catalog["exposure"].get("exposeAllTools", False)),
+                config_source=catalog["exposure"].get("configSource"),
+                parse_chat_tool_count=int(catalog["exposure"].get("parseChatToolCount", len(parse_tools.tool_names()))),
+                workflow_tool_count=int(catalog["exposure"].get("workflowToolCount", 0)),
+                mcp_tool_count=int(catalog["exposure"].get("mcpToolCount", catalog.get("count", 0))),
+            )
+        if family == "workflow":
+            return workflow_tools.execute(tool_name, raw_args)
+        return parse_tools.execute(tool_name, raw_args)
+    except (ChatToolValidationError, ChatToolExecutionError, ValueError) as exc:
+        raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
 
 
 def _run_chat_job(job_id: str, session_id: str) -> None:
@@ -5674,6 +5731,8 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self) -> None:
+        if self._handle_builtin_docs_get():
+            return
         if self._handle_api("GET"):
             return
 
@@ -5717,6 +5776,13 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
     def _request_path(self) -> str:
         return urlparse(self.path).path or "/"
+
+    def _request_query_params(self) -> Dict[str, List[str]]:
+        return parse_qs(urlparse(self.path).query, keep_blank_values=True)
+
+    def _request_base_url(self) -> str:
+        host = str(self.headers.get("Host") or "127.0.0.1:{0}".format(PORT)).strip() or "127.0.0.1:{0}".format(PORT)
+        return "http://{0}".format(host)
 
     def _is_api_path(self, raw_path: str) -> bool:
         return (urlparse(raw_path).path or "").startswith("/api/")
@@ -5771,8 +5837,32 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
         except BrokenPipeError:
             pass
 
+    def _send_text(self, status: HTTPStatus, body: str, *, content_type: str) -> None:
+        encoded = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        try:
+            self.wfile.write(encoded)
+        except BrokenPipeError:
+            pass
+
     def _send_json_error(self, status: HTTPStatus, message: str) -> None:
         self._send_json(status, {"error": str(message)})
+
+    def _handle_builtin_docs_get(self) -> bool:
+        request_path = self._request_path()
+        if request_path == "/openapi.json":
+            self._send_json(HTTPStatus.OK, build_openapi_document(base_url=self._request_base_url()))
+            return True
+        if request_path == "/docs":
+            self._send_text(HTTPStatus.OK, render_swagger_ui_html("/openapi.json"), content_type="text/html; charset=utf-8")
+            return True
+        if request_path == "/redoc":
+            self._send_text(HTTPStatus.OK, render_redoc_html("/openapi.json"), content_type="text/html; charset=utf-8")
+            return True
+        return False
 
     def _handle_api(self, method: str) -> bool:
         request_path = self._request_path()
@@ -5814,6 +5904,18 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         if len(parts) == 4 and parts[0] == "api" and parts[1] == "chat" and parts[2] == "session":
             self._api_get_chat_session(parts[3])
+            return
+
+        if request_path == "/api/mcp/exposure":
+            self._api_get_mcp_exposure()
+            return
+
+        if request_path == "/api/mcp/tools":
+            self._api_get_mcp_tools()
+            return
+
+        if len(parts) == 4 and parts[0] == "api" and parts[1] == "mcp" and parts[2] == "tools":
+            self._api_get_mcp_tool(parts[3])
             return
 
         if request_path == "/api/jobs":
@@ -5971,6 +6073,10 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             return
 
         parts = self._path_parts(request_path)
+
+        if len(parts) == 4 and parts[0] == "api" and parts[1] == "mcp" and parts[2] == "tools":
+            self._api_post_mcp_tool(parts[3])
+            return
 
         if len(parts) == 3 and parts[0] == "api" and parts[1] == "annotations":
             self._api_post_annotation(parts[2])
@@ -6647,6 +6753,46 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             raise ApiError(HTTPStatus.NOT_FOUND, "Unknown sessionId")
 
         self._send_json(HTTPStatus.OK, _chat_session_public_payload(session))
+
+    def _api_get_mcp_exposure(self) -> None:
+        try:
+            mode = resolve_catalog_mode((self._request_query_params().get("mode") or ["active"])[0])
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
+        catalog = build_mcp_http_catalog(project_root=_project_root(), mode=mode, parse_tools=_get_chat_runtime()[0], workflow_tools=_build_workflow_runtime())
+        self._send_json(HTTPStatus.OK, catalog["exposure"])
+
+    def _api_get_mcp_tools(self) -> None:
+        try:
+            mode = resolve_catalog_mode((self._request_query_params().get("mode") or ["active"])[0])
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
+        catalog = build_mcp_http_catalog(project_root=_project_root(), mode=mode, parse_tools=_get_chat_runtime()[0], workflow_tools=_build_workflow_runtime())
+        self._send_json(HTTPStatus.OK, catalog)
+
+    def _api_get_mcp_tool(self, tool_name: str) -> None:
+        try:
+            mode = resolve_catalog_mode((self._request_query_params().get("mode") or ["active"])[0])
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
+        tool_entry = get_mcp_tool_entry(
+            tool_name,
+            project_root=_project_root(),
+            mode=mode,
+            parse_tools=_get_chat_runtime()[0],
+            workflow_tools=_build_workflow_runtime(),
+        )
+        if tool_entry is None:
+            raise ApiError(HTTPStatus.NOT_FOUND, "Unknown MCP tool: {0}".format(tool_name))
+        self._send_json(HTTPStatus.OK, tool_entry)
+
+    def _api_post_mcp_tool(self, tool_name: str) -> None:
+        try:
+            mode = resolve_catalog_mode((self._request_query_params().get("mode") or ["active"])[0])
+        except ValueError as exc:
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
+        body = self._expect_object(self._read_json_body(required=False) or {}, "Request body")
+        self._send_json(HTTPStatus.OK, _execute_mcp_http_tool(tool_name, body, mode=mode))
 
     def _api_post_chat_session(self) -> None:
         body = self._read_json_body(required=False)

--- a/python/test_external_api_surface.py
+++ b/python/test_external_api_surface.py
@@ -1,0 +1,170 @@
+import json
+import pathlib
+import sys
+import threading
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import server
+from external_api.catalog import build_mcp_http_catalog
+from external_api.openapi import build_openapi_document
+
+
+@contextmanager
+def _serve_parse_http() -> str:
+    httpd = server._BoundedThreadHTTPServer(("127.0.0.1", 0), server.RangeRequestHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield "http://127.0.0.1:{0}".format(httpd.server_port)
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=5)
+        httpd.server_close()
+
+
+def test_build_openapi_document_includes_mcp_bridge_and_auth_paths() -> None:
+    spec = build_openapi_document(base_url="http://127.0.0.1:8766")
+
+    assert spec["openapi"] == "3.1.0"
+    assert spec["info"]["title"] == "PARSE HTTP API"
+    assert spec["servers"] == [{"url": "http://127.0.0.1:8766"}]
+    assert "/api/config" in spec["paths"]
+    assert "/api/auth/status" in spec["paths"]
+    assert "/api/mcp/exposure" in spec["paths"]
+    assert "/api/mcp/tools" in spec["paths"]
+    assert "/api/mcp/tools/{toolName}" in spec["paths"]
+    assert spec["paths"]["/api/mcp/tools/{toolName}"]["post"]["operationId"] == "executeMcpTool"
+
+
+def test_build_openapi_document_covers_the_current_http_route_surface() -> None:
+    spec = build_openapi_document(base_url="http://127.0.0.1:8766")
+    assert set(spec["paths"].keys()) == {
+        "/api/config",
+        "/api/annotations/{speaker}",
+        "/api/stt-segments/{speaker}",
+        "/api/pipeline/state/{speaker}",
+        "/api/chat/session/{sessionId}",
+        "/api/jobs",
+        "/api/jobs/active",
+        "/api/jobs/{jobId}",
+        "/api/jobs/{jobId}/logs",
+        "/api/enrichments",
+        "/api/auth/status",
+        "/api/auth/key",
+        "/api/auth/start",
+        "/api/auth/poll",
+        "/api/auth/logout",
+        "/api/worker/status",
+        "/api/export/lingpy",
+        "/api/export/nexus",
+        "/api/contact-lexemes/coverage",
+        "/api/tags",
+        "/api/spectrogram",
+        "/api/lexeme/search",
+        "/api/onboard/speaker",
+        "/api/onboard/speaker/status",
+        "/api/normalize",
+        "/api/normalize/status",
+        "/api/stt",
+        "/api/stt/status",
+        "/api/suggest",
+        "/api/chat/session",
+        "/api/chat/run",
+        "/api/chat/run/status",
+        "/api/tags/merge",
+        "/api/concepts/import",
+        "/api/tags/import",
+        "/api/lexeme-notes",
+        "/api/lexeme-notes/import",
+        "/api/offset/detect",
+        "/api/offset/detect-from-pair",
+        "/api/offset/apply",
+        "/api/compute/status",
+        "/api/compute/{computeType}",
+        "/api/compute/{computeType}/status",
+        "/api/{computeType}/status",
+        "/api/mcp/exposure",
+        "/api/mcp/tools",
+        "/api/mcp/tools/{toolName}",
+    }
+
+
+def test_build_mcp_http_catalog_includes_workflow_specs_and_safety_metadata(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "config").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "config" / "mcp_config.json").write_text('{"expose_all_tools": false}', encoding="utf-8")
+
+    catalog = build_mcp_http_catalog(project_root=tmp_path, mode="all")
+
+    assert catalog["mode"] == "all"
+    assert catalog["exposure"]["workflowToolCount"] == 3
+    tool_names = {tool["name"] for tool in catalog["tools"]}
+    assert "project_context_read" in tool_names
+    assert "run_full_annotation_pipeline" in tool_names
+
+    workflow_spec = next(tool for tool in catalog["tools"] if tool["name"] == "run_full_annotation_pipeline")
+    assert workflow_spec["family"] == "workflow"
+    assert workflow_spec["parameters"]["type"] == "object"
+    assert workflow_spec["meta"]["x-parse"]["supports_dry_run"] is True
+
+
+def test_http_openapi_and_docs_endpoints_are_served(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    with _serve_parse_http() as base_url:
+        with urllib.request.urlopen(base_url + "/openapi.json", timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            content_type = response.headers.get("Content-Type", "")
+        assert payload["openapi"] == "3.1.0"
+        assert "/api/mcp/tools" in payload["paths"]
+        assert content_type.startswith("application/json")
+
+        with urllib.request.urlopen(base_url + "/docs", timeout=10) as response:
+            swagger_html = response.read().decode("utf-8")
+        assert "SwaggerUIBundle" in swagger_html
+        assert "/openapi.json" in swagger_html
+
+        with urllib.request.urlopen(base_url + "/redoc", timeout=10) as response:
+            redoc_html = response.read().decode("utf-8")
+        assert "Redoc.init" in redoc_html
+        assert "/openapi.json" in redoc_html
+
+
+def test_http_mcp_bridge_lists_and_executes_tools(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    with _serve_parse_http() as base_url:
+        with urllib.request.urlopen(base_url + "/api/mcp/tools?mode=all", timeout=10) as response:
+            catalog = json.loads(response.read().decode("utf-8"))
+        names = {tool["name"] for tool in catalog["tools"]}
+        assert "project_context_read" in names
+        assert "run_full_annotation_pipeline" in names
+
+        request = urllib.request.Request(
+            url=base_url + "/api/mcp/tools/project_context_read?mode=all",
+            data=json.dumps({"include": ["project"]}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["tool"] == "project_context_read"
+        assert payload["ok"] is True
+        assert "result" in payload
+
+
+def test_http_mcp_bridge_rejects_invalid_mode_with_400(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    with _serve_parse_http() as base_url:
+        try:
+            urllib.request.urlopen(base_url + "/api/mcp/tools?mode=bogus", timeout=10)
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 400
+            payload = json.loads(exc.read().decode("utf-8"))
+            assert "mode must be one of" in payload["error"]
+        else:
+            raise AssertionError("Expected HTTP 400 for invalid mode")


### PR DESCRIPTION
## Summary
- serve a full OpenAPI 3.1 document from `python/server.py` at `/openapi.json` plus `/docs` and `/redoc`
- add an HTTP MCP bridge for schema discovery + tool execution (`/api/mcp/exposure`, `/api/mcp/tools`, `/api/mcp/tools/{toolName}`)
- add the publishable `python/packages/parse_mcp/` package with `ParseMcpClient` and official LangChain / LlamaIndex / CrewAI wrappers
- document the external API surface, MCP schema, and local auth model in README/docs
- centralize MCP catalog/exposure helpers in `python/external_api/` so the HTTP bridge and stdio adapter reuse the same metadata source of truth
- rebased onto current `origin/main` after PR #192 landed and re-ran full PARSE validation

## Testing
- `python3 -m pytest python/test_external_api_surface.py python/packages/parse_mcp/tests/test_client.py python/packages/parse_mcp/tests/test_langchain.py python/packages/parse_mcp/tests/test_llamaindex.py python/packages/parse_mcp/tests/test_crewai.py python/packages/parse_mcp/tests/test_package_smoke.py python/adapters/test_mcp_adapter.py python/ai/test_workflow_tools.py python/test_server_workspace_config.py python/test_server_static_paths.py python/test_server_auth_key_refresh.py -q`
- `python3 -m py_compile python/server.py python/adapters/mcp_adapter.py python/external_api/__init__.py python/external_api/catalog.py python/external_api/openapi.py python/packages/parse_mcp/src/parse_mcp/__init__.py python/packages/parse_mcp/src/parse_mcp/models.py python/packages/parse_mcp/src/parse_mcp/_schema.py python/packages/parse_mcp/src/parse_mcp/client.py python/packages/parse_mcp/src/parse_mcp/langchain.py python/packages/parse_mcp/src/parse_mcp/llamaindex.py python/packages/parse_mcp/src/parse_mcp/crewai.py python/test_external_api_surface.py`
- `python3 -m pip wheel --no-deps python/packages/parse_mcp -w /tmp/parse_mcp_dist`
- `npm run test -- --run`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Notes
- existing HTTP and MCP tool behavior is preserved; this PR standardizes schemas, discovery, and packaging around the current surface
- the local PARSE HTTP API remains workstation-local and is not bearer-protected; provider credentials continue to be managed through `/api/auth/*` and local `config/auth_tokens.json`
