### PR TITLE
docs: refresh README and top-level docs after PR audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Annotate per-speaker recordings with tiered IPA/orthography, then compare across
 
 - **Dual-mode unified React shell** for annotation and comparison in one workspace
 - **Fieldwork-first design** for long recordings, uneven metadata, and iterative review
-- **AI-native workflow surface** with a built-in chat assistant powered by **47 PARSE-specific tools**
-- **Full MCP server mode** exposing a curated **32-tool task surface** for external agents and automation, plus `mcp_get_exposure_mode`
+- **AI-native workflow surface** with a built-in chat assistant powered by **50 PARSE-specific tools**
+- **Full MCP server mode** exposing a curated **32-tool task surface** by default (**36** adapter tools including workflow macros + `mcp_get_exposure_mode`)
 - **CLEF — Contact Lexeme Explorer Feature** for borrowing adjudication via a 10-provider contact-language lookup stack
 - **Lexical Anchor Alignment System** for locating repeated lexical items across long recordings and across speakers
 - **Export pipeline** for LingPy TSV and NEXUS outputs used in downstream comparative workflows
@@ -54,7 +54,7 @@ It combines:
 - **Tier 2 forced alignment** with wav2vec2 for tighter word-level boundaries
 - **Draggable timestamp correction** and clip-bounded playback for manual review
 - **Batch transcription** with preflight checks and rerun-failed support
-- **Timestamp-offset detection/apply workflows** for constant CSV↔audio misalignment
+- **Timestamp-offset detection/apply workflows** for constant CSV↔audio misalignment, now with async progress, crash-log surfacing, and protection for manually adjusted / anchored lexemes
 - **Search & anchor lexeme** tooling built on the Lexical Anchor Alignment System
 - **Shared tags** and the in-session **AI chat dock**
 
@@ -96,11 +96,19 @@ PARSE exposes three machine-facing integration surfaces:
 That means external agent clients such as Claude Code, Cursor, Cline, Hermes, Windsurf, Codex, or other MCP-capable tools can call a curated subset of PARSE functions programmatically, without going through the browser UI.
 
 Current counts:
-- **47** built-in `ParseChatTools`
+- **50** built-in `ParseChatTools`
 - **3** workflow macros in `python/ai/workflow_tools.py`
 - **32** default MCP task tools
-- **33** total default MCP adapter tools including read-only `mcp_get_exposure_mode`
-- **51** total MCP adapter tools with `config/mcp_config.json` → `{ "expose_all_tools": true }`
+- **36** total default MCP adapter tools including read-only `mcp_get_exposure_mode`
+- **54** total MCP adapter tools with `config/mcp_config.json` → `{ "expose_all_tools": true }`
+
+#### Generic job observability
+
+- `GET /api/jobs` — list recent jobs with status / progress / type filters
+- `GET /api/jobs/{jobId}` — read one generic job snapshot, including `errorCode`, `logCount`, and lock metadata
+- `GET /api/jobs/{jobId}/logs` — read structured per-job logs (and crash-log tails when present)
+
+These endpoints back the in-app progress UI, the MCP observability tools, and callback-driven external automation.
 
 #### OpenAPI and interactive docs
 
@@ -143,10 +151,10 @@ It provides:
 ## 📚 Documentation
 
 - [Getting Started](docs/getting-started.md) — installation, launch paths, requirements, environment variables, `ai_config.json`, GPU notes, and troubleshooting
-- [Getting Started with External Agents](docs/getting-started-external-agents.md) — MCP stdio setup, HTTP automation entry points, environment conventions, and agent-facing examples
+- [Getting Started with External Agents](docs/getting-started-external-agents.md) — MCP stdio setup, HTTP MCP bridge / `parse-mcp` entry points, environment conventions, and agent-facing examples
 - [User Guide](docs/user-guide.md) — detailed Annotate/Compare workflows, CLEF usage, Lexical Anchor Alignment, and workspace hydration
-- [AI Integration](docs/ai-integration.md) — provider routing, model roles, configuration, external dependencies, the full 47-tool chat surface, and MCP workflow macros
-- [API Reference](docs/api-reference.md) — HTTP endpoints, OpenAPI docs, MCP bridge routes, examples, and the full 32-tool MCP task surface
+- [AI Integration](docs/ai-integration.md) — provider routing, model roles, configuration, external dependencies, the full 50-tool chat surface, and MCP workflow macros
+- [API Reference](docs/api-reference.md) — HTTP endpoints, generic job observability, OpenAPI docs, MCP bridge routes, examples, and the full 32-tool MCP task surface
 - [MCP Schema](docs/mcp-schema.md) — MCP schema shape, HTTP bridge endpoints, exposure modes, and authentication model
 - [Architecture](docs/architecture.md) — unified shell, backend/data design, OpenAPI/MCP standardization points, and CLEF provider registry
 - [Developer Guide](docs/developer-guide.md) — project structure, tech stack, local development flow, and extension points for chat tools, MCP tools, and endpoints

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ It combines:
 
 - **WaveSurfer 7** waveform review for long recordings
 - **Four annotation tiers**: IPA, orthography, concept, and speaker
-- **Stacked transcription lanes** for STT, IPA, and ORTH with synchronized horizontal scrolling
+- **Stacked transcription lanes** for STT, IPA, and ORTH with synchronized horizontal scrolling and inline edit / split / merge / delete controls
 - **Audio normalization**, **speaker-level STT**, **ORTH transcription**, and **acoustic IPA fill** jobs
 - **Tier 2 forced alignment** with wav2vec2 for tighter word-level boundaries
+- **Per-speaker undo/redo** for annotation edits, including merge recovery and STT-tier migration
 - **Draggable timestamp correction** and clip-bounded playback for manual review
 - **Batch transcription** with preflight checks and rerun-failed support
 - **Timestamp-offset detection/apply workflows** for constant CSV↔audio misalignment, now with async progress, crash-log surfacing, and protection for manually adjusted / anchored lexemes

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -217,11 +217,11 @@ The current README describes it as a **domain-specific assistant**, not a genera
 - export and downstream-pipeline assistance
 - troubleshooting across the PARSE workflow
 
-## Full built-in chat tool surface (47 tools)
+## Full built-in chat tool surface (50 tools)
 
-The in-app assistant currently exposes **47 PARSE-specific tools**.
+The in-app assistant currently exposes **50 PARSE-specific tools**.
 
-### Read-only / preview tools (16)
+### Read-only / preview tools (15)
 
 | Tool | Description |
 |---|---|
@@ -240,7 +240,15 @@ The in-app assistant currently exposes **47 PARSE-specific tools**.
 | `enrichments_read` | Read computed enrichments with optional top-level filtering |
 | `lexeme_notes_read` | Read stored lexeme notes with optional speaker/concept filtering |
 | `phonetic_rules_apply` | Apply or inspect phonetic-rule normalization / equivalence logic |
-| `jobs_list_active` | List active background jobs so agents can recover state after restarts |
+
+### Job observability tools (4)
+
+| Tool | Description |
+|---|---|
+| `jobs_list_active` | List active backend jobs so the in-app assistant can recover progress after reloads |
+| `jobs_list` | List active or recent jobs with status / type / speaker filters |
+| `job_status` | Read one generic job snapshot, including `errorCode`, progress, lock metadata, and log counts |
+| `job_logs` | Read structured per-job logs and surfaced crash-log tails |
 
 ### Job-triggering tools (12)
 
@@ -312,12 +320,12 @@ Multi-source speakers may still require manual or virtual-timeline coordination 
 
 ## MCP subset versus in-app tool surface
 
-Not every in-app chat tool is exported over MCP, and MCP also exposes 3 workflow-only macros that live outside the built-in 47-tool chat surface.
+Not every in-app chat tool is exported over MCP, and MCP also exposes 3 workflow-only macros plus read-only `mcp_get_exposure_mode` outside the built-in 50-tool chat surface.
 
-- **Built-in chat tools**: 47
+- **Built-in chat tools**: 50
 - **Default MCP task tools**: 32
-- **Default MCP adapter surface including `mcp_get_exposure_mode`**: 33
-- **Full MCP adapter surface with `expose_all_tools=true`**: 51
+- **Default MCP adapter surface including workflow macros + `mcp_get_exposure_mode`**: 36
+- **Full MCP adapter surface with `expose_all_tools=true`**: 54
 
 Task 5 adds an HTTP MCP bridge on top of that same schema surface:
 - `GET /api/mcp/exposure`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -28,6 +28,8 @@ A few patterns recur across the API:
 
 - job-start endpoints usually return `{ "jobId": "...", "status": "running" }`
 - status endpoints typically accept either `jobId` or `job_id`
+- generic job snapshots expose shared fields such as `type`, `status`, `progress`, `message`, `errorCode`, `logCount`, and `locks`
+- heavy-job starters can optionally attach a `callbackUrl` so external automation can receive the final generic job payload on completion or error
 - binary export/image endpoints return files rather than JSON
 - compute endpoints normalize job handling across multiple background workflows
 - `/api/config` carries a schema-versioned payload; if the config contract changes incompatibly, update the corresponding version constants in both `python/server.py` and `src/api/client.ts`
@@ -43,7 +45,10 @@ A few patterns recur across the API:
 | `GET /api/stt-segments/{speaker}` | Read cached STT segments for a speaker | Returns `segments: []` when cache is missing rather than 404 |
 | `GET /api/enrichments` | Read comparative enrichments | Returns `{ enrichments: ... }` |
 | `GET /api/tags` | Read tag definitions and assignments | Shared across Annotate and Compare |
+| `GET /api/jobs` | List recent backend jobs | Supports status / type / speaker filters and returns generic job snapshots |
 | `GET /api/jobs/active` | List active backend jobs | Used to rehydrate progress after reload |
+| `GET /api/jobs/{jobId}` | Read one backend job | Includes generic status, progress, `errorCode`, `logCount`, and lock metadata |
+| `GET /api/jobs/{jobId}/logs` | Read structured logs for one backend job | Returns per-entry timestamps, levels, events, and crash-log tails when present |
 | `GET /api/pipeline/state/{speaker}` | Read coverage-aware pipeline state | Includes `full_coverage` metadata per step |
 | `GET /api/chat/session/{sessionId}` | Read one chat session | Returns message history and token metadata |
 
@@ -111,9 +116,9 @@ A few patterns recur across the API:
 | `POST /api/enrichments` | Save enrichments | Accepts either `{ enrichments: ... }` or the raw object |
 | `POST /api/config` | Update project configuration | Current server accepts POST as an update path |
 | `POST /api/tags/merge` | Merge tag definitions | Shared tag persistence |
-| `POST /api/offset/detect` | Detect a constant timestamp offset | Supports STT-based alignment checks |
-| `POST /api/offset/detect-from-pair` | Detect a timestamp offset from trusted manual pairs | STT-free correction path |
-| `POST /api/offset/apply` | Apply a constant timestamp shift | Mutates the speaker annotation file |
+| `POST /api/offset/detect` | Detect a constant timestamp offset | Starts an async compute job with progress updates and crash-log capture |
+| `POST /api/offset/detect-from-pair` | Detect a timestamp offset from trusted manual pairs | STT-free async correction path |
+| `POST /api/offset/apply` | Apply a constant timestamp shift | Mutates the speaker annotation file while preserving manually adjusted / anchored lexemes |
 
 ## PUT endpoints
 
@@ -390,7 +395,7 @@ pip install 'mcp[cli]'
 
 If no explicit environment block is passed, the adapter also reads repo-local overrides from `.parse-env`.
 
-## Full MCP task surface (32 task tools + `mcp_get_exposure_mode`)
+## Full MCP task surface (32 task tools + 3 workflow macros; 36 default adapter tools including `mcp_get_exposure_mode`)
 
 ### Inspection / preview / preflight
 
@@ -422,6 +427,14 @@ If no explicit environment block is passed, the adapter also reads repo-local ov
 | `pipeline_run` | Start a one-speaker full pipeline or step-subset run |
 | `compute_status` | Poll any compute job |
 
+### Job observability
+
+| Tool | Description |
+|---|---|
+| `jobs_list` | List active or recent jobs with optional status / type / speaker filters |
+| `job_status` | Read one generic job snapshot, including `errorCode`, progress, `logCount`, and lock metadata |
+| `job_logs` | Read structured per-job logs and surfaced crash-log tails |
+
 ### Alignment / correction
 
 | Tool | Description |
@@ -448,6 +461,8 @@ If no explicit environment block is passed, the adapter also reads repo-local ov
 | `run_full_annotation_pipeline` | Run STT → forced alignment → acoustic IPA for one speaker in one call |
 | `prepare_compare_mode` | Resolve a concept slice across speakers and return a compare-ready preview bundle |
 | `export_complete_lingpy_dataset` | Export LingPy TSV + NEXUS, optionally refreshing contact lexeme references first |
+
+`jobs_list_active` remains an in-app assistant helper, but the MCP/default external surface now uses the generic `jobs_list` / `job_status` / `job_logs` trio so agents can inspect both active and recent work consistently.
 
 ## `parse-mcp` Python package
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,11 +14,11 @@ flowchart LR
     Client --> Server[python/server.py\nHTTP API + built frontend serving]
     Server --> Annotations[annotations/<Speaker>.json\nper-speaker annotation records]
     Server --> Enrichments[parse-enrichments.json\ncomparative overlays + notes]
-    Server --> ChatTools[python/ai/chat_tools.py\n47 PARSE-specific tools]
+    Server --> ChatTools[python/ai/chat_tools.py\n50 PARSE-specific tools]
     Server --> Compare[python/compare/*\ncognates + CLEF providers]
     Server --> Models[local & remote AI providers\nfaster-whisper / wav2vec2 / OpenAI / xAI]
     Server --> External[OpenAPI 3.1 + HTTP MCP bridge\n/openapi.json + /api/mcp/*]
-    ChatTools --> MCP[python/adapters/mcp_adapter.py\n32-task MCP surface + workflow macros]
+    ChatTools --> MCP[python/adapters/mcp_adapter.py\n32-task MCP surface + 3 workflow macros]
     External --> PyPkg[python/packages/parse_mcp\nLangChain / LlamaIndex / CrewAI wrappers]
     Compare --> Exports[LingPy TSV + NEXUS]
 ```
@@ -289,9 +289,9 @@ The in-app assistant works through `python/ai/chat_tools.py`.
 
 Current counts:
 
-- **47** built-in PARSE chat tools
+- **50** built-in PARSE chat tools
 - **32** MCP task tools via `python/adapters/mcp_adapter.py`
-- **33** total default MCP adapter tools including `mcp_get_exposure_mode`
+- **36** total default MCP adapter tools including workflow macros + `mcp_get_exposure_mode`
 
 This separation matters architecturally:
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -38,7 +38,7 @@ python/
   adapters/
     mcp_adapter.py      -- MCP adapter
   ai/
-    chat_tools.py       -- ParseChatTools (47 tools)
+    chat_tools.py       -- ParseChatTools (50 tools)
     chat_orchestrator.py
     stt_pipeline.py
     forced_align.py
@@ -259,7 +259,7 @@ A new tool should follow this pattern:
    - alignment / correction
    - tag-related
    - write / export / merge
-4. Update `docs/ai-integration.md` to keep the 47-tool list current
+4. Update `docs/ai-integration.md` to keep the 50-tool list current
 5. If the tool should also be exposed externally, add it to the MCP adapter and update `docs/api-reference.md`
 
 ### Why this matters

--- a/docs/getting-started-external-agents.md
+++ b/docs/getting-started-external-agents.md
@@ -266,7 +266,12 @@ That is normal. The default MCP surface is curated. If you need the full PARSE t
 
 ### Can I use an official `parse_mcp` Python package or an HTTP MCP bridge?
 
-Not from the current repository state. The shipped, code-verified external-agent interfaces in this repo are the **stdio MCP adapter** and the **local HTTP API**.
+Yes. Current `main` ships both:
+
+- the **HTTP MCP bridge** on the local PARSE server (`/api/mcp/exposure`, `/api/mcp/tools`, `/api/mcp/tools/{toolName}`)
+- the official **`parse-mcp`** Python package scaffold under `python/packages/parse_mcp/`
+
+For most local agent setups, the **stdio MCP adapter** is still the simplest place to start. Use the HTTP bridge or `parse-mcp` when you need schema discovery / execution over HTTP or wrapper integration with LangChain, LlamaIndex, or CrewAI.
 
 ## What’s next
 

--- a/docs/mcp_agent_roadmap.md
+++ b/docs/mcp_agent_roadmap.md
@@ -4,23 +4,23 @@ Future improvements to make PARSE a first-class citizen in agent-driven workflow
 
 ---
 
-## 1. Expose all 47 ParseChatTools via MCP
+## 1. Expose all 50 ParseChatTools via MCP
 
 **Status:** ✅ Complete
 
 **Shipped:**
-- `python/adapters/mcp_adapter.py` still exposes the legacy **29 `ParseChatTools`** surface by default.
-- Task 3 adds 3 workflow macros on top of that base, so the current default adapter surface is **33 tools total** including `mcp_get_exposure_mode`.
-- Opt-in config at `config/mcp_config.json` (or fallback root `mcp_config.json`) enables the full **47-tool** `ParseChatTools` surface; with the 3 workflow macros and `mcp_get_exposure_mode`, the current full adapter surface is **51 tools total**:
+- `python/adapters/mcp_adapter.py` exposes a curated **32-tool default task surface** by default.
+- Task 3 adds 3 workflow macros on top of that base, so the current default adapter surface is **36 tools total** including `mcp_get_exposure_mode`.
+- Opt-in config at `config/mcp_config.json` (or fallback root `mcp_config.json`) enables the full **50-tool** `ParseChatTools` surface; with the 3 workflow macros and `mcp_get_exposure_mode`, the current full adapter surface is **54 tools total**:
 
 ```json
 { "expose_all_tools": true }
 ```
 
 **Notes:**
-- Default behavior is unchanged for existing callers that rely on the legacy 29 PARSE tool wrappers.
+- Default behavior remains curated for external agents rather than mirroring the entire in-app chat surface.
 - The internal chat dock still uses `ParseChatTools` directly; this task only changes MCP exposure.
-- Newly exposed tools include the missing write/export/pipeline helpers such as normalize, enrichments, lexeme notes, exports, peaks, source-index validation, and transcript reformatting.
+- Newly exposed tools now also include the generic job observability trio (`jobs_list`, `job_status`, `job_logs`) alongside the earlier write/export/pipeline helpers.
 - `mcp_get_exposure_mode` lets external agents self-inspect whether the active MCP server is running in the default or full-exposure mode.
 
 ---
@@ -57,11 +57,22 @@ Macros are easier to discover, easier to prompt, and safer to execute.
 
 ## 4. Observability & control layer
 
-Critical for long-running agent jobs:
+**Status:** ✅ Complete
 
-- Expose job queue status, progress percentage, and live logs via MCP/HTTP.
-- Add webhook / callback URL support so agents are notified when heavy jobs finish (e.g., batch STT on a 2-hour recording).
-- Resource locking so a human and an agent can't mutate the same speaker concurrently.
+**Shipped:**
+- Generic HTTP observability endpoints:
+  - `GET /api/jobs`
+  - `GET /api/jobs/{jobId}`
+  - `GET /api/jobs/{jobId}/logs`
+- Matching MCP tools:
+  - `jobs_list`
+  - `job_status`
+  - `job_logs`
+- Shared job payloads now include structured progress, `errorCode`, `logCount`, and lock metadata.
+- Heavy job starters can carry a `callbackUrl`, so external automation can receive the final generic job payload on `complete` / `error`.
+- Speaker-scoped lock metadata prevents humans and agents from mutating the same resources silently in parallel.
+
+These changes make long-running PARSE jobs inspectable across the UI, HTTP automation, and MCP clients with one consistent status shape.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -45,9 +45,11 @@ The current Annotate surface includes:
   - STT
   - IPA
   - ORTH
+- **Inline lane editing** across STT, IPA, and ORTH via double-click or right-click context actions
 - **Synchronized horizontal scrolling** between waveform and lanes
 - **Clip-bounded playback** for the selected region
 - A global **Space** play/pause hotkey
+- **Per-speaker undo/redo** controls in the Annotate playback bar, with `Ctrl/Cmd+Z`, `Ctrl/Cmd+Shift+Z`, and `Ctrl/Cmd+Y`
 - Concept display and sorting controls
 - Tag/filter controls for selective review
 - The shared **AI chat dock**
@@ -74,6 +76,7 @@ The speaker-level STT job (`/api/stt`) provides:
 - automatic language detection from project metadata when available
 - tunable task / VAD / beam-size settings through config
 - nested word-level timestamps in `segments[].words[]`
+- an editable STT lane in Annotate mode: the first manual STT edit lazily migrates cached STT segments into `record.tiers.stt`, after which STT supports the same inline edit / split / merge / delete affordances as IPA and ORTH
 
 This is the main starting point for locating lexical material in long recordings.
 
@@ -126,6 +129,8 @@ Automation in PARSE is intentionally review-first.
 
 Annotate mode supports:
 
+- inline lane editing on STT / IPA / ORTH with context-menu split, merge-with-next, and delete actions
+- per-speaker undo/redo with merge recovery and operation-labelled toasts
 - draggable lexeme timestamp editing
 - manual boundary correction
 - constant timestamp-offset detect/apply workflows for CSV↔audio misalignment


### PR DESCRIPTION
## Summary
- audit merged PRs #187-#199 since the last major README/docs refresh and update the top-level docs from current code rather than PR titles alone
- refresh README + focused docs for the current PARSE tool surface (50 in-app chat tools, 32 default MCP task tools, 36 default adapter tools, 54 full adapter tools)
- document the shipped generic job observability surface (`/api/jobs*`, `jobs_list`, `job_status`, `job_logs`), async offset workflow behavior, current HTTP MCP bridge / `parse-mcp` package status, and the new Annotate editing affordances from PR #199

## PRs audited
- #187 Search & anchor lexeme UI move
- #188 richer MCP safety metadata for dangerous mutators
- #189 MCP safety metadata rollout
- #190 async offset-detect jobs
- #191 MCP workflow macros
- #192 job observability endpoints
- #193 offset status/crash-log follow-up
- #194 external API standardization
- #195 external agents getting-started guide
- #196 parse-mcp packaging metadata hardening
- #197 protect manually-adjusted lexemes from global offset
- #198 drop stale Concept|Word toggle + Region/Snap readout
- #199 STT inline editing + undo/redo with merge recovery

## Files updated
- `README.md`
- `docs/ai-integration.md`
- `docs/api-reference.md`
- `docs/architecture.md`
- `docs/developer-guide.md`
- `docs/getting-started-external-agents.md`
- `docs/mcp_agent_roadmap.md`
- `docs/user-guide.md`

## Verification
- `git diff --check`
- code-grounded count check via `ParseChatTools`, `DEFAULT_MCP_TOOL_NAMES`, and `DEFAULT_MCP_WORKFLOW_TOOL_NAMES` (`50 / 32 / 3 / 36 / 54`)
- spot-check current routes/package presence for `/api/jobs*`, HTTP MCP bridge endpoints, and `python/packages/parse_mcp/`
- code inspection for current Annotate affordances in `src/ParseUI.tsx`, `src/components/annotate/TranscriptionLanes.tsx`, `src/components/annotate/AnnotateMode.tsx`, and `src/stores/annotationStore.ts`
