### PR TITLE
feat: add websocket job streaming for STT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — PARSE React + Vite Integration (2026)
 
-## Current State (updated 2026-04-21)
+## Current State (updated 2026-04-24)
 
 PARSE has crossed the React pivot and the unified UI redesign is **merged to `main`**.
 
@@ -22,6 +22,12 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
   - Server endpoints:
     - `POST /api/compute/contact-lexemes`
     - `GET /api/contact-lexemes/coverage`
+- **Streaming responses shipped**:
+  - Additive WebSocket sidecar in `python/external_api/streaming.py`
+  - Dedicated port via `PARSE_WS_PORT` (default `8767`)
+  - Per-job subscription endpoint: `ws://<host>:<ws_port>/ws/jobs/{jobId}`
+  - Typed events: `job.snapshot`, `job.progress`, `job.log`, `stt.segment`, `job.complete`, `job.error`
+  - Existing HTTP polling and callback flows remain fully supported
 
 ## MCP adapter note
 
@@ -43,6 +49,10 @@ PARSE has crossed the React pivot and the unified UI redesign is **merged to `ma
   - `GET /openapi.json`
   - `GET /docs`
   - `GET /redoc`
+- Additive WebSocket job streaming now runs beside the HTTP server:
+  - `ws://<host>:<PARSE_WS_PORT or 8767>/ws/jobs/{jobId}`
+  - event envelope fields: `event`, `jobId`, `type`, `ts`, `payload`
+  - current v1 events: `job.snapshot`, `job.progress`, `job.log`, `stt.segment`, `job.complete`, `job.error`
 - Official external wrappers now live in `python/packages/parse_mcp/`.
 - Mutability meanings:
   - `read_only` — inspection only; no writes or background jobs
@@ -110,15 +120,11 @@ Use the generic tools when an agent needs transport-independent job inspection i
 Recommended agent pattern:
 1. Start a heavy job (`pipeline_run`, `stt_start`, `audio_normalize_start`, etc.)
 2. Poll `job_status` for transport-neutral state
-<<<<<<< HEAD
-3. Read `job_logs` when the human asks "what is it doing?" or when progress stalls
-4. Fall back to old per-type status tools only when a workflow needs type-specific payload shaping
-=======
 3. Inspect `locks` when coordinating speaker-scoped mutating work between humans and agents
 4. Read `job_logs` when the human asks "what is it doing?" or when progress stalls
 5. For HTTP-started jobs that need push completion, pass `callbackUrl` (absolute `http(s)` URL) on the job-start request so PARSE POSTs the final generic job payload on `complete` / `error`
-6. Fall back to old per-type status tools only when a workflow needs type-specific payload shaping
->>>>>>> 660eb33 (feat: add job completion callbacks)
+6. For realtime progress, connect to `ws://<host>:<PARSE_WS_PORT or 8767>/ws/jobs/{jobId}` and consume the typed event stream
+7. Fall back to old per-type status tools only when a workflow needs type-specific payload shaping
 
 ## Client/Server Contract Surface
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,10 +6,11 @@
 
 ## API overview
 
-PARSE has two programmatic surfaces:
+PARSE has three programmatic surfaces:
 
 1. **HTTP API** — used by the browser frontend and any local automation that talks to `python/server.py`
-2. **MCP server mode** — used by external agent clients through the PARSE MCP adapter
+2. **WebSocket job streaming** — additive realtime job updates from the sidecar in `python/external_api/streaming.py`
+3. **MCP server mode** — used by external agent clients through the PARSE MCP adapter
 
 ### Base URLs
 
@@ -17,6 +18,7 @@ During active development:
 
 - frontend: `http://localhost:5173`
 - API backend: `http://localhost:8766`
+- WebSocket sidecar: `ws://localhost:8767` (override with `PARSE_WS_PORT`)
 
 In practice, the React app usually calls relative `/api/...` paths through the Vite proxy.
 
@@ -33,6 +35,48 @@ A few patterns recur across the API:
 - binary export/image endpoints return files rather than JSON
 - compute endpoints normalize job handling across multiple background workflows
 - `/api/config` carries a schema-versioned payload; if the config contract changes incompatibly, update the corresponding version constants in both `python/server.py` and `src/api/client.ts`
+
+## WebSocket job streaming
+
+WebSocket streaming is additive. Clients can continue polling `/api/stt/status`, `/api/compute/{type}/status`, or `/api/jobs/{jobId}` exactly as before.
+
+### Endpoint
+
+- `ws://<host>:<PARSE_WS_PORT or 8767>/ws/jobs/{jobId}`
+
+### Event envelope
+
+```json
+{
+  "event": "job.progress",
+  "jobId": "stt-abc123",
+  "type": "stt",
+  "ts": "2026-04-24T22:30:00Z",
+  "payload": {
+    "progress": 42.5,
+    "message": "Transcribing (17 segments)",
+    "segmentsProcessed": 17,
+    "totalSegments": 0
+  }
+}
+```
+
+### Current v1 event types
+
+| Event | Purpose |
+|---|---|
+| `job.snapshot` | Initial job state sent immediately after subscribe |
+| `job.progress` | Current public job payload after a progress/running update |
+| `job.log` | One structured log entry from the job ring buffer |
+| `stt.segment` | Provisional partial STT segment for in-flight decoding |
+| `job.complete` | Terminal success payload |
+| `job.error` | Terminal error payload |
+
+### Notes
+
+- `stt.segment` packets are provisional and meant for UX / agent steering.
+- The persisted STT cache and final job `result` remain the canonical artifacts.
+- Closely emitted events like `job.log` and `job.progress` may arrive in either order unless a stricter ordering contract is documented for that event pair.
 
 ## GET endpoints
 
@@ -160,6 +204,12 @@ Example response:
   "jobId": "stt-abc123",
   "status": "running"
 }
+```
+
+To subscribe to realtime updates for the started job, connect to:
+
+```text
+ws://localhost:8767/ws/jobs/stt-abc123
 ```
 
 ### Poll STT status

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -75,6 +75,7 @@ dist/                   -- build output
 
 - Python 3.10–3.12
 - local HTTP server in `python/server.py`
+- additive WebSocket job-streaming sidecar in `python/external_api/streaming.py` (`PARSE_WS_PORT`, default `8767`)
 - OpenAPI 3.1 generation + interactive docs (`/openapi.json`, `/docs`, `/redoc`)
 - HTTP MCP bridge for schema discovery + tool execution (`/api/mcp/*`)
 - background job orchestration for STT / normalize / compute / chat
@@ -133,6 +134,42 @@ npm run build
 ```
 
 The Python backend can then serve the built frontend from `http://localhost:8766/`.
+
+### WebSocket job streaming
+
+The backend now also exposes an additive realtime stream beside the HTTP API:
+
+- environment variable: `PARSE_WS_PORT`
+- default port: `8767`
+- endpoint shape: `ws://localhost:8767/ws/jobs/{jobId}`
+
+This sidecar is optional. Existing HTTP polling remains supported and is still the baseline compatibility path.
+
+Current v1 streamed event names:
+
+- `job.snapshot`
+- `job.progress`
+- `job.log`
+- `stt.segment`
+- `job.complete`
+- `job.error`
+
+Example Python client:
+
+```python
+import json
+from websockets.sync.client import connect
+
+job_id = "stt-abc123"
+with connect(f"ws://127.0.0.1:8767/ws/jobs/{job_id}") as ws:
+    while True:
+        event = json.loads(ws.recv())
+        print(event["event"], event["payload"])
+        if event["event"] in {"job.complete", "job.error"}:
+            break
+```
+
+For STT jobs, `stt.segment` packets are provisional progress signals for UX and agent steering. The persisted cache/result written on completion remains the canonical artifact.
 
 ### Compute runtime modes and deployment notes
 
@@ -243,6 +280,19 @@ At minimum update:
 - `docs/architecture.md` if the new route changes the data model or workflow surface
 - the root `README.md` if the change is user-visible enough to belong on the landing page
 
+## How to add a new WebSocket stream
+
+PARSE's current realtime transport is intentionally narrow: a dedicated per-job stream layered on top of the existing HTTP server rather than a framework migration.
+
+When extending it:
+
+1. Prefer reusing the existing job registry in `python/server.py` rather than inventing a parallel state store.
+2. Publish typed envelopes through `python/external_api/streaming.py`.
+3. Keep polling endpoints working; streaming must stay additive, never mandatory.
+4. Use stable event names (`job.progress`, `job.log`, `stt.segment`, etc.).
+5. Document any new event types in `docs/api-reference.md` and `AGENTS.md`.
+6. Test event presence without over-specifying incidental ordering unless ordering is part of the explicit contract.
+
 ## How to add a new chat tool
 
 The built-in assistant works through `ParseChatTools` in `python/ai/chat_tools.py`.
@@ -293,6 +343,10 @@ Task 5 adds two more extension surfaces that matter for contributors:
 3. **Publishable wrapper package** — `python/packages/parse_mcp/`
    - keep discovery/execution behavior aligned with the HTTP MCP bridge
    - framework wrappers should remain thin adapters over the discovered tool schema
+4. **WebSocket streaming sidecar** — `python/external_api/streaming.py` + `python/server.py`
+   - keep the per-job stream shape aligned with the live job registry
+   - treat polling, callbacks, and streaming as complementary transports over the same job state
+   - do not assume strict ordering between near-simultaneous events like `job.log` and `job.progress` unless the code explicitly enforces it
 
 When adding or renaming MCP-visible tools, update all three layers together:
 - stdio adapter

--- a/docs/mcp_agent_roadmap.md
+++ b/docs/mcp_agent_roadmap.md
@@ -105,10 +105,32 @@ These changes make long-running PARSE jobs inspectable across the UI, HTTP autom
 
 ---
 
-## 6. Future / nice-to-have
+## 6. Streaming responses (WebSocket)
+
+**Status:** ✅ Complete
+
+**Shipped:**
+- Added an additive WebSocket sidecar in `python/external_api/streaming.py` rather than migrating the custom HTTP server to a new framework.
+- The sidecar runs on `PARSE_WS_PORT` with default port `8767`.
+- Per-job subscription endpoint:
+  - `ws://<host>:<ws_port>/ws/jobs/{jobId}`
+- Current v1 event types:
+  - `job.snapshot`
+  - `job.progress`
+  - `job.log`
+  - `stt.segment`
+  - `job.complete`
+  - `job.error`
+- First supported realtime workflow is STT:
+  - live job progress updates
+  - provisional partial segment packets while decoding
+- Existing HTTP polling and callback flows remain fully supported and are still the compatibility baseline.
+
+---
+
+## 7. Future / nice-to-have
 
 | Idea | Value |
 |------|-------|
-| Streaming responses (WebSocket) | Agents get real-time waveform updates or partial results |
 | Built-in sandbox / permission system | Scope an agent to a single speaker: `"agent can only edit speaker X"` |
 | Remote / cloud mode | Run PARSE headless on a GPU server; agents connect via MCP over the internet |

--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -1018,6 +1018,7 @@ class AIProvider(abc.ABC):
         audio_path: Path,
         language: Optional[str] = None,
         progress_callback: Optional[Callable[[float, int], None]] = None,
+        segment_callback: Optional[Callable[[Segment], None]] = None,
     ) -> List[Segment]:
         """Transcribe an audio file into timestamped segments."""
         raise NotImplementedError
@@ -1275,6 +1276,7 @@ class LocalWhisperProvider(AIProvider):
         audio_path: Path,
         language: Optional[str] = None,
         progress_callback: Optional[Callable[[float, int], None]] = None,
+        segment_callback: Optional[Callable[[Segment], None]] = None,
     ) -> List[Segment]:
         """Run full-file STT with faster-whisper."""
         path = Path(audio_path).expanduser().resolve()
@@ -1326,6 +1328,8 @@ class LocalWhisperProvider(AIProvider):
                 if words_out:
                     seg_dict["words"] = words_out
                 segs_out.append(seg_dict)
+                if segment_callback is not None:
+                    segment_callback(copy.deepcopy(seg_dict))
                 if progress_callback is not None and total_duration > 0.0:
                     progress = _coerce_confidence(end / total_duration) * 100.0
                     progress_callback(progress, len(segs_out))
@@ -1491,6 +1495,7 @@ class OpenAIProvider(AIProvider):
         audio_path: Path,
         language: Optional[str] = None,
         progress_callback: Optional[Callable[[float, int], None]] = None,
+        segment_callback: Optional[Callable[[Segment], None]] = None,
     ) -> List[Segment]:
         """Transcribe audio with OpenAI STT endpoint."""
         path = Path(audio_path).expanduser().resolve()
@@ -1541,6 +1546,8 @@ class OpenAIProvider(AIProvider):
                         "confidence": confidence,
                     }
                 )
+                if segment_callback is not None:
+                    segment_callback(copy.deepcopy(segments_out[-1]))
 
                 if progress_callback is not None:
                     progress_callback(100.0, index)
@@ -1555,6 +1562,8 @@ class OpenAIProvider(AIProvider):
                     "confidence": 0.0,
                 }
             )
+            if segment_callback is not None:
+                segment_callback(copy.deepcopy(segments_out[-1]))
             if progress_callback is not None:
                 progress_callback(100.0, 1)
 
@@ -1625,12 +1634,14 @@ class XAIProvider(OpenAIProvider):
         audio_path: Path,
         language: Optional[str] = None,
         progress_callback: Optional[Callable[[float, int], None]] = None,
+        segment_callback: Optional[Callable[[Segment], None]] = None,
     ) -> List[Segment]:
         """Use local faster-whisper fallback for STT."""
         return self._stt_fallback.transcribe(
             audio_path=audio_path,
             language=language,
             progress_callback=progress_callback,
+            segment_callback=segment_callback,
         )
 
 
@@ -1659,12 +1670,14 @@ class OllamaProvider(AIProvider):
         audio_path: Path,
         language: Optional[str] = None,
         progress_callback: Optional[Callable[[float, int], None]] = None,
+        segment_callback: Optional[Callable[[Segment], None]] = None,
     ) -> List[Segment]:
         """Use local faster-whisper fallback for STT."""
         return self._stt_fallback.transcribe(
             audio_path=audio_path,
             language=language,
             progress_callback=progress_callback,
+            segment_callback=segment_callback,
         )
 
     def _generate(self, prompt: str) -> str:

--- a/python/external_api/streaming.py
+++ b/python/external_api/streaming.py
@@ -13,8 +13,17 @@ import json
 import threading
 from typing import Any, Callable, Dict, Optional, Set
 
-import websockets
-from websockets.exceptions import ConnectionClosed
+
+def _load_websockets_runtime() -> tuple[Any, type[BaseException]]:
+    try:
+        import websockets
+        from websockets.exceptions import ConnectionClosed
+    except ImportError as exc:
+        raise RuntimeError(
+            "PARSE WebSocket streaming requires the optional 'websockets' package. "
+            "Install it to enable ws://<host>:<PARSE_WS_PORT or 8767>/ws/jobs/{jobId}."
+        ) from exc
+    return websockets, ConnectionClosed
 
 
 class JobStreamingSidecar:
@@ -45,6 +54,7 @@ class JobStreamingSidecar:
         self._subscribers: Dict[str, Set[Any]] = {}
         self._ready = threading.Event()
         self._startup_exception: Optional[BaseException] = None
+        self._connection_closed_exc: Optional[type[BaseException]] = None
 
     @property
     def port(self) -> int:
@@ -136,7 +146,9 @@ class JobStreamingSidecar:
     async def _async_start(self) -> None:
         self._publish_queue = asyncio.Queue()
         self._publisher_task = asyncio.create_task(self._publisher_loop())
-        self._server = await websockets.serve(
+        websockets_mod, connection_closed_exc = _load_websockets_runtime()
+        self._connection_closed_exc = connection_closed_exc
+        self._server = await websockets_mod.serve(
             self._handle_connection,
             self._host,
             self._requested_port,
@@ -192,8 +204,14 @@ class JobStreamingSidecar:
         for conn in recipients:
             try:
                 await conn.send(message)
-            except ConnectionClosed:
-                stale.append(conn)
+            except Exception as exc:
+                if (
+                    self._connection_closed_exc is not None
+                    and isinstance(exc, self._connection_closed_exc)
+                ):
+                    stale.append(conn)
+                    continue
+                raise
         if stale:
             live = self._subscribers.get(job_id)
             if live is not None:
@@ -221,8 +239,13 @@ class JobStreamingSidecar:
             async for _message in conn:
                 # v1 is server-push only; incoming client messages are ignored.
                 continue
-        except ConnectionClosed:
-            return
+        except Exception as exc:
+            if (
+                self._connection_closed_exc is not None
+                and isinstance(exc, self._connection_closed_exc)
+            ):
+                return
+            raise
         finally:
             live = self._subscribers.get(job_id)
             if live is not None:

--- a/python/external_api/streaming.py
+++ b/python/external_api/streaming.py
@@ -1,0 +1,240 @@
+"""WebSocket streaming sidecar for PARSE job events.
+
+Additive transport only: the existing HTTP API remains authoritative for start
+and poll flows, while this sidecar lets clients subscribe to a single job for
+push updates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import threading
+from typing import Any, Callable, Dict, Optional, Set
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+
+class JobStreamingSidecar:
+    """One-process WebSocket sidecar with a dedicated asyncio loop/thread.
+
+    Clients subscribe per job via ``/ws/jobs/{jobId}``. The sidecar sends an
+    initial ``job.snapshot`` event, then broadcasts subsequent envelopes pushed
+    in from the synchronous server threads.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        get_snapshot_event: Callable[[str], Optional[Dict[str, Any]]],
+    ) -> None:
+        self._host = str(host or "127.0.0.1")
+        self._requested_port = int(port)
+        self._port: Optional[int] = None
+        self._get_snapshot_event = get_snapshot_event
+
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._server = None
+        self._publisher_task: Optional[asyncio.Task[Any]] = None
+        self._publish_queue: Optional[asyncio.Queue[Optional[Dict[str, Any]]]] = None
+        self._subscribers: Dict[str, Set[Any]] = {}
+        self._ready = threading.Event()
+        self._startup_exception: Optional[BaseException] = None
+
+    @property
+    def port(self) -> int:
+        if self._port is None:
+            raise RuntimeError("WebSocket sidecar has not started yet")
+        return int(self._port)
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    def start(self, timeout: float = 5.0) -> "JobStreamingSidecar":
+        if self.is_running():
+            return self
+
+        self._ready.clear()
+        self._startup_exception = None
+        self._thread = threading.Thread(
+            target=self._thread_main,
+            name="parse-ws-sidecar",
+            daemon=True,
+        )
+        self._thread.start()
+        if not self._ready.wait(timeout=timeout):
+            raise RuntimeError("Timed out starting PARSE WebSocket sidecar")
+        if self._startup_exception is not None:
+            raise RuntimeError(
+                "Failed to start PARSE WebSocket sidecar: {0}".format(
+                    self._startup_exception
+                )
+            ) from self._startup_exception
+        return self
+
+    def is_running(self) -> bool:
+        return bool(
+            self._thread is not None
+            and self._thread.is_alive()
+            and self._loop is not None
+            and self._loop.is_running()
+        )
+
+    def stop(self, timeout: float = 5.0) -> None:
+        loop = self._loop
+        thread = self._thread
+        if loop is None or thread is None:
+            return
+        if loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(self._async_shutdown(), loop)
+            future.result(timeout=timeout)
+        thread.join(timeout=timeout)
+        self._thread = None
+        self._loop = None
+
+    def job_url(self, job_id: str) -> str:
+        safe_host = self._host
+        if safe_host in {"0.0.0.0", "::"}:
+            safe_host = "127.0.0.1"
+        return "ws://{0}:{1}/ws/jobs/{2}".format(safe_host, self.port, job_id)
+
+    def publish(self, event: Dict[str, Any]) -> None:
+        loop = self._loop
+        queue = self._publish_queue
+        if loop is None or queue is None or not loop.is_running():
+            return
+        asyncio.run_coroutine_threadsafe(queue.put(copy.deepcopy(event)), loop)
+
+    def _thread_main(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        try:
+            loop.run_until_complete(self._async_start())
+        except BaseException as exc:  # pragma: no cover - startup errors are surfaced to callers
+            self._startup_exception = exc
+            self._ready.set()
+            return
+
+        self._ready.set()
+        try:
+            loop.run_forever()
+        finally:
+            pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.close()
+
+    async def _async_start(self) -> None:
+        self._publish_queue = asyncio.Queue()
+        self._publisher_task = asyncio.create_task(self._publisher_loop())
+        self._server = await websockets.serve(
+            self._handle_connection,
+            self._host,
+            self._requested_port,
+        )
+        sockets = getattr(self._server, "sockets", None) or []
+        if not sockets:
+            raise RuntimeError("WebSocket sidecar failed to bind a listening socket")
+        self._port = int(sockets[0].getsockname()[1])
+
+    async def _async_shutdown(self) -> None:
+        queue = self._publish_queue
+        publisher_task = self._publisher_task
+        if queue is not None:
+            await queue.put(None)
+        if publisher_task is not None:
+            await publisher_task
+            self._publisher_task = None
+
+        subscribers = [conn for group in self._subscribers.values() for conn in group]
+        self._subscribers.clear()
+        for conn in subscribers:
+            try:
+                await conn.close(code=1001, reason="PARSE WebSocket sidecar shutdown")
+            except Exception:
+                pass
+
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        loop = self._loop
+        if loop is not None:
+            loop.call_soon(loop.stop)
+
+    async def _publisher_loop(self) -> None:
+        assert self._publish_queue is not None
+        while True:
+            event = await self._publish_queue.get()
+            if event is None:
+                return
+            await self._broadcast(event)
+
+    async def _broadcast(self, event: Dict[str, Any]) -> None:
+        job_id = str(event.get("jobId") or "").strip()
+        if not job_id:
+            return
+        recipients = list(self._subscribers.get(job_id, set()))
+        if not recipients:
+            return
+        message = json.dumps(event, ensure_ascii=False, default=str)
+        stale = []
+        for conn in recipients:
+            try:
+                await conn.send(message)
+            except ConnectionClosed:
+                stale.append(conn)
+        if stale:
+            live = self._subscribers.get(job_id)
+            if live is not None:
+                for conn in stale:
+                    live.discard(conn)
+                if not live:
+                    self._subscribers.pop(job_id, None)
+
+    async def _handle_connection(self, conn: Any) -> None:
+        job_id = self._job_id_from_path(
+            str(getattr(getattr(conn, "request", None), "path", "") or "")
+        )
+        if not job_id:
+            await conn.close(code=1008, reason="Unsupported PARSE stream path")
+            return
+
+        subscribers = self._subscribers.setdefault(job_id, set())
+        subscribers.add(conn)
+        try:
+            snapshot = self._get_snapshot_event(job_id)
+            if snapshot is None:
+                await conn.close(code=1008, reason="Unknown PARSE jobId")
+                return
+            await conn.send(json.dumps(snapshot, ensure_ascii=False, default=str))
+            async for _message in conn:
+                # v1 is server-push only; incoming client messages are ignored.
+                continue
+        except ConnectionClosed:
+            return
+        finally:
+            live = self._subscribers.get(job_id)
+            if live is not None:
+                live.discard(conn)
+                if not live:
+                    self._subscribers.pop(job_id, None)
+
+    @staticmethod
+    def _job_id_from_path(path: str) -> str:
+        normalized = str(path or "").strip()
+        prefix = "/ws/jobs/"
+        if not normalized.startswith(prefix):
+            return ""
+        job_id = normalized[len(prefix):].strip("/")
+        return job_id.strip()

--- a/python/server.py
+++ b/python/server.py
@@ -30,6 +30,7 @@ from ai.ipa_transcribe import transcribe_slice as _acoustic_transcribe_slice
 from audio_pipeline_paths import build_normalized_output_path
 from external_api.catalog import build_mcp_http_catalog, get_mcp_tool_entry, mcp_exposure_payload, resolve_catalog_mode
 from external_api.openapi import build_openapi_document, render_redoc_html, render_swagger_ui_html
+from external_api.streaming import JobStreamingSidecar
 
 try:
     from compare import cognate_compute as cognate_compute_module
@@ -39,6 +40,7 @@ except Exception:
 
 HOST = "0.0.0.0"
 PORT = 8766
+WS_PORT = 8767
 JOB_RETENTION_SECONDS = 60 * 60
 JOB_LOG_MAX_ENTRIES = 200
 JOB_LOCK_TTL_SECONDS = 10 * 60
@@ -77,6 +79,9 @@ CHAT_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 _jobs: Dict[str, Dict[str, Any]] = {}
 _jobs_lock = threading.Lock()
+
+_job_streaming_lock = threading.Lock()
+_job_streaming_sidecar: Optional[JobStreamingSidecar] = None
 
 _chat_sessions: Dict[str, Dict[str, Any]] = {}
 _chat_sessions_lock = threading.Lock()
@@ -2148,6 +2153,7 @@ def _start_persistent_worker() -> bool:
             on_progress=_set_job_progress,
             on_complete=_set_job_complete,
             on_error=_set_job_error,
+            on_stt_segment=_publish_stt_partial_segment,
         )
         started = handle.start(ready_timeout=180.0)
         if not started:
@@ -2582,19 +2588,27 @@ def _append_job_log_locked(
     if not isinstance(logs, list):
         logs = []
         job["logs"] = logs
-    logs.append(
-        _job_log_entry(
-            level=level,
-            event=event,
-            message=message,
-            source=source,
-            progress=progress,
-            data=data,
-        )
+    entry = _job_log_entry(
+        level=level,
+        event=event,
+        message=message,
+        source=source,
+        progress=progress,
+        data=data,
     )
+    logs.append(entry)
     log_limit = _job_log_limit()
     if len(logs) > log_limit:
         del logs[:-log_limit]
+    job_id = str(job.get("jobId") or "").strip()
+    job_type = str(job.get("type") or "").strip()
+    if job_id and job_type:
+        _publish_job_stream_event(
+            "job.log",
+            job_id=job_id,
+            job_type=job_type,
+            payload=entry,
+        )
 
 
 _MUTATING_SPEAKER_JOB_TYPES = frozenset({"normalize", "stt", "onboard:speaker"})
@@ -2992,6 +3006,8 @@ def _compute_checkpoint(label: str, **kv: Any) -> None:
         pass
 
 def _set_job_running(job_id: str, message: Optional[str] = None) -> None:
+    stream_payload: Optional[Dict[str, Any]] = None
+    job_type = ""
     with _jobs_lock:
         job = _jobs.get(job_id)
         if job is None:
@@ -3012,6 +3028,16 @@ def _set_job_running(job_id: str, message: Optional[str] = None) -> None:
             message=str(job.get("message") or message or "Job started"),
             progress=_clamp_progress(job.get("progress", 0.0)),
         )
+        job_type = str(job.get("type") or "")
+        stream_payload = _job_response_payload(job)
+
+    if stream_payload is not None and job_type:
+        _publish_job_stream_event(
+            "job.progress",
+            job_id=job_id,
+            job_type=job_type,
+            payload=stream_payload,
+        )
 
 
 
@@ -3022,6 +3048,8 @@ def _set_job_progress(
     segments_processed: Optional[int] = None,
     total_segments: Optional[int] = None,
 ) -> None:
+    stream_payload: Optional[Dict[str, Any]] = None
+    job_type = ""
     with _jobs_lock:
         job = _jobs.get(job_id)
         if job is None or job.get("status") != "running":
@@ -3070,6 +3098,16 @@ def _set_job_progress(
                 message="Progress updated",
                 progress=current_progress,
             )
+        job_type = str(job.get("type") or "")
+        stream_payload = _job_response_payload(job)
+
+    if stream_payload is not None and job_type:
+        _publish_job_stream_event(
+            "job.progress",
+            job_id=job_id,
+            job_type=job_type,
+            payload=stream_payload,
+        )
 
 
 
@@ -3081,6 +3119,8 @@ def _set_job_complete(
     total_segments: Optional[int] = None,
 ) -> None:
     callback_snapshot: Optional[Dict[str, Any]] = None
+    stream_payload: Optional[Dict[str, Any]] = None
+    job_type = ""
     with _jobs_lock:
         job = _jobs.get(job_id)
         if job is None:
@@ -3118,7 +3158,16 @@ def _set_job_complete(
             progress=100.0,
         )
         callback_snapshot = copy.deepcopy(job)
+        job_type = str(job.get("type") or "")
+        stream_payload = _job_response_payload(job)
 
+    if stream_payload is not None and job_type:
+        _publish_job_stream_event(
+            "job.complete",
+            job_id=job_id,
+            job_type=job_type,
+            payload=stream_payload,
+        )
     if callback_snapshot is not None:
         _dispatch_job_callback_async(callback_snapshot)
 
@@ -3134,6 +3183,8 @@ def _set_job_error(
     one-line reason on top and the full Python traceback below without
     having to split-on-newline."""
     callback_snapshot: Optional[Dict[str, Any]] = None
+    stream_payload: Optional[Dict[str, Any]] = None
+    job_type = ""
     with _jobs_lock:
         job = _jobs.get(job_id)
         if job is None:
@@ -3159,7 +3210,16 @@ def _set_job_error(
             progress=_clamp_progress(job.get("progress", 0.0)),
         )
         callback_snapshot = copy.deepcopy(job)
+        job_type = str(job.get("type") or "")
+        stream_payload = _job_response_payload(job)
 
+    if stream_payload is not None and job_type:
+        _publish_job_stream_event(
+            "job.error",
+            job_id=job_id,
+            job_type=job_type,
+            payload=stream_payload,
+        )
     if callback_snapshot is not None:
         _dispatch_job_callback_async(callback_snapshot)
 
@@ -3289,6 +3349,125 @@ def _job_response_payload(job: Dict[str, Any]) -> Dict[str, Any]:
     return payload
 
 
+def _resolve_ws_port() -> int:
+    raw = str(os.environ.get("PARSE_WS_PORT") or "").strip()
+    if not raw:
+        return WS_PORT
+    try:
+        port = int(raw)
+    except (TypeError, ValueError):
+        return WS_PORT
+    if 0 <= port <= 65535:
+        return port
+    return WS_PORT
+
+
+
+def _job_stream_envelope(
+    event_type: str,
+    *,
+    job_id: str,
+    job_type: str,
+    payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    return {
+        "event": str(event_type),
+        "jobId": str(job_id),
+        "type": str(job_type),
+        "ts": _utc_now_iso(),
+        "payload": copy.deepcopy(payload),
+    }
+
+
+
+def _job_snapshot_stream_event(job_id: str) -> Optional[Dict[str, Any]]:
+    job = _get_job_snapshot(job_id)
+    if job is None:
+        return None
+    return _job_stream_envelope(
+        "job.snapshot",
+        job_id=str(job.get("jobId") or job_id),
+        job_type=str(job.get("type") or ""),
+        payload=_job_response_payload(job),
+    )
+
+
+
+def _job_streaming_sidecar_or_none() -> Optional[JobStreamingSidecar]:
+    with _job_streaming_lock:
+        return _job_streaming_sidecar
+
+
+
+def _start_websocket_sidecar(host: Optional[str] = None, port: Optional[int] = None) -> JobStreamingSidecar:
+    global _job_streaming_sidecar
+    requested_host = str(host or HOST).strip() or HOST
+    requested_port = _resolve_ws_port() if port is None else int(port)
+    with _job_streaming_lock:
+        sidecar = _job_streaming_sidecar
+        if sidecar is not None:
+            same_host = str(sidecar.host or "") == requested_host
+            same_port = sidecar.port == requested_port if requested_port != 0 else True
+            if sidecar.is_running() and same_host and same_port:
+                return sidecar
+            sidecar.stop()
+        sidecar = JobStreamingSidecar(
+            host=requested_host,
+            port=requested_port,
+            get_snapshot_event=_job_snapshot_stream_event,
+        ).start()
+        _job_streaming_sidecar = sidecar
+        return sidecar
+
+
+
+def _shutdown_websocket_sidecar() -> None:
+    global _job_streaming_sidecar
+    with _job_streaming_lock:
+        sidecar = _job_streaming_sidecar
+        _job_streaming_sidecar = None
+    if sidecar is not None:
+        sidecar.stop()
+
+
+
+def _publish_job_stream_event(
+    event_type: str,
+    *,
+    job_id: str,
+    job_type: str,
+    payload: Dict[str, Any],
+) -> None:
+    sidecar = _job_streaming_sidecar_or_none()
+    if sidecar is None:
+        return
+    sidecar.publish(
+        _job_stream_envelope(
+            event_type,
+            job_id=job_id,
+            job_type=job_type,
+            payload=payload,
+        )
+    )
+
+
+
+def _publish_stt_partial_segment(job_id: str, segment: Dict[str, Any]) -> None:
+    job = _get_job_snapshot(job_id)
+    if job is None:
+        return
+    _publish_job_stream_event(
+        "stt.segment",
+        job_id=str(job.get("jobId") or job_id),
+        job_type=str(job.get("type") or "stt"),
+        payload={
+            "provisional": True,
+            "segment": copy.deepcopy(segment),
+        },
+    )
+
+
+
 def _list_active_jobs_snapshots() -> List[Dict[str, Any]]:
     """Return public snapshots for all currently-running jobs.
 
@@ -3413,12 +3592,44 @@ def _run_stt_job(
             segments_processed=segments_processed,
         )
 
+    def _segment_callback(segment: Dict[str, Any]) -> None:
+        if not isinstance(segment, dict):
+            return
+        partial_segment: Dict[str, Any] = {}
+        try:
+            partial_segment["start"] = float(segment.get("start", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            partial_segment["start"] = 0.0
+        try:
+            partial_segment["end"] = float(
+                segment.get("end", partial_segment["start"]) or partial_segment["start"]
+            )
+        except (TypeError, ValueError):
+            partial_segment["end"] = partial_segment["start"]
+        partial_segment["text"] = str(segment.get("text", "") or "").strip()
+        try:
+            partial_segment["confidence"] = float(segment.get("confidence", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            partial_segment["confidence"] = 0.0
+        words = segment.get("words")
+        if isinstance(words, list) and words:
+            partial_segment["words"] = copy.deepcopy(words)
+        _publish_stt_partial_segment(job_id, partial_segment)
+
     try:
-        segments = provider.transcribe(
-            audio_path=audio_path,
-            language=language,
-            progress_callback=_progress_callback,
-        )
+        transcribe_kwargs = {
+            "audio_path": audio_path,
+            "language": language,
+            "progress_callback": _progress_callback,
+            "segment_callback": _segment_callback,
+        }
+        try:
+            segments = provider.transcribe(**transcribe_kwargs)
+        except TypeError as exc:
+            if "segment_callback" not in str(exc):
+                raise
+            transcribe_kwargs.pop("segment_callback", None)
+            segments = provider.transcribe(**transcribe_kwargs)
     except Exception as exc:
         import traceback
         tb = traceback.format_exc()
@@ -8158,6 +8369,7 @@ def _startup_banner_lines(
         "=" * 60,
         "  Serving: {0}".format(serve_dir),
         "  Port   : {0}".format(PORT),
+        "  WS Port: {0}".format(_resolve_ws_port()),
         "",
         "  React dev UI (current workflow; requires `npm run dev`):",
         "    Annotate: http://localhost:5173/",
@@ -8181,7 +8393,10 @@ def _startup_banner_lines(
         ])
     lines.extend([
         "",
-        "  Features: Range requests [x]  CORS [x]  Threaded [x]  API [x]",
+        "  WebSocket job streaming:",
+        "    ws://localhost:{0}/ws/jobs/{{jobId}}".format(_resolve_ws_port()),
+        "",
+        "  Features: Range requests [x]  CORS [x]  Threaded [x]  API [x]  WS streaming [x]",
         "  Press Ctrl+C to stop.",
         "=" * 60,
     ])
@@ -8269,6 +8484,15 @@ def main() -> None:
     server_address = (HOST, PORT)
     httpd = _BoundedThreadHTTPServer(server_address, RangeRequestHandler)
 
+    try:
+        _start_websocket_sidecar(host=HOST, port=_resolve_ws_port())
+    except Exception as exc:
+        print(
+            "[WARN] WebSocket streaming disabled: {0}".format(exc),
+            file=sys.stderr,
+            flush=True,
+        )
+
     if _resolve_compute_mode() == "persistent":
         if not _start_persistent_worker():
             print(
@@ -8288,6 +8512,13 @@ def main() -> None:
     except KeyboardInterrupt:
         print("\nServer stopped.")
         sys.exit(0)
+    finally:
+        try:
+            httpd.server_close()
+        except Exception:
+            pass
+        _shutdown_websocket_sidecar()
+        _shutdown_persistent_worker()
 
 
 if __name__ == "__main__":

--- a/python/test_optional_websocket_dependency.py
+++ b/python/test_optional_websocket_dependency.py
@@ -1,0 +1,68 @@
+import pathlib
+import subprocess
+import sys
+
+
+def _python_dir() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parent
+
+
+def test_server_imports_without_websockets_installed() -> None:
+    script = f"""
+import builtins
+import pathlib
+import sys
+
+orig_import = builtins.__import__
+
+def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == 'websockets' or name.startswith('websockets.'):
+        raise ImportError("No module named 'websockets'")
+    return orig_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = fake_import
+sys.path.insert(0, {str(_python_dir())!r})
+import server
+print('SERVER_IMPORT_OK')
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "SERVER_IMPORT_OK" in result.stdout
+
+
+def test_starting_sidecar_without_websockets_gives_clear_error() -> None:
+    script = f"""
+import builtins
+import pathlib
+import sys
+
+orig_import = builtins.__import__
+
+def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == 'websockets' or name.startswith('websockets.'):
+        raise ImportError("No module named 'websockets'")
+    return orig_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = fake_import
+sys.path.insert(0, {str(_python_dir())!r})
+import server
+try:
+    server._start_websocket_sidecar(host='127.0.0.1', port=0)
+except RuntimeError as exc:
+    print(str(exc))
+else:
+    raise SystemExit('expected RuntimeError')
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "requires the optional 'websockets' package" in result.stdout

--- a/python/test_websocket_streaming.py
+++ b/python/test_websocket_streaming.py
@@ -1,0 +1,156 @@
+import json
+import pathlib
+import sys
+import threading
+from typing import Any, Dict, Iterable, Optional
+
+from websockets.sync.client import connect
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server
+
+
+class _StreamingStubProvider:
+    def __init__(self, *, partial_segments: Optional[Iterable[Dict[str, Any]]] = None, final_segments: Optional[Iterable[Dict[str, Any]]] = None):
+        self.partial_segments = list(partial_segments or [])
+        self.final_segments = list(final_segments or [])
+
+    def transcribe(
+        self,
+        audio_path,
+        language=None,
+        progress_callback=None,
+        segment_callback=None,
+    ):
+        if progress_callback is not None:
+            progress_callback(12.5, 0)
+        if segment_callback is not None:
+            for segment in self.partial_segments:
+                segment_callback(segment)
+        if progress_callback is not None:
+            progress_callback(55.0, len(self.partial_segments))
+        return list(self.final_segments)
+
+
+def _recv_event(ws, expected_event: str, *, timeout: float = 5.0) -> Dict[str, Any]:
+    while True:
+        payload = json.loads(ws.recv(timeout=timeout))
+        if payload.get("event") == expected_event:
+            return payload
+
+
+def _recv_events(ws, expected_events: Iterable[str], *, timeout: float = 5.0) -> Dict[str, Dict[str, Any]]:
+    wanted = {str(event) for event in expected_events}
+    received: Dict[str, Dict[str, Any]] = {}
+    while wanted - received.keys():
+        payload = json.loads(ws.recv(timeout=timeout))
+        event_name = str(payload.get("event") or "")
+        if event_name in wanted and event_name not in received:
+            received[event_name] = payload
+    return received
+
+
+def test_resolve_ws_port_prefers_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("PARSE_WS_PORT", "9876")
+    assert server._resolve_ws_port() == 9876
+
+
+def test_websocket_stream_receives_snapshot_progress_log_and_complete_events() -> None:
+    server._jobs.clear()
+    sidecar = server._start_websocket_sidecar(host="127.0.0.1", port=0)
+    try:
+        job_id = server._create_job("stt", {"speaker": "Fail01", "sourceWav": "audio.wav"})
+        with connect(sidecar.job_url(job_id), open_timeout=5, close_timeout=5) as ws:
+            snapshot = _recv_event(ws, "job.snapshot")
+            assert snapshot["jobId"] == job_id
+            assert snapshot["type"] == "stt"
+            assert snapshot["payload"]["status"] == "running"
+
+            server._set_job_progress(
+                job_id,
+                25.0,
+                message="Transcribing (1 segments)",
+                segments_processed=1,
+            )
+            streamed = _recv_events(ws, {"job.progress", "job.log"})
+            progress = streamed["job.progress"]
+            assert progress["payload"]["progress"] == 25.0
+            assert progress["payload"]["segmentsProcessed"] == 1
+            assert progress["payload"]["message"] == "Transcribing (1 segments)"
+
+            log_event = streamed["job.log"]
+            assert log_event["payload"]["event"] == "job.progress"
+            assert log_event["payload"]["message"] == "Transcribing (1 segments)"
+
+            server._set_job_complete(job_id, {"segments": []}, message="STT complete")
+            complete = _recv_event(ws, "job.complete")
+            assert complete["payload"]["status"] == "complete"
+            assert complete["payload"]["result"] == {"segments": []}
+    finally:
+        sidecar.stop()
+
+
+def test_run_stt_job_streams_provisional_segments_over_websocket(tmp_path, monkeypatch) -> None:
+    server._jobs.clear()
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    audio_path = tmp_path / "speaker.wav"
+    audio_path.write_bytes(b"\0")
+    monkeypatch.setattr(
+        server,
+        "get_stt_provider",
+        lambda: _StreamingStubProvider(
+            partial_segments=[
+                {
+                    "start": 0.0,
+                    "end": 0.4,
+                    "text": "partial one",
+                    "confidence": 0.31,
+                }
+            ],
+            final_segments=[
+                {
+                    "start": 0.0,
+                    "end": 0.5,
+                    "text": "final one",
+                    "confidence": 0.88,
+                }
+            ],
+        ),
+    )
+
+    sidecar = server._start_websocket_sidecar(host="127.0.0.1", port=0)
+    try:
+        job_id = server._create_job("stt", {"speaker": "Fail01", "sourceWav": "speaker.wav"})
+        result_holder: Dict[str, Any] = {}
+
+        def _run() -> None:
+            result_holder["result"] = server._run_stt_job(job_id, "Fail01", "speaker.wav", "ckb")
+
+        with connect(sidecar.job_url(job_id), open_timeout=5, close_timeout=5) as ws:
+            _recv_event(ws, "job.snapshot")
+            thread = threading.Thread(target=_run, daemon=True)
+            thread.start()
+
+            stt_segment = _recv_event(ws, "stt.segment")
+            assert stt_segment["payload"]["provisional"] is True
+            assert stt_segment["payload"]["segment"] == {
+                "start": 0.0,
+                "end": 0.4,
+                "text": "partial one",
+                "confidence": 0.31,
+            }
+
+            progress = _recv_event(ws, "job.progress")
+            assert progress["payload"]["progress"] >= 2.0
+
+            thread.join(timeout=5)
+            assert result_holder["result"]["segments"] == [
+                {
+                    "start": 0.0,
+                    "end": 0.5,
+                    "text": "final one",
+                    "confidence": 0.88,
+                }
+            ]
+    finally:
+        sidecar.stop()

--- a/python/test_websocket_streaming.py
+++ b/python/test_websocket_streaming.py
@@ -4,7 +4,9 @@ import sys
 import threading
 from typing import Any, Dict, Iterable, Optional
 
-from websockets.sync.client import connect
+import pytest
+
+connect = pytest.importorskip("websockets.sync.client").connect
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import server

--- a/python/workers/compute_worker.py
+++ b/python/workers/compute_worker.py
@@ -65,10 +65,12 @@ class WorkerHandle:
         on_progress: Callable[..., None],
         on_complete: Callable[..., None],
         on_error: Callable[[str, str], None],
+        on_stt_segment: Optional[Callable[[str, Dict[str, Any]], None]] = None,
     ) -> None:
         self._on_progress = on_progress
         self._on_complete = on_complete
         self._on_error = on_error
+        self._on_stt_segment = on_stt_segment
         self._ctx = multiprocessing.get_context("spawn")
         self._job_queue: Optional[Any] = None
         self._event_queue: Optional[Any] = None
@@ -226,6 +228,10 @@ class WorkerHandle:
                     except TypeError:
                         combined = err if not tb else "{0}\n{1}".format(err, tb)
                         self._on_error(job_id, combined)
+                elif kind == "stt_segment" and self._on_stt_segment is not None:
+                    segment = event.get("segment")
+                    if isinstance(segment, dict):
+                        self._on_stt_segment(job_id, segment)
             except Exception as exc:
                 print(
                     "[WORKER] monitor handler failed ({0}): {1}".format(kind, exc),
@@ -309,9 +315,20 @@ def _install_parent_emitters(event_queue: Any) -> None:
             traceback=str(traceback_str) if traceback_str else "",
         )
 
+    def _patched_stt_segment(job_id, segment):
+        if not isinstance(segment, dict):
+            return
+        _emit(
+            event_queue,
+            "stt_segment",
+            job_id=job_id,
+            segment=segment,
+        )
+
     server_mod._set_job_progress = _patched_progress
     server_mod._set_job_complete = _patched_complete
     server_mod._set_job_error = _patched_error
+    server_mod._publish_stt_partial_segment = _patched_stt_segment
 
 
 def _install_aligner_preload() -> Any:


### PR DESCRIPTION
## Summary
- add an additive WebSocket job-streaming sidecar on `PARSE_WS_PORT` (default `8767`)
- publish typed per-job events on `ws://<host>:<ws_port>/ws/jobs/{jobId}`
- stream STT progress plus provisional `stt.segment` packets without breaking existing HTTP polling or callbacks
- document the new transport in `AGENTS.md`, `docs/developer-guide.md`, `docs/api-reference.md`, and `docs/mcp_agent_roadmap.md`

## Implementation notes
- keep the existing custom `python/server.py` HTTP stack; no FastAPI/aiohttp migration
- reuse the live in-memory job registry and lifecycle hooks for `job.snapshot`, `job.progress`, `job.log`, `job.complete`, and `job.error`
- extend STT providers with optional `segment_callback` support so partial segments can be pushed during decoding
- relay partial STT packets through the persistent worker path as well as in-process execution
- make websocket tests tolerate valid `job.log` / `job.progress` arrival reordering rather than over-specifying incidental ordering

## Validation
- `python3 -m pytest python/test_websocket_streaming.py python/test_external_api_surface.py python/test_run_stt_job.py -q`
- `npm run test -- --run`
- `./node_modules/.bin/tsc --noEmit`

## Results
- targeted Python suite: 16 passed
- Vitest suite: 38 files / 240 tests passed
- TypeScript compile: passed

## Notes
- existing frontend/browser polling remains unchanged; this PR adds an optional realtime transport rather than switching the client over to WebSockets
- existing Vitest output still includes pre-existing React Router future-flag warnings and `localStorage is not defined` stderr from tag-store persistence tests
