### PR TITLE
fix: harden parse-mcp PyPI release metadata

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -300,7 +300,11 @@ When adding or renaming MCP-visible tools, update all three layers together:
 
 ### Publishing `parse-mcp` to PyPI
 
-When the package metadata or release contents change, validate and publish from the repo root:
+When the package metadata or release contents change, validate and publish from the repo root.
+
+1. Validate locally and build the release artifacts.
+2. Test on TestPyPI first so you can confirm installability before the real release.
+3. Publish the same version to PyPI only after the TestPyPI smoke check looks correct.
 
 ```bash
 python3 -m pip install build twine
@@ -308,6 +312,7 @@ python3 -m pytest python/packages/parse_mcp/tests -q
 python3 -m build python/packages/parse_mcp
 python3 -m twine check python/packages/parse_mcp/dist/*
 python3 -m twine upload --repository testpypi python/packages/parse_mcp/dist/*
+python3 -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ parse-mcp
 python3 -m twine upload python/packages/parse_mcp/dist/*
 ```
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -298,6 +298,25 @@ When adding or renaming MCP-visible tools, update all three layers together:
 - HTTP MCP bridge
 - `parse-mcp` package docs/tests
 
+### Publishing `parse-mcp` to PyPI
+
+When the package metadata or release contents change, validate and publish from the repo root:
+
+```bash
+python3 -m pip install build twine
+python3 -m pytest python/packages/parse_mcp/tests -q
+python3 -m build python/packages/parse_mcp
+python3 -m twine check python/packages/parse_mcp/dist/*
+python3 -m twine upload --repository testpypi python/packages/parse_mcp/dist/*
+python3 -m twine upload python/packages/parse_mcp/dist/*
+```
+
+Release notes:
+- preferred public package name: `parse-mcp`
+- current metadata lives in `python/packages/parse_mcp/pyproject.toml`
+- the repo owner should remain the primary PyPI maintainer
+- publish to TestPyPI first when releasing a version for the first time or after metadata changes
+
 ## How to add or extend a CLEF provider
 
 CLEF providers live under `python/compare/providers/`.

--- a/python/packages/parse_mcp/pyproject.toml
+++ b/python/packages/parse_mcp/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "0.1.0"
 description = "Official PARSE MCP HTTP bridge client and agent-framework wrappers"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
   {name = "Lucas Ardelean"}
 ]
@@ -17,12 +18,21 @@ dependencies = [
 ]
 keywords = ["mcp", "linguistics", "fieldwork", "phonetics", "langchain", "llamaindex", "crewai"]
 classifiers = [
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: Libraries",
 ]
+
+[project.urls]
+Homepage = "https://github.com/ArdeleanLucas/PARSE"
+Repository = "https://github.com/ArdeleanLucas/PARSE"
+Issues = "https://github.com/ArdeleanLucas/PARSE/issues"
+Documentation = "https://github.com/ArdeleanLucas/PARSE/tree/main/docs"
 
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.2"]

--- a/python/packages/parse_mcp/pyproject.toml
+++ b/python/packages/parse_mcp/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 dependencies = [
   "pydantic>=2.7,<3",
 ]
-keywords = ["mcp", "linguistics", "fieldwork", "phonetics", "langchain", "llamaindex", "crewai"]
+keywords = ["mcp", "linguistics", "fieldwork", "phonetics", "langchain", "llama-index", "llamaindex", "crewai"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",

--- a/python/packages/parse_mcp/tests/test_packaging_metadata.py
+++ b/python/packages/parse_mcp/tests/test_packaging_metadata.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pathlib
+import tomllib
+
+
+PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = PACKAGE_ROOT / "pyproject.toml"
+
+
+def load_pyproject() -> dict:
+    with PYPROJECT_PATH.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_release_metadata_is_pypi_ready() -> None:
+    payload = load_pyproject()
+    build_system = payload["build-system"]
+    project = payload["project"]
+
+    assert any(requirement.startswith("setuptools>=77") for requirement in build_system["requires"])
+    assert project["name"] == "parse-mcp"
+    assert project["readme"] == "README.md"
+    assert project["requires-python"] == ">=3.10"
+    assert project["license"] == "MIT"
+    assert project["license-files"] == ["LICENSE"]
+    assert project["urls"] == {
+        "Homepage": "https://github.com/ArdeleanLucas/PARSE",
+        "Repository": "https://github.com/ArdeleanLucas/PARSE",
+        "Issues": "https://github.com/ArdeleanLucas/PARSE/issues",
+        "Documentation": "https://github.com/ArdeleanLucas/PARSE/tree/main/docs",
+    }
+
+
+def test_core_dependencies_stay_minimal() -> None:
+    project = load_pyproject()["project"]
+    dependencies = set(project["dependencies"])
+
+    assert dependencies == {"pydantic>=2.7,<3"}
+    assert "langchain-core>=0.2" not in dependencies
+    assert "llama-index-core>=0.10" not in dependencies
+    assert "crewai>=0.30" not in dependencies

--- a/python/packages/parse_mcp/tests/test_packaging_metadata.py
+++ b/python/packages/parse_mcp/tests/test_packaging_metadata.py
@@ -6,6 +6,7 @@ import tomllib
 
 PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1]
 PYPROJECT_PATH = PACKAGE_ROOT / "pyproject.toml"
+DEVELOPER_GUIDE_PATH = PACKAGE_ROOT.parents[2] / "docs" / "developer-guide.md"
 
 
 def load_pyproject() -> dict:
@@ -30,6 +31,26 @@ def test_release_metadata_is_pypi_ready() -> None:
         "Issues": "https://github.com/ArdeleanLucas/PARSE/issues",
         "Documentation": "https://github.com/ArdeleanLucas/PARSE/tree/main/docs",
     }
+
+
+def test_package_metadata_supports_pypi_discoverability() -> None:
+    project = load_pyproject()["project"]
+    classifiers = set(project["classifiers"])
+    keywords = set(project["keywords"])
+
+    assert {
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+    }.issubset(classifiers)
+    assert {"mcp", "langchain", "llama-index", "crewai", "linguistics"}.issubset(keywords)
+
+
+def test_release_docs_require_testpypi_first() -> None:
+    guide = DEVELOPER_GUIDE_PATH.read_text(encoding="utf-8")
+
+    assert "Test on TestPyPI first" in guide
+    assert "twine upload --repository testpypi" in guide
 
 
 def test_core_dependencies_stay_minimal() -> None:


### PR DESCRIPTION
## Summary
- harden `parse-mcp` package metadata for PyPI by switching to SPDX-style MIT licensing, explicit license files, project URLs, and discoverability-friendly keywords
- keep explicit Python 3.10/3.11/3.12 classifiers covered by regression tests so future metadata edits do not silently regress them
- document a safer release flow in the developer guide: validate locally, test on TestPyPI first, smoke-install from TestPyPI, then publish to PyPI

## Validation
- `python3 -m pytest python/packages/parse_mcp/tests/test_packaging_metadata.py -q` (RED: 2 failed, 2 passed before the polish)
- `python3 -m pytest python/packages/parse_mcp/tests/test_packaging_metadata.py -q` (GREEN: 4 passed)
- `python3 -m pytest python/packages/parse_mcp/tests -q`
- `python3 -m build python/packages/parse_mcp`
- `python3 -m twine check python/packages/parse_mcp/dist/*`
- `python3 -m pytest python/test_external_api_surface.py python/packages/parse_mcp/tests/test_client.py python/packages/parse_mcp/tests/test_langchain.py python/packages/parse_mcp/tests/test_llamaindex.py python/packages/parse_mcp/tests/test_crewai.py python/packages/parse_mcp/tests/test_package_smoke.py python/packages/parse_mcp/tests/test_packaging_metadata.py python/adapters/test_mcp_adapter.py python/ai/test_workflow_tools.py python/test_server_workspace_config.py python/test_server_static_paths.py python/test_server_auth_key_refresh.py -q`
- `npm run test -- --run`
- `./node_modules/.bin/tsc --noEmit`

## PyPI status
- `parse-mcp` currently returns 404 on `https://pypi.org/pypi/parse-mcp/json`, so the name still appears available
- wheel/sdist metadata passes `twine check`, includes SPDX MIT licensing, and now carries the requested discoverability coverage in tests
- actual upload is still pending PyPI credentials / maintainer action
