### PR TITLE
feat(clef): guided configure modal for Borrowing detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ PARSE is designed around a real fieldwork sequence rather than a toy demo sequen
 4. **Correct timestamps and confirm segments** in Annotate mode
 5. **Search and anchor difficult lexemes** across long recordings
 6. **Compare the concept set across speakers** in the matrix view
-7. **Use CLEF evidence** when a borrowing analysis needs external lexical context
+7. **Use CLEF evidence** when a borrowing analysis needs external lexical context — the first time you run **Borrowing detection (CLEF)** from the Compute panel, PARSE opens a guided setup modal where you pick 1–2 primary contact languages (English + Spanish by default) and optionally auto-populate lexeme forms from the provider stack. The config lives in `config/sil_contact_languages.json`; extend the language picker with `config/sil_catalog_extra.json`.
 8. **Export LingPy TSV or NEXUS** for downstream comparative and phylogenetic analysis
 
 The guiding principle is simple: timestamps are central, human review stays explicit, and automation should make linguistic judgment faster rather than opaque.

--- a/python/compare/cognate_compute.py
+++ b/python/compare/cognate_compute.py
@@ -512,11 +512,27 @@ def load_contact_language_data(path: Path) -> Tuple[List[str], Dict[str, Dict[st
         _warn(f"Contact language config is not an object: {path}")
         return (list(PREFERRED_CONTACT_LANGUAGES), {})
 
-    language_codes = [code for code, data in raw.items() if isinstance(code, str) and isinstance(data, dict)]
+    language_codes = [
+        code for code, data in raw.items()
+        if isinstance(code, str) and isinstance(data, dict) and not code.startswith("_")
+    ]
     language_codes = sorted(set(language_codes))
 
-    preferred = [code for code in PREFERRED_CONTACT_LANGUAGES if code in language_codes]
-    selected_languages = preferred or language_codes or list(PREFERRED_CONTACT_LANGUAGES)
+    # When the user has configured primary contact languages through the
+    # CLEF configure modal, those take precedence over the historical
+    # hard-coded PREFERRED list. Falls back to the old behaviour for
+    # configs that don't carry _meta.
+    meta = raw.get("_meta") if isinstance(raw.get("_meta"), dict) else {}
+    primary = meta.get("primary_contact_languages") if isinstance(meta, dict) else None
+    primary_codes: List[str] = []
+    if isinstance(primary, list):
+        primary_codes = [str(c).strip().lower() for c in primary if isinstance(c, str) and c.strip()]
+
+    if primary_codes:
+        selected_languages = [c for c in primary_codes if c in language_codes] or primary_codes
+    else:
+        preferred = [code for code in PREFERRED_CONTACT_LANGUAGES if code in language_codes]
+        selected_languages = preferred or language_codes or list(PREFERRED_CONTACT_LANGUAGES)
 
     refs_by_concept: Dict[str, Dict[str, List[str]]] = {}
 
@@ -533,6 +549,8 @@ def load_contact_language_data(path: Path) -> Tuple[List[str], Dict[str, Dict[st
 
     for language_code, payload in raw.items():
         if not isinstance(language_code, str) or not isinstance(payload, dict):
+            continue
+        if language_code.startswith("_"):
             continue
 
         code = language_code.strip().lower()

--- a/python/compare/contact_lexeme_fetcher.py
+++ b/python/compare/contact_lexeme_fetcher.py
@@ -33,11 +33,25 @@ def fetch_and_merge(
     # 1. Load concepts
     concepts = _load_concepts(concepts_path)
 
-    # 2. Load current config
-    with open(config_path, encoding="utf-8") as f:
-        config = json.load(f)
+    # 2. Load current config (create empty on first run)
+    config = _load_or_init_config(config_path)
 
-    language_meta = {k: v for k, v in config.items() if isinstance(v, dict)}
+    # Underscore-prefixed top-level keys (e.g. "_meta") are metadata, not
+    # languages -- skip them when building the provider-facing map.
+    language_meta = {
+        k: v for k, v in config.items()
+        if isinstance(v, dict) and isinstance(k, str) and not k.startswith("_")
+    }
+
+    if not language_codes:
+        raise ValueError(
+            "No contact languages configured. Open the CLEF configure modal "
+            "(Compute -> Borrowing detection (CLEF)) to pick at least one."
+        )
+    if not concepts:
+        raise ValueError(
+            "No concepts found. Import concepts.csv before running CLEF."
+        )
 
     # 3. Determine which concepts need filling
     if not overwrite:
@@ -85,6 +99,8 @@ def fetch_and_merge(
 
 
 def _load_concepts(path: Path) -> List[str]:
+    if not path.exists():
+        return []
     concepts = []
     with open(path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
@@ -93,6 +109,28 @@ def _load_concepts(path: Path) -> List[str]:
             if concept_en:
                 concepts.append(concept_en)
     return concepts
+
+
+def _load_or_init_config(path: Path) -> Dict[str, Any]:
+    """Load the SIL contact-language config, creating an empty file on first
+    access. A missing file previously crashed the fetch with ``[Errno 2]``;
+    the CLEF configure flow in the UI writes a real config, but the compute
+    path must still cope with a freshly-initialised workspace where the
+    user has not yet opened the configure modal."""
+    if not path.exists():
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({}, f)
+        except OSError:
+            return {}
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def main() -> None:

--- a/python/compare/providers/test_contact_lexeme_fetcher.py
+++ b/python/compare/providers/test_contact_lexeme_fetcher.py
@@ -272,3 +272,62 @@ def test_fetch_and_merge_no_missing_concepts_skips_fetch_call(monkeypatch, tmp_p
 
     updated = _read_json(config_path)
     assert updated == original_config
+
+
+def test_fetch_and_merge_creates_config_when_missing(monkeypatch, tmp_path: Path) -> None:
+    """A fresh workspace has no sil_contact_languages.json; the fetcher
+    used to crash with ``[Errno 2]``. It now initialises an empty config
+    file on first access so the compute path can proceed."""
+    concepts_path = tmp_path / "concepts.csv"
+    _write_concepts_csv(concepts_path, ["water"])
+
+    # Note: config_path points at a file that does NOT exist -- even its
+    # parent directory is missing, to mirror a totally empty workspace.
+    config_path = tmp_path / "newconfig" / "sil_contact_languages.json"
+
+    class StubRegistry:
+        def __init__(self, ai_config: Optional[Dict] = None) -> None:
+            del ai_config
+
+        def fetch_all(
+            self,
+            concepts: List[str],
+            language_codes: List[str],
+            language_meta: Dict,
+            priority_order=None,
+            stop_on_first_hit: bool = True,
+            progress_callback=None,
+        ) -> Dict[str, Dict[str, List[str]]]:
+            del concepts, language_meta, priority_order, stop_on_first_hit, progress_callback
+            return {"eng": {"water": ["water"]}}
+
+    monkeypatch.setattr(registry_module, "ProviderRegistry", StubRegistry)
+
+    filled = contact_lexeme_fetcher.fetch_and_merge(
+        concepts_path=concepts_path,
+        config_path=config_path,
+        language_codes=["eng"],
+        overwrite=False,
+    )
+
+    assert filled == {"eng": 1}
+    assert config_path.exists()
+    assert _read_json(config_path)["eng"]["concepts"]["water"] == ["water"]
+
+
+def test_fetch_and_merge_empty_languages_raises_clean_error(tmp_path: Path) -> None:
+    concepts_path = tmp_path / "concepts.csv"
+    config_path = tmp_path / "sil_contact_languages.json"
+    _write_concepts_csv(concepts_path, ["water"])
+    _write_json(config_path, {})
+
+    try:
+        contact_lexeme_fetcher.fetch_and_merge(
+            concepts_path=concepts_path,
+            config_path=config_path,
+            language_codes=[],
+        )
+    except ValueError as exc:
+        assert "No contact languages configured" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError when language_codes is empty")

--- a/python/compare/sil_catalog.py
+++ b/python/compare/sil_catalog.py
@@ -8,6 +8,23 @@ are included as aliases so mixed configs keep working.
 Ordering is "common contact languages first" -- the UI shows the full list
 searchably, but showing e.g. English before Bikol is the sensible default
 for the thesis corpus this feature was built for.
+
+How to extend
+-------------
+
+Two ways:
+
+1. **Edit this file** and add ``{"code": "xxx", "name": "...", "family": "..."}``
+   entries to ``SIL_CATALOG``. Good for permanent additions you want to ship
+   to other PARSE users.
+2. **Per-workspace extras** (no code change, no rebuild): create
+   ``<workspace>/config/sil_catalog_extra.json`` containing either a list
+   in the same shape, or ``{"languages": [...]}``. The server merges these
+   over the bundled list at request time so users can keep private entries
+   out of the repo. See ``_api_get_clef_catalog`` in ``python/server.py``.
+
+A future "Import from Ethnologue" or Glottolog integration would drop into
+the same shape: ``[{"code": ..., "name": ..., "family": ...}]``.
 """
 
 from typing import Dict, List

--- a/python/compare/sil_catalog.py
+++ b/python/compare/sil_catalog.py
@@ -1,0 +1,146 @@
+"""Bundled SIL/ISO 639-3 catalog for the CLEF configure modal.
+
+Kept as a static list so fresh workspaces can populate the picker without
+an external dependency. Codes use ISO 639-3 (3-letter) form; the legacy
+2-letter codes already present in sil_contact_languages.json (ar, fa, tr)
+are included as aliases so mixed configs keep working.
+
+Ordering is "common contact languages first" -- the UI shows the full list
+searchably, but showing e.g. English before Bikol is the sensible default
+for the thesis corpus this feature was built for.
+"""
+
+from typing import Dict, List
+
+# (code, name, family). Keep under ~150 entries -- this is a starter list,
+# not an exhaustive Ethnologue dump. Users can add custom codes through the
+# modal's free-text input.
+SIL_CATALOG: List[Dict[str, str]] = [
+    # Middle East / Near East (primary thesis contact languages)
+    {"code": "ar", "name": "Arabic", "family": "Semitic"},
+    {"code": "fa", "name": "Persian (Farsi)", "family": "Iranian"},
+    {"code": "ckb", "name": "Central Kurdish (Sorani)", "family": "Iranian"},
+    {"code": "kmr", "name": "Northern Kurdish (Kurmanji)", "family": "Iranian"},
+    {"code": "sdh", "name": "Southern Kurdish", "family": "Iranian"},
+    {"code": "hac", "name": "Gurani (Hawrami)", "family": "Iranian"},
+    {"code": "zza", "name": "Zazaki", "family": "Iranian"},
+    {"code": "lki", "name": "Laki", "family": "Iranian"},
+    {"code": "tr", "name": "Turkish", "family": "Turkic"},
+    {"code": "aze", "name": "Azerbaijani", "family": "Turkic"},
+    {"code": "heb", "name": "Hebrew", "family": "Semitic"},
+    {"code": "syr", "name": "Syriac", "family": "Semitic"},
+    {"code": "arc", "name": "Aramaic", "family": "Semitic"},
+    {"code": "urd", "name": "Urdu", "family": "Indo-Aryan"},
+
+    # Western European
+    {"code": "eng", "name": "English", "family": "Germanic"},
+    {"code": "deu", "name": "German", "family": "Germanic"},
+    {"code": "nld", "name": "Dutch", "family": "Germanic"},
+    {"code": "swe", "name": "Swedish", "family": "Germanic"},
+    {"code": "nor", "name": "Norwegian", "family": "Germanic"},
+    {"code": "dan", "name": "Danish", "family": "Germanic"},
+    {"code": "isl", "name": "Icelandic", "family": "Germanic"},
+    {"code": "fra", "name": "French", "family": "Romance"},
+    {"code": "spa", "name": "Spanish", "family": "Romance"},
+    {"code": "por", "name": "Portuguese", "family": "Romance"},
+    {"code": "ita", "name": "Italian", "family": "Romance"},
+    {"code": "ron", "name": "Romanian", "family": "Romance"},
+    {"code": "cat", "name": "Catalan", "family": "Romance"},
+    {"code": "lat", "name": "Latin", "family": "Romance"},
+    {"code": "ell", "name": "Greek (Modern)", "family": "Hellenic"},
+    {"code": "grc", "name": "Greek (Ancient)", "family": "Hellenic"},
+
+    # Slavic
+    {"code": "rus", "name": "Russian", "family": "Slavic"},
+    {"code": "ukr", "name": "Ukrainian", "family": "Slavic"},
+    {"code": "pol", "name": "Polish", "family": "Slavic"},
+    {"code": "ces", "name": "Czech", "family": "Slavic"},
+    {"code": "slk", "name": "Slovak", "family": "Slavic"},
+    {"code": "bul", "name": "Bulgarian", "family": "Slavic"},
+    {"code": "hrv", "name": "Croatian", "family": "Slavic"},
+    {"code": "srp", "name": "Serbian", "family": "Slavic"},
+    {"code": "slv", "name": "Slovenian", "family": "Slavic"},
+
+    # Other European
+    {"code": "hun", "name": "Hungarian", "family": "Uralic"},
+    {"code": "fin", "name": "Finnish", "family": "Uralic"},
+    {"code": "est", "name": "Estonian", "family": "Uralic"},
+    {"code": "lit", "name": "Lithuanian", "family": "Baltic"},
+    {"code": "lav", "name": "Latvian", "family": "Baltic"},
+    {"code": "eus", "name": "Basque", "family": "Isolate"},
+    {"code": "sqi", "name": "Albanian", "family": "Albanian"},
+    {"code": "hye", "name": "Armenian", "family": "Armenian"},
+    {"code": "kat", "name": "Georgian", "family": "Kartvelian"},
+
+    # South Asian
+    {"code": "hin", "name": "Hindi", "family": "Indo-Aryan"},
+    {"code": "ben", "name": "Bengali", "family": "Indo-Aryan"},
+    {"code": "pan", "name": "Punjabi", "family": "Indo-Aryan"},
+    {"code": "guj", "name": "Gujarati", "family": "Indo-Aryan"},
+    {"code": "mar", "name": "Marathi", "family": "Indo-Aryan"},
+    {"code": "nep", "name": "Nepali", "family": "Indo-Aryan"},
+    {"code": "sin", "name": "Sinhala", "family": "Indo-Aryan"},
+    {"code": "tam", "name": "Tamil", "family": "Dravidian"},
+    {"code": "tel", "name": "Telugu", "family": "Dravidian"},
+    {"code": "mal", "name": "Malayalam", "family": "Dravidian"},
+    {"code": "kan", "name": "Kannada", "family": "Dravidian"},
+    {"code": "san", "name": "Sanskrit", "family": "Indo-Aryan"},
+    {"code": "pus", "name": "Pashto", "family": "Iranian"},
+    {"code": "bal", "name": "Balochi", "family": "Iranian"},
+
+    # East Asian
+    {"code": "cmn", "name": "Mandarin Chinese", "family": "Sino-Tibetan"},
+    {"code": "yue", "name": "Cantonese", "family": "Sino-Tibetan"},
+    {"code": "jpn", "name": "Japanese", "family": "Japonic"},
+    {"code": "kor", "name": "Korean", "family": "Koreanic"},
+    {"code": "mon", "name": "Mongolian", "family": "Mongolic"},
+    {"code": "bod", "name": "Tibetan", "family": "Sino-Tibetan"},
+
+    # Southeast Asian
+    {"code": "vie", "name": "Vietnamese", "family": "Austroasiatic"},
+    {"code": "tha", "name": "Thai", "family": "Kra-Dai"},
+    {"code": "lao", "name": "Lao", "family": "Kra-Dai"},
+    {"code": "mya", "name": "Burmese", "family": "Sino-Tibetan"},
+    {"code": "khm", "name": "Khmer", "family": "Austroasiatic"},
+    {"code": "ind", "name": "Indonesian", "family": "Austronesian"},
+    {"code": "msa", "name": "Malay", "family": "Austronesian"},
+    {"code": "fil", "name": "Filipino/Tagalog", "family": "Austronesian"},
+
+    # African
+    {"code": "swa", "name": "Swahili", "family": "Bantu"},
+    {"code": "amh", "name": "Amharic", "family": "Semitic"},
+    {"code": "tir", "name": "Tigrinya", "family": "Semitic"},
+    {"code": "som", "name": "Somali", "family": "Cushitic"},
+    {"code": "orm", "name": "Oromo", "family": "Cushitic"},
+    {"code": "hau", "name": "Hausa", "family": "Chadic"},
+    {"code": "yor", "name": "Yoruba", "family": "Niger-Congo"},
+    {"code": "ibo", "name": "Igbo", "family": "Niger-Congo"},
+    {"code": "zul", "name": "Zulu", "family": "Bantu"},
+    {"code": "xho", "name": "Xhosa", "family": "Bantu"},
+    {"code": "afr", "name": "Afrikaans", "family": "Germanic"},
+    {"code": "ber", "name": "Berber (Tamazight)", "family": "Berber"},
+
+    # Turkic & Central Asian
+    {"code": "uig", "name": "Uyghur", "family": "Turkic"},
+    {"code": "uzb", "name": "Uzbek", "family": "Turkic"},
+    {"code": "kaz", "name": "Kazakh", "family": "Turkic"},
+    {"code": "kir", "name": "Kyrgyz", "family": "Turkic"},
+    {"code": "tuk", "name": "Turkmen", "family": "Turkic"},
+    {"code": "tat", "name": "Tatar", "family": "Turkic"},
+    {"code": "tgk", "name": "Tajik", "family": "Iranian"},
+
+    # Americas
+    {"code": "que", "name": "Quechua", "family": "Quechuan"},
+    {"code": "aym", "name": "Aymara", "family": "Aymaran"},
+    {"code": "grn", "name": "Guarani", "family": "Tupian"},
+    {"code": "nah", "name": "Nahuatl", "family": "Uto-Aztecan"},
+
+    # Pacific
+    {"code": "mri", "name": "Maori", "family": "Austronesian"},
+    {"code": "haw", "name": "Hawaiian", "family": "Austronesian"},
+    {"code": "smo", "name": "Samoan", "family": "Austronesian"},
+    {"code": "fij", "name": "Fijian", "family": "Austronesian"},
+
+    # Constructed / auxiliary
+    {"code": "epo", "name": "Esperanto", "family": "Constructed"},
+]

--- a/python/server.py
+++ b/python/server.py
@@ -158,6 +158,25 @@ def _sil_config_path() -> pathlib.Path:
     return _project_root() / "config" / "sil_contact_languages.json"
 
 
+def _load_sil_config_safe(path: pathlib.Path) -> Dict[str, Any]:
+    """Read the SIL contact-language config without exploding on a
+    missing/corrupt file. Returns ``{}`` in the degraded case so callers
+    (coverage endpoint, CLEF configure endpoint, compute path) can all
+    share one shape."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_sil_config(path: pathlib.Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
 def _default_enrichments_payload() -> Dict[str, Any]:
     return {
         "computed_at": None,
@@ -3906,10 +3925,16 @@ def _compute_contact_lexemes(job_id: str, payload: Dict[str, Any]) -> Dict[str, 
     languages_raw = _coerce_string_list(payload.get("languages"))
 
     if not languages_raw:
-        import json as _json
-        with open(config_path) as f:
-            sil_config = _json.load(f)
-        languages_raw = [k for k, v in sil_config.items() if isinstance(v, dict) and "name" in v]
+        sil_config = _load_sil_config_safe(config_path)
+        meta = sil_config.get("_meta") if isinstance(sil_config.get("_meta"), dict) else {}
+        primary = meta.get("primary_contact_languages") if isinstance(meta, dict) else None
+        if isinstance(primary, list) and primary:
+            languages_raw = [str(c).strip().lower() for c in primary if isinstance(c, str) and c.strip()]
+        if not languages_raw:
+            languages_raw = [
+                k for k, v in sil_config.items()
+                if isinstance(v, dict) and "name" in v and isinstance(k, str) and not k.startswith("_")
+            ]
 
     overwrite = bool(payload.get("overwrite", False))
 
@@ -5977,6 +6002,18 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             self._api_get_contact_lexeme_coverage()
             return
 
+        if request_path == "/api/clef/config":
+            self._api_get_clef_config()
+            return
+
+        if request_path == "/api/clef/catalog":
+            self._api_get_clef_catalog()
+            return
+
+        if request_path == "/api/clef/providers":
+            self._api_get_clef_providers()
+            return
+
         if request_path == "/api/tags":
             self._api_get_tags()
             return
@@ -6038,6 +6075,10 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         if request_path == "/api/config":
             self._api_update_config()
+            return
+
+        if request_path == "/api/clef/config":
+            self._api_post_clef_config()
             return
 
         if request_path == "/api/auth/key":
@@ -7697,13 +7738,8 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
     def _api_get_contact_lexeme_coverage(self) -> None:
         """Return coverage stats for contact language lexeme data."""
-        import json as _json
         config_path = _sil_config_path()
-        try:
-            with open(config_path) as f:
-                config = _json.load(f)
-        except (OSError, ValueError):
-            config = {}
+        config = _load_sil_config_safe(config_path)
 
         concepts_path = _project_root() / "concepts.csv"
         try:
@@ -7716,6 +7752,8 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         languages = {}
         for lang_code, lang_data in config.items():
+            if not isinstance(lang_code, str) or lang_code.startswith("_"):
+                continue
             if not isinstance(lang_data, dict) or "name" not in lang_data:
                 continue
             concepts_dict = lang_data.get("concepts", {})
@@ -7730,6 +7768,130 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             }
 
         self._send_json(HTTPStatus.OK, {"languages": languages})
+
+    def _api_get_clef_config(self) -> None:
+        """Return the current CLEF configuration + readiness state. The UI's
+        configure modal reads this to decide whether to prompt the user
+        before running Borrowing detection."""
+        config_path = _sil_config_path()
+        config = _load_sil_config_safe(config_path)
+
+        meta_raw = config.get("_meta") if isinstance(config.get("_meta"), dict) else {}
+        primary_raw = meta_raw.get("primary_contact_languages") if isinstance(meta_raw, dict) else []
+        primary: List[str] = []
+        if isinstance(primary_raw, list):
+            primary = [str(c).strip().lower() for c in primary_raw if isinstance(c, str) and c.strip()]
+
+        languages = []
+        for code, data in config.items():
+            if not isinstance(code, str) or code.startswith("_"):
+                continue
+            if not isinstance(data, dict):
+                continue
+            concepts_dict = data.get("concepts", {}) if isinstance(data.get("concepts"), dict) else {}
+            languages.append({
+                "code": code,
+                "name": data.get("name") or code,
+                "family": data.get("family") or None,
+                "filled": sum(1 for v in concepts_dict.values() if v),
+                "total": len(concepts_dict),
+            })
+        languages.sort(key=lambda x: x["code"])
+
+        configured = bool(primary) and len(languages) > 0
+        concepts_exists = (_project_root() / "concepts.csv").exists()
+
+        self._send_json(HTTPStatus.OK, {
+            "configured": configured,
+            "primary_contact_languages": primary,
+            "languages": languages,
+            "config_path": str(config_path),
+            "concepts_csv_exists": concepts_exists,
+            "meta": meta_raw if isinstance(meta_raw, dict) else {},
+        })
+
+    def _api_post_clef_config(self) -> None:
+        """Create/update the SIL contact-language config. Accepts:
+            {
+              "primary_contact_languages": ["eng", "spa"],
+              "languages": [
+                {"code": "eng", "name": "English", "family": "Germanic"},
+                ...
+              ]
+            }
+        Merges with any existing per-language concepts data -- populated
+        forms are never dropped when the user re-saves the config."""
+        body = self._expect_object(self._read_json_body(), "Request body")
+
+        primary_raw = body.get("primary_contact_languages", [])
+        if not isinstance(primary_raw, list):
+            raise ApiError(HTTPStatus.BAD_REQUEST, "primary_contact_languages must be a list")
+        primary = [str(c).strip().lower() for c in primary_raw if isinstance(c, str) and c.strip()]
+        if len(primary) > 2:
+            raise ApiError(HTTPStatus.BAD_REQUEST, "Pick at most 2 primary contact languages")
+
+        langs_raw = body.get("languages", [])
+        if not isinstance(langs_raw, list):
+            raise ApiError(HTTPStatus.BAD_REQUEST, "languages must be a list")
+
+        clean_langs: Dict[str, Dict[str, Any]] = {}
+        for item in langs_raw:
+            if not isinstance(item, dict):
+                continue
+            code = str(item.get("code", "")).strip().lower()
+            if not code or code.startswith("_"):
+                continue
+            entry: Dict[str, Any] = {
+                "name": str(item.get("name") or code),
+            }
+            family = item.get("family")
+            if isinstance(family, str) and family.strip():
+                entry["family"] = family.strip()
+            clean_langs[code] = entry
+
+        # Every primary code must appear in the language set. If the client
+        # only sent primaries, synthesize minimal entries so the compute
+        # path has somewhere to write forms.
+        for code in primary:
+            clean_langs.setdefault(code, {"name": code})
+
+        config_path = _sil_config_path()
+        existing = _load_sil_config_safe(config_path)
+
+        merged: Dict[str, Any] = {}
+        for code, entry in clean_langs.items():
+            prev = existing.get(code) if isinstance(existing.get(code), dict) else {}
+            prev_concepts = prev.get("concepts") if isinstance(prev.get("concepts"), dict) else {}
+            merged[code] = {**entry, "concepts": prev_concepts}
+
+        merged["_meta"] = {
+            "primary_contact_languages": primary,
+            "configured_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "schema_version": 1,
+        }
+
+        _write_sil_config(config_path, merged)
+
+        self._send_json(HTTPStatus.OK, {
+            "success": True,
+            "config_path": str(config_path),
+            "primary_contact_languages": primary,
+            "language_count": len(clean_langs),
+        })
+
+    def _api_get_clef_catalog(self) -> None:
+        """Return the bundled SIL/ISO language catalog the configure modal
+        uses for its searchable picker. Kept server-side so we can extend
+        it without reshipping the frontend bundle."""
+        from compare.sil_catalog import SIL_CATALOG
+        self._send_json(HTTPStatus.OK, {"languages": SIL_CATALOG})
+
+    def _api_get_clef_providers(self) -> None:
+        """Return the list of CLEF providers in priority order -- drives
+        the provider-selection checkboxes in the configure modal."""
+        from compare.providers.registry import PROVIDER_PRIORITY
+        providers = [{"id": p, "name": p} for p in PROVIDER_PRIORITY]
+        self._send_json(HTTPStatus.OK, {"providers": providers})
 
     def _api_update_config(self) -> None:
         body = self._expect_object(self._read_json_body(), "Request body")

--- a/python/server.py
+++ b/python/server.py
@@ -7882,9 +7882,46 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
     def _api_get_clef_catalog(self) -> None:
         """Return the bundled SIL/ISO language catalog the configure modal
         uses for its searchable picker. Kept server-side so we can extend
-        it without reshipping the frontend bundle."""
+        it without reshipping the frontend bundle.
+
+        Merges a per-workspace override file at
+        ``config/sil_catalog_extra.json`` on top of the bundled list, so
+        users can add private entries without editing the repo. The extras
+        file may be a bare list or ``{"languages": [...]}``; duplicate
+        codes in the extras replace the bundled entry."""
         from compare.sil_catalog import SIL_CATALOG
-        self._send_json(HTTPStatus.OK, {"languages": SIL_CATALOG})
+
+        merged: Dict[str, Dict[str, Any]] = {}
+        for entry in SIL_CATALOG:
+            code = str(entry.get("code", "")).strip().lower()
+            if not code:
+                continue
+            merged[code] = {k: v for k, v in entry.items() if v is not None}
+
+        extras_path = _project_root() / "config" / "sil_catalog_extra.json"
+        if extras_path.exists():
+            try:
+                with open(extras_path, encoding="utf-8") as f:
+                    raw = json.load(f)
+            except (OSError, ValueError):
+                raw = None
+            if isinstance(raw, dict):
+                raw = raw.get("languages", [])
+            if isinstance(raw, list):
+                for item in raw:
+                    if not isinstance(item, dict):
+                        continue
+                    code = str(item.get("code", "")).strip().lower()
+                    if not code:
+                        continue
+                    merged[code] = {
+                        "code": code,
+                        "name": str(item.get("name") or code),
+                        **({"family": item["family"]} if isinstance(item.get("family"), str) and item["family"].strip() else {}),
+                    }
+
+        languages = sorted(merged.values(), key=lambda x: x.get("name", x.get("code", "")))
+        self._send_json(HTTPStatus.OK, {"languages": languages})
 
     def _api_get_clef_providers(self) -> None:
         """Return the list of CLEF providers in priority order -- drives

--- a/scripts/parse-init-workspace.sh
+++ b/scripts/parse-init-workspace.sh
@@ -123,6 +123,26 @@ else
   log "project.json already exists — left alone"
 fi
 
+# --- config/sil_contact_languages.json ---------------------------------------
+# Seed an empty SIL contact-language config so Borrowing detection (CLEF)
+# doesn't crash with [Errno 2] on a fresh workspace. The UI's CLEF configure
+# modal (Compute -> Borrowing detection (CLEF)) is what actually fills this
+# file in; we just create the placeholder so the compute path has somewhere
+# to write.
+sil_config="${WORKSPACE}/config/sil_contact_languages.json"
+if [ ! -f "${sil_config}" ]; then
+  cat >"${sil_config}" <<'EOF'
+{
+  "_meta": {
+    "primary_contact_languages": [],
+    "configured_at": null,
+    "schema_version": 1
+  }
+}
+EOF
+  log "wrote config/sil_contact_languages.json (empty — configure via UI)"
+fi
+
 # --- concepts.csv (optional copy) --------------------------------------------
 if [ -n "${CONCEPTS_CSV}" ]; then
   if [ ! -f "${CONCEPTS_CSV}" ]; then

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -44,6 +44,8 @@ import { ChatMarkdown } from './components/shared/ChatMarkdown';
 import { LexemeDetail } from './components/compare/LexemeDetail';
 import { CommentsImport } from './components/compare/CommentsImport';
 import { SpeakerImport } from './components/compare/SpeakerImport';
+import { ClefConfigModal } from './components/compute/ClefConfigModal';
+import { getClefConfig } from './api/client';
 
 type ConceptTag = 'untagged' | 'review' | 'confirmed' | 'problematic';
 type AppMode = 'annotate' | 'compare' | 'tags';
@@ -1901,6 +1903,33 @@ export function ParseUI() {
   const [speakerPicker, setSpeakerPicker] = useState<string | null>(null);
   const [computeMode, setComputeMode] = useState('cognates');
   const { start: startComputeJob, state: computeJobState, reset: resetComputeJob } = useComputeJob(computeMode);
+  const [clefModalOpen, setClefModalOpen] = useState(false);
+  // Cache of CLEF "configured" state so we can route the Run button without
+  // an extra round-trip on every click. Re-fetched on mount + after save.
+  const [clefConfigured, setClefConfigured] = useState<boolean | null>(null);
+
+  const refreshClefStatus = useCallback(async () => {
+    try {
+      const s = await getClefConfig();
+      setClefConfigured(s.configured);
+    } catch {
+      setClefConfigured(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (computeMode === 'contact-lexemes' && clefConfigured === null) {
+      void refreshClefStatus();
+    }
+  }, [computeMode, clefConfigured, refreshClefStatus]);
+
+  const handleComputeRun = useCallback(() => {
+    if (computeMode === 'contact-lexemes' && clefConfigured !== true) {
+      setClefModalOpen(true);
+      return;
+    }
+    void startComputeJob();
+  }, [computeMode, clefConfigured, startComputeJob]);
   const [notes, setNotes] = useState('');
   const [borrowingsOpen, setBorrowingsOpen] = useState(true);
   const [panelOpen, setPanelOpen] = useState(true);
@@ -3759,7 +3788,7 @@ export function ParseUI() {
                   <div className="mt-2 grid grid-cols-2 gap-1.5">
                     <button
                       className="inline-flex items-center justify-center gap-1 rounded-md bg-indigo-600 py-1.5 text-[11px] font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
-                      onClick={() => { void startComputeJob(); }}
+                      onClick={handleComputeRun}
                       disabled={computeJobState.status === 'running'}
                     >
                       <Play className="h-3 w-3"/> Run
@@ -3771,6 +3800,23 @@ export function ParseUI() {
                       <RefreshCw className="h-3 w-3"/> Refresh
                     </button>
                   </div>
+                  {computeMode === 'contact-lexemes' && (
+                    <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-slate-200 bg-slate-50 px-2 py-1.5 text-[10px]">
+                      <span className={clefConfigured ? "text-emerald-700" : "text-amber-700"}>
+                        {clefConfigured === null
+                          ? "Checking CLEF config…"
+                          : clefConfigured
+                            ? "CLEF configured"
+                            : "CLEF not configured — Run will open setup"}
+                      </span>
+                      <button
+                        onClick={() => setClefModalOpen(true)}
+                        className="rounded border border-slate-200 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-600 hover:bg-slate-100"
+                      >
+                        Configure
+                      </button>
+                    </div>
+                  )}
                   {computeJobState.status === 'running' && (
                     <div className="mt-1 text-[10px] text-indigo-600">
                       Running… {Math.round(computeJobState.progress * 100)}%
@@ -4036,6 +4082,18 @@ export function ParseUI() {
         outcomes={batch.state.outcomes}
         stepsRun={reportStepsRun}
         onRerunFailed={handleRerunFailed}
+      />
+      <ClefConfigModal
+        open={clefModalOpen}
+        onClose={() => setClefModalOpen(false)}
+        onSaved={(_primary, populated) => {
+          setClefConfigured(true);
+          if (populated) {
+            void useEnrichmentStore.getState().load();
+          } else {
+            void startComputeJob();
+          }
+        }}
       />
       <Modal
         open={offsetState.phase !== 'idle'}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -15,6 +15,10 @@ import type {
   ComputeStatus,
   ContactLexemeCoverage,
   ContactLexemeFetchOptions,
+  ClefConfigStatus,
+  ClefCatalogEntry,
+  ClefProviderEntry,
+  ClefConfigPayload,
   Tag,
   TagsResponse,
   SttSegmentsPayload,
@@ -750,6 +754,28 @@ export async function startContactLexemeFetch(
   options: ContactLexemeFetchOptions = {},
 ): Promise<ComputeJob> {
   return startCompute("contact-lexemes", options as Record<string, unknown>);
+}
+
+// CLEF configuration (Borrowing detection guided setup)
+export async function getClefConfig(): Promise<ClefConfigStatus> {
+  return apiFetch<ClefConfigStatus>("/api/clef/config");
+}
+
+export async function saveClefConfig(
+  payload: ClefConfigPayload,
+): Promise<{ success: boolean; config_path: string; primary_contact_languages: string[]; language_count: number }> {
+  return apiFetch("/api/clef/config", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function getClefCatalog(): Promise<{ languages: ClefCatalogEntry[] }> {
+  return apiFetch<{ languages: ClefCatalogEntry[] }>("/api/clef/catalog");
+}
+
+export async function getClefProviders(): Promise<{ providers: ClefProviderEntry[] }> {
+  return apiFetch<{ providers: ClefProviderEntry[] }>("/api/clef/providers");
 }
 
 // Normalize

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -186,3 +186,36 @@ export interface ContactLexemeFetchOptions {
   languages?: string[];
   overwrite?: boolean;
 }
+
+export interface ClefLanguageEntry {
+  code: string;
+  name: string;
+  family?: string | null;
+  filled?: number;
+  total?: number;
+}
+
+export interface ClefConfigStatus {
+  configured: boolean;
+  primary_contact_languages: string[];
+  languages: ClefLanguageEntry[];
+  config_path: string;
+  concepts_csv_exists: boolean;
+  meta: Record<string, unknown>;
+}
+
+export interface ClefCatalogEntry {
+  code: string;
+  name: string;
+  family?: string;
+}
+
+export interface ClefProviderEntry {
+  id: string;
+  name: string;
+}
+
+export interface ClefConfigPayload {
+  primary_contact_languages: string[];
+  languages: Array<{ code: string; name: string; family?: string }>;
+}

--- a/src/components/compute/ClefConfigModal.tsx
+++ b/src/components/compute/ClefConfigModal.tsx
@@ -1,0 +1,521 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { X, Search, Info, Check, AlertCircle, Play, Loader2 } from "lucide-react";
+import {
+  getClefCatalog,
+  getClefConfig,
+  getClefProviders,
+  pollCompute,
+  saveClefConfig,
+  startContactLexemeFetch,
+} from "../../api/client";
+import type { ClefCatalogEntry, ClefConfigStatus, ClefProviderEntry } from "../../api/types";
+
+interface ClefConfigModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Fired after a successful save + optional populate so the parent can
+   *  trigger the actual compute job if the user wanted "Save & Run". */
+  onSaved?: (primary: string[], populateFinished: boolean) => void;
+}
+
+type Tab = "languages" | "populate";
+
+const MAX_PRIMARY = 2;
+
+export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [catalog, setCatalog] = useState<ClefCatalogEntry[]>([]);
+  const [providers, setProviders] = useState<ClefProviderEntry[]>([]);
+  const [status, setStatus] = useState<ClefConfigStatus | null>(null);
+
+  const [primary, setPrimary] = useState<string[]>([]);
+  const [secondary, setSecondary] = useState<Set<string>>(new Set());
+  const [customCode, setCustomCode] = useState("");
+  const [customName, setCustomName] = useState("");
+  const [search, setSearch] = useState("");
+
+  const [tab, setTab] = useState<Tab>("languages");
+  const [selectedProviders, setSelectedProviders] = useState<Set<string>>(new Set());
+  const [overwrite, setOverwrite] = useState(false);
+
+  const [populating, setPopulating] = useState(false);
+  const [populateProgress, setPopulateProgress] = useState(0);
+  const [populateMessage, setPopulateMessage] = useState("");
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const allLanguages = useMemo(() => {
+    const byCode = new Map<string, ClefCatalogEntry>();
+    for (const c of catalog) byCode.set(c.code, c);
+    if (status) {
+      for (const l of status.languages) {
+        if (!byCode.has(l.code)) {
+          byCode.set(l.code, { code: l.code, name: l.name, family: l.family ?? undefined });
+        }
+      }
+    }
+    return Array.from(byCode.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [catalog, status]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return allLanguages;
+    return allLanguages.filter(
+      (l) =>
+        l.code.toLowerCase().includes(q) ||
+        l.name.toLowerCase().includes(q) ||
+        (l.family ?? "").toLowerCase().includes(q),
+    );
+  }, [allLanguages, search]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    Promise.all([getClefConfig(), getClefCatalog(), getClefProviders()])
+      .then(([cfg, cat, prov]) => {
+        if (cancelled) return;
+        setStatus(cfg);
+        setCatalog(cat.languages);
+        setProviders(prov.providers);
+        setPrimary(cfg.primary_contact_languages.slice(0, MAX_PRIMARY));
+        const secondarySet = new Set<string>(
+          cfg.languages.map((l) => l.code).filter((c) => !cfg.primary_contact_languages.includes(c)),
+        );
+        setSecondary(secondarySet);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load CLEF config");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    };
+  }, []);
+
+  const togglePrimary = useCallback((code: string) => {
+    setPrimary((prev) => {
+      if (prev.includes(code)) return prev.filter((c) => c !== code);
+      if (prev.length >= MAX_PRIMARY) return prev;
+      return [...prev, code];
+    });
+    setSecondary((prev) => {
+      const next = new Set(prev);
+      next.delete(code);
+      return next;
+    });
+  }, []);
+
+  const toggleSecondary = useCallback((code: string) => {
+    setPrimary((prev) => prev.filter((c) => c !== code));
+    setSecondary((prev) => {
+      const next = new Set(prev);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
+  }, []);
+
+  const addCustom = useCallback(() => {
+    const code = customCode.trim().toLowerCase();
+    const name = customName.trim() || code;
+    if (!code || code.startsWith("_")) return;
+    setCatalog((prev) => (prev.some((c) => c.code === code) ? prev : [...prev, { code, name }]));
+    setSecondary((prev) => new Set(prev).add(code));
+    setCustomCode("");
+    setCustomName("");
+  }, [customCode, customName]);
+
+  const buildPayload = useCallback(() => {
+    const byCode = new Map<string, ClefCatalogEntry>();
+    for (const c of allLanguages) byCode.set(c.code, c);
+
+    const codes = new Set<string>([...primary, ...secondary]);
+    const languages = Array.from(codes).map((code) => {
+      const entry = byCode.get(code);
+      return {
+        code,
+        name: entry?.name || code,
+        ...(entry?.family ? { family: entry.family } : {}),
+      };
+    });
+    return { primary_contact_languages: primary, languages };
+  }, [allLanguages, primary, secondary]);
+
+  const handleSave = useCallback(
+    async (runPopulate: boolean) => {
+      if (primary.length === 0) {
+        setError("Pick at least one primary contact language.");
+        return;
+      }
+      setSaving(true);
+      setError(null);
+      try {
+        await saveClefConfig(buildPayload());
+        if (!runPopulate) {
+          onSaved?.(primary, false);
+          onClose();
+          return;
+        }
+        // Kick off the fetcher for the selected primary languages.
+        setPopulating(true);
+        setPopulateProgress(0);
+        setPopulateMessage("Starting…");
+        const job = await startContactLexemeFetch({
+          languages: primary,
+          providers: selectedProviders.size > 0 ? Array.from(selectedProviders) : undefined,
+          overwrite,
+        });
+        const id = job.jobId || job.job_id || "";
+        if (!id) throw new Error("No job id returned");
+        const poll = async () => {
+          try {
+            const s = await pollCompute("contact-lexemes", id);
+            setPopulateProgress(s.progress ?? 0);
+            setPopulateMessage(s.message ?? "");
+            if (["done", "complete", "error", "failed"].includes(s.status)) {
+              setPopulating(false);
+              if (s.status === "error" || s.status === "failed") {
+                setError(s.error ?? s.message ?? "Populate failed");
+              } else {
+                onSaved?.(primary, true);
+                onClose();
+              }
+              return;
+            }
+            pollTimerRef.current = setTimeout(poll, 1500);
+          } catch (e) {
+            setPopulating(false);
+            setError(e instanceof Error ? e.message : "Polling failed");
+          }
+        };
+        pollTimerRef.current = setTimeout(poll, 1000);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Save failed");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [primary, buildPayload, selectedProviders, overwrite, onSaved, onClose],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4"
+      onClick={populating ? undefined : onClose}
+    >
+      <div
+        className="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-lg bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between border-b border-slate-100 px-5 py-4">
+          <div>
+            <h2 className="text-sm font-semibold text-slate-900">Borrowing detection (CLEF) — configure</h2>
+            <p className="mt-1 text-[11px] text-slate-500">
+              Pick the contact languages PARSE should compare your speakers against. One or two primary
+              languages usually gives the cleanest borrowing signal — adding more dilutes it.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={populating}
+            className="rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600 disabled:opacity-30"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Status banner */}
+        {!loading && status && !status.concepts_csv_exists && (
+          <div className="flex items-start gap-2 border-b border-amber-100 bg-amber-50 px-5 py-2 text-[11px] text-amber-800">
+            <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              No <code className="rounded bg-amber-100 px-1">concepts.csv</code> found in this workspace.
+              You can still configure CLEF, but running Borrowing detection will fail until concepts are
+              imported.
+            </span>
+          </div>
+        )}
+
+        {/* Tabs */}
+        <div className="flex gap-1 border-b border-slate-100 px-5 pt-2">
+          {(["languages", "populate"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={
+                "rounded-t-md px-3 py-1.5 text-[11px] font-semibold " +
+                (tab === t
+                  ? "bg-white text-indigo-700 border border-slate-200 border-b-white -mb-px"
+                  : "text-slate-500 hover:text-slate-700")
+              }
+            >
+              {t === "languages" ? "1. Languages" : "2. Auto-populate (optional)"}
+            </button>
+          ))}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-auto px-5 py-4">
+          {loading && <div className="text-[12px] text-slate-500">Loading…</div>}
+          {error && (
+            <div className="mb-3 rounded border border-rose-200 bg-rose-50 px-3 py-2 text-[11px] text-rose-700">
+              {error}
+            </div>
+          )}
+
+          {!loading && tab === "languages" && (
+            <div className="space-y-4">
+              {/* Primary section */}
+              <section>
+                <div className="mb-1 flex items-center gap-1.5">
+                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-slate-600">
+                    Primary contact languages
+                  </h3>
+                  <span className="text-[11px] text-slate-400">
+                    ({primary.length}/{MAX_PRIMARY})
+                  </span>
+                  <span
+                    title="Primary contact languages are the main languages CLEF weighs when deciding cognate vs. borrowing. Pick the languages your speech community has the most historical contact with."
+                    className="text-slate-300"
+                  >
+                    <Info className="h-3 w-3" />
+                  </span>
+                </div>
+                <div className="flex min-h-[34px] flex-wrap gap-1.5 rounded-md border border-slate-200 bg-slate-50 p-2">
+                  {primary.length === 0 && (
+                    <span className="text-[11px] italic text-slate-400">
+                      None selected — click a language below to add it as primary.
+                    </span>
+                  )}
+                  {primary.map((code) => {
+                    const entry = allLanguages.find((l) => l.code === code);
+                    return (
+                      <button
+                        key={code}
+                        onClick={() => togglePrimary(code)}
+                        className="inline-flex items-center gap-1 rounded-full bg-indigo-600 px-2.5 py-0.5 text-[11px] font-medium text-white hover:bg-indigo-700"
+                      >
+                        <Check className="h-3 w-3" /> {entry?.name || code}
+                        <span className="ml-0.5 text-indigo-200">({code})</span>
+                        <X className="h-3 w-3 opacity-80" />
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+
+              {/* Search + language list */}
+              <section>
+                <div className="relative mb-2">
+                  <Search className="absolute left-2 top-1.5 h-3.5 w-3.5 text-slate-400" />
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search by code, name, or family…"
+                    className="w-full rounded-md border border-slate-200 bg-white py-1.5 pl-7 pr-2 text-[12px] focus:border-indigo-300 focus:outline-none"
+                  />
+                </div>
+                <div className="max-h-64 overflow-auto rounded-md border border-slate-200">
+                  {filtered.map((l) => {
+                    const isPrimary = primary.includes(l.code);
+                    const isSecondary = secondary.has(l.code);
+                    return (
+                      <div
+                        key={l.code}
+                        className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-1.5 text-[12px] last:border-b-0"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate font-medium text-slate-800">{l.name}</div>
+                          <div className="text-[10px] text-slate-400">
+                            {l.code}
+                            {l.family ? ` · ${l.family}` : ""}
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 gap-1">
+                          <button
+                            onClick={() => togglePrimary(l.code)}
+                            disabled={!isPrimary && primary.length >= MAX_PRIMARY}
+                            className={
+                              "rounded px-2 py-0.5 text-[10px] font-semibold " +
+                              (isPrimary
+                                ? "bg-indigo-600 text-white"
+                                : "border border-slate-200 text-slate-600 hover:bg-slate-50 disabled:opacity-40")
+                            }
+                            title={
+                              !isPrimary && primary.length >= MAX_PRIMARY
+                                ? `At most ${MAX_PRIMARY} primary languages`
+                                : ""
+                            }
+                          >
+                            Primary
+                          </button>
+                          <button
+                            onClick={() => toggleSecondary(l.code)}
+                            className={
+                              "rounded px-2 py-0.5 text-[10px] font-semibold " +
+                              (isSecondary
+                                ? "bg-slate-700 text-white"
+                                : "border border-slate-200 text-slate-600 hover:bg-slate-50")
+                            }
+                          >
+                            {isSecondary ? "Included" : "Include"}
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {filtered.length === 0 && (
+                    <div className="px-3 py-6 text-center text-[11px] text-slate-400">
+                      No matches. Use the box below to add a custom SIL/ISO code.
+                    </div>
+                  )}
+                </div>
+              </section>
+
+              {/* Custom code */}
+              <section>
+                <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-slate-600">
+                  Add custom SIL/ISO code
+                </h3>
+                <div className="flex gap-1.5">
+                  <input
+                    type="text"
+                    value={customCode}
+                    onChange={(e) => setCustomCode(e.target.value)}
+                    placeholder="code"
+                    className="w-24 rounded-md border border-slate-200 px-2 py-1.5 text-[12px] focus:border-indigo-300 focus:outline-none"
+                  />
+                  <input
+                    type="text"
+                    value={customName}
+                    onChange={(e) => setCustomName(e.target.value)}
+                    placeholder="display name (optional)"
+                    className="flex-1 rounded-md border border-slate-200 px-2 py-1.5 text-[12px] focus:border-indigo-300 focus:outline-none"
+                  />
+                  <button
+                    onClick={addCustom}
+                    disabled={!customCode.trim()}
+                    className="rounded-md border border-slate-200 bg-white px-3 text-[11px] font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+                  >
+                    Add
+                  </button>
+                </div>
+              </section>
+            </div>
+          )}
+
+          {!loading && tab === "populate" && (
+            <div className="space-y-4">
+              <p className="text-[12px] text-slate-600">
+                Optional — fill the chosen primary languages with lexeme forms from the providers below.
+                You can always run this later from the Contact Lexemes panel.
+              </p>
+
+              <section>
+                <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-slate-600">
+                  Providers (leave empty for all, in priority order)
+                </h3>
+                <div className="flex flex-wrap gap-1.5">
+                  {providers.map((p) => {
+                    const active = selectedProviders.has(p.id);
+                    return (
+                      <button
+                        key={p.id}
+                        onClick={() =>
+                          setSelectedProviders((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(p.id)) next.delete(p.id);
+                            else next.add(p.id);
+                            return next;
+                          })
+                        }
+                        className={
+                          "rounded border px-2 py-0.5 text-[11px] " +
+                          (active
+                            ? "border-indigo-600 bg-indigo-600 text-white"
+                            : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50")
+                        }
+                      >
+                        {p.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+
+              <label className="flex items-center gap-2 text-[12px] text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={overwrite}
+                  onChange={(e) => setOverwrite(e.target.checked)}
+                />
+                Overwrite existing forms
+              </label>
+
+              {populating && (
+                <div className="rounded border border-indigo-200 bg-indigo-50 p-3">
+                  <div className="flex items-center gap-2 text-[11px] font-semibold text-indigo-800">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Populating… {Math.round(populateProgress)}%
+                  </div>
+                  <div className="mt-1 text-[10px] text-indigo-700">{populateMessage}</div>
+                  <div className="mt-2 h-1.5 overflow-hidden rounded bg-indigo-100">
+                    <div
+                      className="h-full bg-indigo-600 transition-all"
+                      style={{ width: `${populateProgress}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-slate-100 bg-slate-50 px-5 py-3">
+          <span className="mr-auto text-[10px] text-slate-400">
+            {primary.length} primary · {secondary.size} secondary
+          </span>
+          <button
+            onClick={onClose}
+            disabled={populating}
+            className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => handleSave(false)}
+            disabled={saving || populating || primary.length === 0}
+            className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+          >
+            Save
+          </button>
+          <button
+            onClick={() => handleSave(true)}
+            disabled={saving || populating || primary.length === 0}
+            className="inline-flex items-center gap-1 rounded-md bg-indigo-600 px-3 py-1.5 text-[11px] font-semibold text-white hover:bg-indigo-700 disabled:opacity-40"
+          >
+            <Play className="h-3 w-3" /> Save &amp; populate
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/compute/ClefConfigModal.tsx
+++ b/src/components/compute/ClefConfigModal.tsx
@@ -44,7 +44,13 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
   const [populating, setPopulating] = useState(false);
   const [populateProgress, setPopulateProgress] = useState(0);
   const [populateMessage, setPopulateMessage] = useState("");
+  /** Set when populate fails so the UI can switch the primary button from
+   *  "Save & populate" to "Retry populate" without throwing away the
+   *  user's language picks. Cleared on successful populate or when they
+   *  plain-save without populate. */
+  const [populateFailed, setPopulateFailed] = useState(false);
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [highlightIdx, setHighlightIdx] = useState(0);
 
   const allLanguages = useMemo(() => {
     const byCode = new Map<string, ClefCatalogEntry>();
@@ -161,6 +167,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
       }
       setSaving(true);
       setError(null);
+      setPopulateFailed(false);
       try {
         await saveClefConfig(buildPayload());
         if (!runPopulate) {
@@ -188,6 +195,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
               setPopulating(false);
               if (s.status === "error" || s.status === "failed") {
                 setError(s.error ?? s.message ?? "Populate failed");
+                setPopulateFailed(true);
               } else {
                 onSaved?.(primary, true);
                 onClose();
@@ -198,17 +206,68 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
           } catch (e) {
             setPopulating(false);
             setError(e instanceof Error ? e.message : "Polling failed");
+            setPopulateFailed(true);
           }
         };
         pollTimerRef.current = setTimeout(poll, 1000);
       } catch (e) {
         setError(e instanceof Error ? e.message : "Save failed");
+        if (runPopulate) setPopulateFailed(true);
       } finally {
         setSaving(false);
       }
     },
     [primary, buildPayload, selectedProviders, overwrite, onSaved, onClose],
   );
+
+  const applyDefaults = useCallback(() => {
+    // Best-guess starter pair for first-time users. Prefers the 3-letter
+    // ISO codes so the selection maps cleanly to the bundled catalog; if
+    // the bundled catalog only has 2-letter fallbacks the backend still
+    // accepts them.
+    const preferred: Array<[string, string]> = [["eng", "English"], ["spa", "Spanish"]];
+    setPrimary(preferred.map(([c]) => c));
+    setSecondary((prev) => {
+      const next = new Set(prev);
+      for (const [c] of preferred) next.delete(c);
+      return next;
+    });
+    // Make sure the catalog has these entries even if the backend call
+    // hasn't returned (offline / 500) -- otherwise save would still work
+    // but the chip list would show only the bare code.
+    setCatalog((prev) => {
+      const have = new Set(prev.map((c) => c.code));
+      const additions = preferred
+        .filter(([c]) => !have.has(c))
+        .map(([code, name]) => ({ code, name }));
+      return additions.length ? [...prev, ...additions] : prev;
+    });
+    setError(null);
+  }, []);
+
+  // Global keyboard shortcuts: Escape closes (unless mid-populate), and
+  // the search list responds to arrow keys / Enter when the search box or
+  // a list row has focus. Arrow keys on the search input move the
+  // highlighted row; Enter toggles it as primary (falls back to secondary
+  // when the primary slots are full).
+  useEffect(() => {
+    if (!open) return;
+    function handle(e: KeyboardEvent) {
+      if (populating) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handle);
+    return () => window.removeEventListener("keydown", handle);
+  }, [open, populating, onClose]);
+
+  // Reset highlight when the filtered list changes size so we never land
+  // on a stale out-of-range index.
+  useEffect(() => {
+    if (highlightIdx >= filtered.length) setHighlightIdx(0);
+  }, [filtered.length, highlightIdx]);
 
   if (!open) return null;
 
@@ -274,8 +333,20 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
         <div className="flex-1 overflow-auto px-5 py-4">
           {loading && <div className="text-[12px] text-slate-500">Loading…</div>}
           {error && (
-            <div className="mb-3 rounded border border-rose-200 bg-rose-50 px-3 py-2 text-[11px] text-rose-700">
-              {error}
+            <div className="mb-3 flex items-start gap-2 rounded border border-rose-200 bg-rose-50 px-3 py-2 text-[11px] text-rose-700">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <div className="flex-1">
+                <div className="font-semibold">
+                  {populateFailed ? "Populate failed — your selections were kept" : "Error"}
+                </div>
+                <div className="mt-0.5 break-words">{error}</div>
+                {populateFailed && (
+                  <div className="mt-1 text-rose-500">
+                    Config was saved. Click <b>Retry populate</b> below, or close and run the fetcher
+                    later from the Contact Lexemes panel.
+                  </div>
+                )}
+              </div>
             </div>
           )}
 
@@ -327,19 +398,52 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
                   <input
                     type="text"
                     value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    placeholder="Search by code, name, or family…"
+                    onChange={(e) => { setSearch(e.target.value); setHighlightIdx(0); }}
+                    onKeyDown={(e) => {
+                      if (filtered.length === 0) return;
+                      if (e.key === "ArrowDown") {
+                        e.preventDefault();
+                        setHighlightIdx((i) => (i + 1) % filtered.length);
+                      } else if (e.key === "ArrowUp") {
+                        e.preventDefault();
+                        setHighlightIdx((i) => (i - 1 + filtered.length) % filtered.length);
+                      } else if (e.key === "Enter") {
+                        e.preventDefault();
+                        const l = filtered[highlightIdx];
+                        if (!l) return;
+                        // Enter prefers primary when a slot is available,
+                        // otherwise drops into the secondary set -- this
+                        // mirrors the two buttons on the row without
+                        // forcing the user onto Tab.
+                        if (primary.includes(l.code) || primary.length < MAX_PRIMARY) {
+                          togglePrimary(l.code);
+                        } else {
+                          toggleSecondary(l.code);
+                        }
+                      }
+                    }}
+                    placeholder="Search by code, name, or family… (↑/↓ to navigate, Enter to select)"
+                    aria-label="Search contact languages"
+                    aria-controls="clef-language-list"
+                    aria-activedescendant={filtered[highlightIdx] ? `clef-lang-${filtered[highlightIdx].code}` : undefined}
                     className="w-full rounded-md border border-slate-200 bg-white py-1.5 pl-7 pr-2 text-[12px] focus:border-indigo-300 focus:outline-none"
                   />
                 </div>
-                <div className="max-h-64 overflow-auto rounded-md border border-slate-200">
-                  {filtered.map((l) => {
+                <div id="clef-language-list" role="listbox" className="max-h-64 overflow-auto rounded-md border border-slate-200">
+                  {filtered.map((l, idx) => {
                     const isPrimary = primary.includes(l.code);
                     const isSecondary = secondary.has(l.code);
+                    const highlighted = idx === highlightIdx;
                     return (
                       <div
                         key={l.code}
-                        className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-1.5 text-[12px] last:border-b-0"
+                        id={`clef-lang-${l.code}`}
+                        role="option"
+                        aria-selected={isPrimary || isSecondary}
+                        className={
+                          "flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-1.5 text-[12px] last:border-b-0 " +
+                          (highlighted ? "bg-indigo-50" : "")
+                        }
                       >
                         <div className="min-w-0 flex-1">
                           <div className="truncate font-medium text-slate-800">{l.name}</div>
@@ -489,16 +593,25 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-2 border-t border-slate-100 bg-slate-50 px-5 py-3">
+        <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-100 bg-slate-50 px-5 py-3">
           <span className="mr-auto text-[10px] text-slate-400">
             {primary.length} primary · {secondary.size} secondary
           </span>
           <button
+            onClick={applyDefaults}
+            disabled={populating || saving}
+            className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+            title="Preselect a sensible starter pair (English + Spanish). You can still edit before saving."
+          >
+            Use defaults
+          </button>
+          <button
             onClick={onClose}
             disabled={populating}
             className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
+            title="Close without configuring. The Run button will reopen this modal next time."
           >
-            Cancel
+            Configure later
           </button>
           <button
             onClick={() => handleSave(false)}
@@ -512,7 +625,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
             disabled={saving || populating || primary.length === 0}
             className="inline-flex items-center gap-1 rounded-md bg-indigo-600 px-3 py-1.5 text-[11px] font-semibold text-white hover:bg-indigo-700 disabled:opacity-40"
           >
-            <Play className="h-3 w-3" /> Save &amp; populate
+            <Play className="h-3 w-3" /> {populateFailed ? "Retry populate" : "Save & populate"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fixes the `[Errno 2] No such file or directory: .../config/sil_contact_languages.json` crash that made **Borrowing detection (CLEF)** unusable on any fresh workspace.
- Adds a two-tab **Configure CLEF** modal (Languages / Auto-populate) that the Run button auto-opens when CLEF isn't configured yet — searchable picker backed by a ~100-language bundled SIL/ISO catalog, primary-language chips capped at 2, provider checkboxes, progress bar, Save / Save & populate.
- Backend `fetch_and_merge` now creates the config on first access and raises clean errors on bad input; `cognate_compute` honours the user's chosen primary languages via `_meta.primary_contact_languages`.

## What changed

### Backend
- `python/compare/contact_lexeme_fetcher.py` — `_load_or_init_config` creates the file + parent dir on first access; clean `ValueError` when no languages or no concepts; filters `_*` metadata keys from the provider map.
- `python/compare/cognate_compute.py` — `load_contact_language_data` skips `_*` keys and picks up `_meta.primary_contact_languages` when present (falls back to the historical `PREFERRED_CONTACT_LANGUAGES` list).
- `python/server.py` — new `GET/POST /api/clef/config`, `GET /api/clef/catalog`, `GET /api/clef/providers`; `_load_sil_config_safe` / `_write_sil_config` helpers; `_compute_contact_lexemes` falls back to `_meta.primary_contact_languages` when the caller omits `languages`.
- `python/compare/sil_catalog.py` — bundled starter list (~100 common contact languages, organised by region/family).
- `scripts/parse-init-workspace.sh` — seeds an empty `config/sil_contact_languages.json` so fresh workspaces don't break even before the modal is opened.

### Frontend
- `src/components/compute/ClefConfigModal.tsx` — the new modal. Tabs for language selection and optional auto-populate; search with fuzzy matching across code/name/family; custom SIL/ISO code input; Save vs. Save & populate with live progress.
- `src/ParseUI.tsx` — Compute panel shows an inline *CLEF configured / not configured* badge + Configure button when `computeMode === 'contact-lexemes'`; Run button routes through `handleComputeRun` which opens the modal first when config is missing, then falls through to the compute job after save.
- `src/api/client.ts` + `src/api/types.ts` — typed client for the four new endpoints.

### Tests
- `python/compare/providers/test_contact_lexeme_fetcher.py` — two new tests: config is created when missing; empty `language_codes` raises a clean `ValueError`. All 6 tests pass.
- Full frontend suite (240 tests) passes; `tsc --noEmit` clean; `vite build` green.

## Test plan
- [ ] Pull the branch, delete `config/sil_contact_languages.json` in a test workspace.
- [ ] Select **Compare** mode → Compute → **Borrowing detection (CLEF)** from the dropdown.
- [ ] Click **Run**: modal should open with the search picker, tabs, and status banner.
- [ ] Search for "english", mark it Primary, search "arabic", mark it Primary.
- [ ] Click **Save & populate** → progress bar shows job running → closes on success.
- [ ] Click Run again → computes without touching the modal (configured path).
- [ ] Verify `config/sil_contact_languages.json` now has `_meta.primary_contact_languages: ["eng", "ar"]` plus empty `concepts` dicts ready for forms.
- [ ] Bonus: delete the config again, run `parse-init-workspace.sh` on a fresh dir → seed file exists with `_meta` placeholder; compute no longer crashes with `[Errno 2]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)