### PR TITLE
docs: add external agents getting-started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The MCP adapter currently exposes **32 task tools** drawn from the broader in-ap
 ## 📚 Documentation
 
 - [Getting Started](docs/getting-started.md) — installation, launch paths, requirements, environment variables, `ai_config.json`, GPU notes, and troubleshooting
+- [Getting Started with External Agents](docs/getting-started-external-agents.md) — MCP stdio setup, HTTP automation entry points, environment conventions, and agent-facing examples
 - [User Guide](docs/user-guide.md) — detailed Annotate/Compare workflows, CLEF usage, Lexical Anchor Alignment, and workspace hydration
 - [AI Integration](docs/ai-integration.md) — provider routing, model roles, configuration, external dependencies, the full 47-tool chat surface, and MCP workflow macros
 - [API Reference](docs/api-reference.md) — HTTP endpoints, compute routes, examples, and the full 32-tool MCP task surface

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -411,6 +411,7 @@ A few operational rules remain important:
 
 ## Related docs
 
+- External agent onboarding: [Getting Started with External Agents](./getting-started-external-agents.md)
 - Provider and model overview: [AI Integration](./ai-integration.md)
 - User-facing workflow context: [User Guide](./user-guide.md)
 - Data model and system design: [Architecture](./architecture.md)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -198,6 +198,7 @@ For documentation-only work, you should still at minimum:
 The top-level docs now serve distinct audiences more cleanly:
 
 - `docs/getting-started.md` — install, launch, config, troubleshooting
+- `docs/getting-started-external-agents.md` — agent-facing MCP + HTTP automation guide
 - `docs/user-guide.md` — end-user workflow
 - `docs/ai-integration.md` — providers, models, chat tool surface
 - `docs/api-reference.md` — HTTP + MCP reference

--- a/docs/getting-started-external-agents.md
+++ b/docs/getting-started-external-agents.md
@@ -212,7 +212,30 @@ for job in payload.get("jobs", []):
     )
 ```
 
-This route is useful when you are wrapping PARSE inside your own service and need transport-neutral status data instead of tool-by-tool polling logic.
+### Python example: inspect the stdio adapter directly
+
+For advanced local scripting, you can also instantiate the PARSE MCP server directly inside Python and inspect the registered tool surface without going through a GUI client:
+
+```python
+import asyncio
+import sys
+from pathlib import Path
+
+repo_root = Path("/absolute/path/to/PARSE")
+sys.path.insert(0, str(repo_root / "python"))
+
+from adapters.mcp_adapter import create_mcp_server
+
+server = create_mcp_server(str(repo_root))
+
+a_sync_tools = asyncio.run(server.list_tools())
+print(f"Registered MCP tools: {len(a_sync_tools)}")
+print(sorted(tool.name for tool in a_sync_tools)[:10])
+```
+
+This is useful when you want to validate the active MCP exposure mode or build custom local harnesses around the stdio adapter implementation itself.
+
+These examples are useful when you are wrapping PARSE inside your own service, validating MCP exposure locally, or building custom harnesses around the agent-facing interface.
 
 ## Safety and best practices
 
@@ -223,7 +246,7 @@ This route is useful when you are wrapping PARSE inside your own service and nee
 - **Onboarding/import remains one speaker at a time.** Do not turn speaker onboarding into a bulk-import workflow.
 - **Use coverage-aware checks.** For pipeline decisions, prefer `full_coverage` instead of treating bare `done=true` as sufficient.
 
-## Troubleshooting
+## Common Issues & Solutions
 
 ### The MCP client connects, but tools fail when they try to start or inspect jobs
 
@@ -244,6 +267,15 @@ That is normal. The default MCP surface is curated. If you need the full PARSE t
 ### Can I use an official `parse_mcp` Python package or an HTTP MCP bridge?
 
 Not from the current repository state. The shipped, code-verified external-agent interfaces in this repo are the **stdio MCP adapter** and the **local HTTP API**.
+
+## What’s next
+
+After you are up and running:
+
+- inspect the full MCP surface from your client, or enable `expose_all_tools` if you need the broader PARSE tool set
+- try the workflow macros first: `run_full_annotation_pipeline`, `prepare_compare_mode`, and `export_complete_lingpy_dataset`
+- use `mcp_get_exposure_mode` to confirm which MCP surface the current project is publishing
+- move from this guide into the API and AI docs below when you need full schema and tool-reference detail
 
 ## Further reading
 

--- a/docs/getting-started-external-agents.md
+++ b/docs/getting-started-external-agents.md
@@ -1,0 +1,259 @@
+# Getting Started with External Agents
+
+> Last updated: 2026-04-24
+>
+> This guide covers the external-agent interfaces that are currently shipped in the PARSE repository. The commands and tool counts below were cross-checked against `python/adapters/mcp_adapter.py`, `python/ai/chat_tools.py`, `python/ai/workflow_tools.py`, `python/adapters/test_mcp_adapter.py`, and the launcher/config docs already in this repo.
+
+PARSE can be used programmatically by external agents and automation without opening the browser UI. Today, the recommended path is the built-in **MCP stdio adapter**. For custom scripts and services that do not speak MCP, PARSE also exposes a local **HTTP API**.
+
+## Overview: current external-agent entry points
+
+| Interface | Best for | Transport | Current status |
+|---|---|---|---|
+| **MCP adapter** | Claude, Cursor, Windsurf, Codex, other MCP-capable agents | stdio | Recommended |
+| **HTTP API** | Local scripts, service wrappers, custom orchestration | HTTP (`http://localhost:8766`) | Supported |
+
+If you are deciding where to start, use **MCP first**. It exposes PARSE tools directly, including workflow macros such as `run_full_annotation_pipeline`, `prepare_compare_mode`, and `export_complete_lingpy_dataset`.
+
+## Prerequisites
+
+Before connecting an external agent, make sure the following are in place:
+
+- **Python 3.10+** and the PARSE project dependencies are installed.
+- The PARSE repo is available locally.
+- The **PARSE API server** is running on the expected port when you want job-backed MCP tools to work reliably.
+- If you plan to use the MCP adapter, install the MCP SDK:
+
+```bash
+pip install 'mcp[cli]'
+```
+
+For normal local development, start PARSE with the launcher from the repo root:
+
+```bash
+./scripts/parse-run.sh
+```
+
+That gives you the backend on `http://localhost:8766` and the Vite frontend on `http://localhost:5173`.
+
+## 1. Recommended: use PARSE through the MCP adapter
+
+### Step 1: start the adapter
+
+From the repo root:
+
+```bash
+python python/adapters/mcp_adapter.py
+```
+
+Useful variants:
+
+```bash
+python python/adapters/mcp_adapter.py --project-root /path/to/project
+python python/adapters/mcp_adapter.py --verbose
+```
+
+### Step 2: configure your MCP client
+
+A minimal client config looks like this:
+
+```json
+{
+  "mcpServers": {
+    "parse": {
+      "command": "python",
+      "args": ["/absolute/path/to/parse/python/adapters/mcp_adapter.py"],
+      "env": {
+        "PARSE_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}
+```
+
+### Environment-variable best practices
+
+For real use, it is better to keep the MCP config small and push machine-local paths into PARSE's existing environment conventions.
+
+Recommended variables:
+
+- `PARSE_PROJECT_ROOT` — project root the adapter should operate on
+- `PARSE_EXTERNAL_READ_ROOTS` — extra absolute read roots outside the workspace
+- `PARSE_CHAT_MEMORY_PATH` — optional persistent markdown memory path for PARSE chat tooling
+- `PARSE_API_PORT` — backend port if you are not using `8766`
+
+A fuller example:
+
+```json
+{
+  "mcpServers": {
+    "parse": {
+      "command": "python",
+      "args": ["/absolute/path/to/parse/python/adapters/mcp_adapter.py"],
+      "env": {
+        "PARSE_PROJECT_ROOT": "/absolute/path/to/your/project",
+        "PARSE_EXTERNAL_READ_ROOTS": "/mnt/c/Users/Lucas/Thesis",
+        "PARSE_CHAT_MEMORY_PATH": "/absolute/path/to/parse-memory.md",
+        "PARSE_API_PORT": "8766"
+      }
+    }
+  }
+}
+```
+
+If you do not want to duplicate those values in each MCP client config, PARSE also supports a gitignored repo-local `.parse-env` file. The standalone MCP adapter reads that file automatically and only fills variables that are not already set in the process environment.
+
+Example `.parse-env`:
+
+```bash
+PARSE_EXTERNAL_READ_ROOTS=/mnt/c/Users/Lucas/Thesis
+PARSE_CHAT_MEMORY_PATH=/absolute/path/to/parse-memory.md
+PARSE_API_PORT=8766
+```
+
+### Step 3: understand the exposed tool surface
+
+The adapter supports two exposure modes:
+
+| Mode | What you get |
+|---|---|
+| **Default** | 36 MCP tools total: 32 curated PARSE tools + 3 workflow macros + `mcp_get_exposure_mode` |
+| **Expose all** | 54 MCP tools total: all 50 `ParseChatTools`, all 3 workflow macros, plus `mcp_get_exposure_mode` |
+
+To enable the full surface, create either:
+
+- `config/mcp_config.json` (preferred), or
+- `mcp_config.json` at the project root (legacy fallback)
+
+with:
+
+```json
+{
+  "expose_all_tools": true
+}
+```
+
+### Step 4: give the agent practical tasks
+
+Examples:
+
+- “Run `run_full_annotation_pipeline` for speaker `Fail02` with `dryRun=true` first.”
+- “Prepare compare mode for concepts `1-25` across `Fail01`, `Mand01`, and `Qasr01`.”
+- “List active jobs, then show logs for the stalled job.”
+- “Export the complete LingPy dataset after refreshing contact lexeme references.”
+
+## 2. Use the local HTTP API for custom automation
+
+If your automation stack does not speak MCP, talk directly to the PARSE backend over HTTP.
+
+### Base URL
+
+```text
+http://localhost:8766
+```
+
+### Common endpoint families
+
+| Endpoint family | Purpose |
+|---|---|
+| `GET /api/config` | Read workspace configuration |
+| `GET /api/annotations/{speaker}` | Read one speaker's annotation payload |
+| `GET /api/pipeline/state/{speaker}` | Inspect pipeline coverage and readiness |
+| `POST /api/stt` + `POST /api/stt/status` | Start and poll STT jobs |
+| `POST /api/compute/{computeType}` + status routes | Start and monitor ORTH / IPA / full-pipeline / contact-lexeme jobs |
+| `GET /api/jobs`, `GET /api/jobs/{jobId}`, `GET /api/jobs/{jobId}/logs` | Generic job observability |
+| `GET /api/export/lingpy`, `GET /api/export/nexus` | Download export artifacts |
+
+### Example: read pipeline state
+
+```bash
+curl http://localhost:8766/api/pipeline/state/Fail02
+```
+
+### Example: start STT
+
+```bash
+curl -X POST http://localhost:8766/api/stt \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "speaker": "Fail02",
+    "source_wav": "audio/working/Fail02/Fail02.wav",
+    "language": "ku"
+  }'
+```
+
+### Example: inspect generic job logs
+
+```bash
+curl "http://localhost:8766/api/jobs/stt-abc123/logs?offset=0&limit=50"
+```
+
+### Python example: list jobs with structured metadata
+
+```python
+import requests
+
+base_url = "http://127.0.0.1:8766"
+response = requests.get(
+    f"{base_url}/api/jobs",
+    params={"statuses": "running,queued", "limit": 10},
+    timeout=30,
+)
+response.raise_for_status()
+payload = response.json()
+
+for job in payload.get("jobs", []):
+    print(
+        job.get("jobId"),
+        job.get("type"),
+        job.get("status"),
+        job.get("progress"),
+        job.get("message"),
+    )
+```
+
+This route is useful when you are wrapping PARSE inside your own service and need transport-neutral status data instead of tool-by-tool polling logic.
+
+## Safety and best practices
+
+- **Start with MCP unless you have a strong reason not to.** The tool layer is safer and more discoverable than calling low-level endpoints ad hoc.
+- **Use `dryRun=true` first** for mutating or job-starting tools whenever the schema supports it.
+- **Prefer workflow macros** when they match the task. They encode safer orchestration than hand-chaining several lower-level tool calls.
+- **Respect PARSE preconditions and metadata.** MCP tools expose machine-readable `meta["x-parse"]` safety metadata, including mutability, dry-run support, preconditions, and postconditions.
+- **Onboarding/import remains one speaker at a time.** Do not turn speaker onboarding into a bulk-import workflow.
+- **Use coverage-aware checks.** For pipeline decisions, prefer `full_coverage` instead of treating bare `done=true` as sufficient.
+
+## Troubleshooting
+
+### The MCP client connects, but tools fail when they try to start or inspect jobs
+
+Make sure the PARSE backend is running on the expected API port. The adapter proxies job-backed operations through the local HTTP server, which defaults to `http://127.0.0.1:8766` unless you override `PARSE_API_PORT` or `PARSE_PORT`.
+
+### The adapter cannot see files outside the project root
+
+Set `PARSE_EXTERNAL_READ_ROOTS` to one or more absolute paths. Without that, the adapter stays inside the stricter workspace sandbox. For persistent local setup, put the value in `.parse-env`.
+
+### My MCP client config is getting cluttered with path-specific environment variables
+
+Keep only the essentials in the client config and move the rest into repo-local `.parse-env`. The adapter already knows how to load it.
+
+### I expected more tools than I see by default
+
+That is normal. The default MCP surface is curated. If you need the full PARSE tool surface, set `{"expose_all_tools": true}` in `config/mcp_config.json`.
+
+### Can I use an official `parse_mcp` Python package or an HTTP MCP bridge?
+
+Not from the current repository state. The shipped, code-verified external-agent interfaces in this repo are the **stdio MCP adapter** and the **local HTTP API**.
+
+## Further reading
+
+- [API Reference](./api-reference.md)
+- [AI Integration](./ai-integration.md)
+- [Getting Started](./getting-started.md)
+- [Developer Guide](./developer-guide.md)
+- MCP adapter source: `python/adapters/mcp_adapter.py`
+- Workflow macros: `python/ai/workflow_tools.py`
+- Tool metadata source of truth: `python/ai/chat_tools.py`
+
+> [!NOTE]
+> If this guide saves you time, star the repo and join the PARSE discussion around external-agent workflows, MCP ergonomics, and field-ready automation.


### PR DESCRIPTION
## Summary
- add a new `docs/getting-started-external-agents.md` guide for PARSE external-agent usage
- keep the content code-verified against the shipped MCP adapter, workflow tools, and HTTP API rather than the unshipped HTTP MCP bridge / `parse_mcp` package draft
- link the new guide from `docs/api-reference.md` and `docs/developer-guide.md`

## What changed
- documented the current external-agent entry points: MCP stdio adapter + local HTTP API
- added prerequisites, MCP config guidance, `.parse-env` best practices, tool-exposure modes, HTTP examples, safety guidance, and troubleshooting
- explicitly documented the current shipped counts:
  - 50 `ParseChatTools`
  - 32 curated default MCP tool names
  - 3 workflow macros
  - 36 total default MCP tools including `mcp_get_exposure_mode`
  - 54 total MCP tools when `expose_all_tools=true`

## Verification
- `python -m pytest python/adapters/test_mcp_adapter.py -q`
- cross-checked doc claims against:
  - `python/adapters/mcp_adapter.py`
  - `python/ai/chat_tools.py`
  - `python/ai/workflow_tools.py`
  - `python/server.py`
  - existing docs/config conventions in `docs/getting-started.md` and `docs/api-reference.md`

## Notes
- The source draft referenced an HTTP MCP bridge and `parse_mcp` Python package, but those are not present in the current repository state, so the new guide documents only what PARSE actually ships today.
