### PR TITLE
docs: refresh README and top-level docs for PRs 201-212

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It combines:
 - **Tier 2 forced alignment** with wav2vec2 for tighter word-level boundaries
 - **Per-speaker undo/redo** for annotation edits, including merge recovery and STT-tier migration
 - **Draggable timestamp correction** and clip-bounded playback for manual review
-- **Batch transcription** with preflight checks and rerun-failed support
+- **Batch transcription** with preflight checks, per-step **Keep / Overwrite** scope controls, and rerun-failed support
 - **Timestamp-offset detection/apply workflows** for constant CSV↔audio misalignment, now with async progress, crash-log surfacing, and protection for manually adjusted / anchored lexemes
 - **Search & anchor lexeme** tooling built on the Lexical Anchor Alignment System
 - **Shared tags** and the in-session **AI chat dock**
@@ -88,11 +88,12 @@ Supported LLM backends currently include **xAI (Grok)** and **OpenAI**. Local sp
 
 ### MCP & External API
 
-PARSE exposes three machine-facing integration surfaces:
+PARSE exposes four machine-facing integration surfaces:
 
 1. **HTTP API** on `http://localhost:8766`
-2. **HTTP MCP bridge** on the same server for schema discovery + tool execution
-3. **stdio MCP adapter** in `python/adapters/mcp_adapter.py`
+2. **WebSocket job streaming** on `ws://localhost:8767/ws/jobs/{jobId}` (override with `PARSE_WS_PORT`)
+3. **HTTP MCP bridge** on the same server for schema discovery + tool execution
+4. **stdio MCP adapter** in `python/adapters/mcp_adapter.py`
 
 That means external agent clients such as Claude Code, Cursor, Cline, Hermes, Windsurf, Codex, or other MCP-capable tools can call a curated subset of PARSE functions programmatically, without going through the browser UI.
 
@@ -110,6 +111,13 @@ Current counts:
 - `GET /api/jobs/{jobId}/logs` — read structured per-job logs (and crash-log tails when present)
 
 These endpoints back the in-app progress UI, the MCP observability tools, and callback-driven external automation.
+
+#### WebSocket job streaming
+
+- `ws://<host>:<PARSE_WS_PORT or 8767>/ws/jobs/{jobId}`
+- current v1 event types: `job.snapshot`, `job.progress`, `job.log`, `stt.segment`, `job.complete`, `job.error`
+
+Streaming is additive: HTTP polling, callbacks, and MCP observability still work exactly as before.
 
 #### OpenAPI and interactive docs
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ PARSE is designed around a real fieldwork sequence rather than a toy demo sequen
 4. **Correct timestamps and confirm segments** in Annotate mode
 5. **Search and anchor difficult lexemes** across long recordings
 6. **Compare the concept set across speakers** in the matrix view
-7. **Use CLEF evidence** when a borrowing analysis needs external lexical context — the first time you run **Borrowing detection (CLEF)** from the Compute panel, PARSE opens a guided setup modal where you pick 1–2 primary contact languages (English + Spanish by default) and optionally auto-populate lexeme forms from the provider stack. The config lives in `config/sil_contact_languages.json`; extend the language picker with `config/sil_catalog_extra.json`.
+7. **Use CLEF evidence** when a borrowing analysis needs external lexical context — the first time you run **Borrowing detection (CLEF)** from the Compute panel, PARSE opens a guided setup modal where you pick 1–2 primary contact languages (English + Spanish by default) and optionally auto-populate lexeme forms from the provider stack. The config lives in `config/sil_contact_languages.json`; extend the language picker with `config/sil_catalog_extra.json`. Each language now also carries an ISO 15924 `script` hint so bare Reference Forms route deterministically between IPA-like Latin text and non-Latin script text.
 8. **Export LingPy TSV or NEXUS** for downstream comparative and phylogenetic analysis
 
 The guiding principle is simple: timestamps are central, human review stays explicit, and automation should make linguistic judgment faster rather than opaque.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ It provides:
 - A **concept × speaker matrix** for side-by-side lexical comparison
 - Cognate controls for **accept**, **split**, **merge**, and **cycle**
 - Per-row editing, speaker flags, and secondary actions for review work
-- **Borrowing adjudication** aided by contact-language similarity evidence
+- **Borrowing adjudication** aided by contact-language similarity evidence, dynamic primary-language similarity columns, and selectable reference forms
 - **Enrichment overlays** for computed comparative metadata
-- The **CLEF** panel for multi-source contact-language lookup
+- The **CLEF** panel for multi-source contact-language lookup, provenance-aware **Sources Report**, and retryable populate workflows
 - The same shared **tag system** used in Annotate mode
 - Export to **LingPy-compatible TSV** and **NEXUS** for downstream phylogenetic analysis
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -89,6 +89,9 @@ WebSocket streaming is additive. Clients can continue polling `/api/stt/status`,
 | `GET /api/stt-segments/{speaker}` | Read cached STT segments for a speaker | Returns `segments: []` when cache is missing rather than 404 |
 | `GET /api/enrichments` | Read comparative enrichments | Returns `{ enrichments: ... }` |
 | `GET /api/tags` | Read tag definitions and assignments | Shared across Annotate and Compare |
+| `GET /api/clef/config` | Read CLEF language configuration | Returns primary contact languages plus saved catalog entries |
+| `GET /api/clef/catalog` | Read bundled CLEF language catalog | Includes the SIL/ISO-backed picker data for the Configure CLEF modal |
+| `GET /api/clef/providers` | Read available CLEF providers | Returns provider keys, labels, and capability metadata for auto-populate setup |
 | `GET /api/jobs` | List recent backend jobs | Supports status / type / speaker filters and returns generic job snapshots |
 | `GET /api/jobs/active` | List active backend jobs | Used to rehydrate progress after reload |
 | `GET /api/jobs/{jobId}` | Read one backend job | Includes generic status, progress, `errorCode`, `logCount`, and lock metadata |
@@ -159,6 +162,7 @@ WebSocket streaming is additive. Clients can continue polling `/api/stt/status`,
 |---|---|---|
 | `POST /api/enrichments` | Save enrichments | Accepts either `{ enrichments: ... }` or the raw object |
 | `POST /api/config` | Update project configuration | Current server accepts POST as an update path |
+| `POST /api/clef/config` | Save CLEF language configuration | Used by the guided Configure CLEF modal before optional auto-populate |
 | `POST /api/tags/merge` | Merge tag definitions | Shared tag persistence |
 | `POST /api/offset/detect` | Detect a constant timestamp offset | Starts an async compute job with progress updates and crash-log capture |
 | `POST /api/offset/detect-from-pair` | Detect a timestamp offset from trusted manual pairs | STT-free async correction path |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -89,8 +89,8 @@ WebSocket streaming is additive. Clients can continue polling `/api/stt/status`,
 | `GET /api/stt-segments/{speaker}` | Read cached STT segments for a speaker | Returns `segments: []` when cache is missing rather than 404 |
 | `GET /api/enrichments` | Read comparative enrichments | Returns `{ enrichments: ... }` |
 | `GET /api/tags` | Read tag definitions and assignments | Shared across Annotate and Compare |
-| `GET /api/clef/config` | Read CLEF language configuration | Returns primary contact languages plus saved catalog entries |
-| `GET /api/clef/catalog` | Read bundled CLEF language catalog | Includes the SIL/ISO-backed picker data for the Configure CLEF modal |
+| `GET /api/clef/config` | Read CLEF language configuration | Returns primary contact languages plus saved catalog entries, including per-language `script` hints |
+| `GET /api/clef/catalog` | Read bundled CLEF language catalog | Includes the SIL/ISO-backed picker data and ISO 15924 `script` hints for the Configure CLEF modal |
 | `GET /api/clef/providers` | Read available CLEF providers | Returns provider keys, labels, and capability metadata for auto-populate setup |
 | `GET /api/clef/sources-report` | Read CLEF provenance summary | Returns provider-attribution breakdowns and per-form source data for the Sources Report modal |
 | `GET /api/jobs` | List recent backend jobs | Supports status / type / speaker filters and returns generic job snapshots |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -92,6 +92,7 @@ WebSocket streaming is additive. Clients can continue polling `/api/stt/status`,
 | `GET /api/clef/config` | Read CLEF language configuration | Returns primary contact languages plus saved catalog entries |
 | `GET /api/clef/catalog` | Read bundled CLEF language catalog | Includes the SIL/ISO-backed picker data for the Configure CLEF modal |
 | `GET /api/clef/providers` | Read available CLEF providers | Returns provider keys, labels, and capability metadata for auto-populate setup |
+| `GET /api/clef/sources-report` | Read CLEF provenance summary | Returns provider-attribution breakdowns and per-form source data for the Sources Report modal |
 | `GET /api/jobs` | List recent backend jobs | Supports status / type / speaker filters and returns generic job snapshots |
 | `GET /api/jobs/active` | List active backend jobs | Used to rehydrate progress after reload |
 | `GET /api/jobs/{jobId}` | Read one backend job | Includes generic status, progress, `errorCode`, `logCount`, and lock metadata |
@@ -163,6 +164,7 @@ WebSocket streaming is additive. Clients can continue polling `/api/stt/status`,
 | `POST /api/enrichments` | Save enrichments | Accepts either `{ enrichments: ... }` or the raw object |
 | `POST /api/config` | Update project configuration | Current server accepts POST as an update path |
 | `POST /api/clef/config` | Save CLEF language configuration | Used by the guided Configure CLEF modal before optional auto-populate |
+| `POST /api/clef/form-selections` | Save CLEF form selections | Persists which populated reference forms should contribute to similarity scoring |
 | `POST /api/tags/merge` | Merge tag definitions | Shared tag persistence |
 | `POST /api/offset/detect` | Detect a constant timestamp offset | Starts an async compute job with progress updates and crash-log capture |
 | `POST /api/offset/detect-from-pair` | Detect a timestamp offset from trusted manual pairs | STT-free async correction path |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ flowchart LR
     Server --> ChatTools[python/ai/chat_tools.py\n50 PARSE-specific tools]
     Server --> Compare[python/compare/*\ncognates + CLEF providers]
     Server --> Models[local & remote AI providers\nfaster-whisper / wav2vec2 / OpenAI / xAI]
+    Server --> Stream[WebSocket sidecar\nPARSE_WS_PORT + /ws/jobs/{jobId}]
     Server --> External[OpenAPI 3.1 + HTTP MCP bridge\n/openapi.json + /api/mcp/*]
     ChatTools --> MCP[python/adapters/mcp_adapter.py\n32-task MCP surface + 3 workflow macros]
     External --> PyPkg[python/packages/parse_mcp\nLangChain / LlamaIndex / CrewAI wrappers]
@@ -95,6 +96,7 @@ It is responsible for:
 - serving workspace configuration
 - reading and writing annotation records
 - managing background jobs
+- publishing additive WebSocket job events through the sidecar endpoint
 - coordinating STT / normalization / compute endpoints
 - exposing chat and auth routes
 - generating exports

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -390,8 +390,27 @@ A provider change usually touches three layers:
 When extending CLEF:
 
 - keep the provider registry explicit
+- keep the guided config surface aligned with the backend endpoints (`GET/POST /api/clef/config`, `GET /api/clef/catalog`, `GET /api/clef/providers`)
+- remember that fresh workspaces may start without `config/sil_contact_languages.json`; backend init and UI copy should treat that as normal, not as a crash path
+- document any new expectations around `config/sil_catalog_extra.json` if the language picker or catalog merge rules change
 - document new coverage or source assumptions
 - update the provider list in user-facing docs if the provider set changes
+
+## Batch transcription modal semantics
+
+`src/components/shared/TranscriptionRunModal.tsx` now has explicit per-step scope controls when selected speakers already have finalized output.
+
+Current semantics:
+
+- **Keep** (`overwrite=false`) is the default when a step collides with existing output
+- **Overwrite** (`overwrite=true`) must be chosen explicitly per step
+- the collisions bar only appears when the selected speakers actually have finalized output for at least one selected step
+
+When changing this modal:
+
+- keep the user-facing **Keep / Overwrite** wording aligned with the real payload semantics
+- preserve the distinction between no-op keep behavior and destructive overwrite behavior in badges, summary text, and tooltips
+- update `docs/user-guide.md` / `README.md` if the rerun semantics change materially
 
 ## Contributing guidelines
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -391,10 +391,18 @@ When extending CLEF:
 
 - keep the provider registry explicit
 - keep the guided config surface aligned with the backend endpoints (`GET/POST /api/clef/config`, `GET /api/clef/catalog`, `GET /api/clef/providers`)
+- keep the provenance / selection endpoints aligned with the UI surfaces (`GET /api/clef/sources-report`, `POST /api/clef/form-selections`)
 - remember that fresh workspaces may start without `config/sil_contact_languages.json`; backend init and UI copy should treat that as normal, not as a crash path
 - document any new expectations around `config/sil_catalog_extra.json` if the language picker or catalog merge rules change
 - document new coverage or source assumptions
 - update the provider list in user-facing docs if the provider set changes
+
+The current CLEF UI also assumes:
+
+- similarity columns are derived dynamically from `primary_contact_languages`, not hard-coded language slots
+- the Reference Forms panel may show multiple forms per language
+- per-form provenance may be available and should stay visible through the Sources Report modal
+- form-selection state persists in `sil_contact_languages.json._meta.form_selections` and affects downstream similarity scoring
 
 ## Batch transcription modal semantics
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -394,6 +394,7 @@ When extending CLEF:
 - keep the provenance / selection endpoints aligned with the UI surfaces (`GET /api/clef/sources-report`, `POST /api/clef/form-selections`)
 - remember that fresh workspaces may start without `config/sil_contact_languages.json`; backend init and UI copy should treat that as normal, not as a crash path
 - document any new expectations around `config/sil_catalog_extra.json` if the language picker or catalog merge rules change
+- preserve per-language ISO 15924 `script` hints when touching the catalog/config flow; `ClefConfigModal` and `GET/POST /api/clef/config` now round-trip them intentionally
 - document new coverage or source assumptions
 - update the provider list in user-facing docs if the provider set changes
 
@@ -401,6 +402,7 @@ The current CLEF UI also assumes:
 
 - similarity columns are derived dynamically from `primary_contact_languages`, not hard-coded language slots
 - the Reference Forms panel may show multiple forms per language
+- bare-string Reference Forms are routed by explicit provider label first, then language `script` hint, then Unicode-block fallback
 - per-form provenance may be available and should stay visible through the Sources Report modal
 - form-selection state persists in `sil_contact_languages.json._meta.form_selections` and affects downstream similarity scoring
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -236,6 +236,7 @@ The launcher and MCP adapter both rely on a shared set of `PARSE_*` environment 
 | `PARSE_EXTERNAL_READ_ROOTS` | empty | Absolute roots that chat tools may read outside the workspace. Use OS path separators for multiple roots, or `*` to disable the sandbox entirely. |
 | `PARSE_CHAT_READ_ONLY` | empty | Override chat mutability: `1` forces read-only, `0` forces write-enabled. Otherwise PARSE defers to `config/ai_config.json`. |
 | `PARSE_API_PORT` | `8766` | Python API server port. |
+| `PARSE_WS_PORT` | `8767` | Additive WebSocket job-streaming sidecar port for `ws://<host>/ws/jobs/{jobId}` subscriptions. |
 | `PARSE_VITE_PORT` | `5173` | Vite dev server port. |
 | `PARSE_SKIP_PULL` | `0` | Skip the `git pull` step in `parse-run.sh`. |
 | `PARSE_PULL_MODE` | `auto` | Git integration strategy: `auto`, `ff`, `rebase`, or `reset`. |
@@ -274,7 +275,33 @@ npm install   # once per clone
 npm run dev
 ```
 
-The backend runs on `8766`; Vite runs on `5173`.
+The backend runs on `8766`; the optional WebSocket sidecar runs on `8767`; Vite runs on `5173`.
+
+If you want realtime STT/job updates, connect to:
+
+```text
+ws://localhost:8767/ws/jobs/{jobId}
+```
+
+or override the sidecar port with `PARSE_WS_PORT`.
+
+## CLEF configuration on a fresh workspace
+
+Borrowing detection (CLEF) no longer assumes `config/sil_contact_languages.json` already exists.
+
+On the first CLEF run, PARSE opens a guided **Configure CLEF** modal that lets you:
+
+- pick 1–2 primary contact languages
+- search the bundled SIL/ISO catalog
+- save the language config only, or **Save & populate** immediately
+
+The resulting config is written to:
+
+- `config/sil_contact_languages.json`
+
+If you need to extend the picker with extra language rows, add:
+
+- `config/sil_catalog_extra.json`
 
 ## Open in browser
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -295,6 +295,8 @@ On the first CLEF run, PARSE opens a guided **Configure CLEF** modal that lets y
 - search the bundled SIL/ISO catalog
 - save the language config only, or **Save & populate** immediately
 
+Catalog entries now include an ISO 15924 `script` hint, and PARSE persists that hint into the CLEF config so bare Reference Forms can be routed deterministically even when providers return unlabeled raw strings.
+
 The resulting config is written to:
 
 - `config/sil_contact_languages.json`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -239,6 +239,17 @@ It is implemented as a provider-registry workflow under `python/compare/provider
 
 When a lexical item might reflect contact influence rather than straightforward inheritance, CLEF can fetch comparison data from multiple external and local sources, then surface that evidence during Compare-mode review.
 
+Populate jobs now follow the same global-job pattern as other heavy PARSE workflows:
+
+- **Save & populate** closes the modal and moves progress into the shared header status chip
+- a successful populate can trigger an automatic recompute so similarity columns refresh against the newly available reference data
+- empty-populate outcomes surface an explicit banner rather than silently looking like success
+- that banner includes **Retry with different providers** so you can reopen the modal directly on the auto-populate tab
+
+The Compare table and detail views also follow the configured CLEF primaries dynamically: similarity columns are no longer hard-coded to Arabic/Persian, and the **Reference Forms** panel can render multiple forms per language.
+
+Each reference form row has a checkbox. Those selections persist to `sil_contact_languages.json._meta.form_selections`, and only the selected forms contribute to the similarity score.
+
 On a fresh workspace, the first run of **Borrowing detection (CLEF)** now opens a guided **Configure CLEF** modal instead of failing on a missing config file. The modal lets you:
 
 - pick 1–2 primary contact languages
@@ -266,9 +277,17 @@ The saved config lives at `config/sil_contact_languages.json`; optional extra ca
 ### Current CLEF endpoints
 
 - `GET /api/clef/config` — read the current CLEF language configuration
+- `GET /api/clef/sources-report` — read corpus-wide provider provenance for populated reference forms
 - `POST /api/clef/config` — save the CLEF language configuration
+- `POST /api/clef/form-selections` — persist which reference forms should count toward similarity scoring
 - `POST /api/compute/contact-lexemes` — start a contact-lexeme fetch job
 - `GET /api/contact-lexemes/coverage` — inspect current provider coverage
+
+### Sources Report and provenance
+
+The **Sources Report** modal summarizes which providers contributed the currently populated reference forms.
+
+This matters for academic use because CLEF no longer treats the populated form list as an opaque blob. New entries can carry per-form provenance such as `wikidata`, `wiktionary`, `asjp`, or other provider sources, while older bare-string entries remain readable as legacy `unknown` provenance until you explicitly repopulate them.
 
 ## AI Workflow Assistant in daily use
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -250,6 +250,8 @@ The Compare table and detail views also follow the configured CLEF primaries dyn
 
 Each reference form row has a checkbox. Those selections persist to `sil_contact_languages.json._meta.form_selections`, and only the selected forms contribute to the similarity score.
 
+Bare-string reference forms are no longer routed by Unicode guessing alone. Each configured contact language now carries an ISO 15924 `script` hint, so PARSE can decide deterministically whether a raw form should land in the IPA-like slot or the script-text slot. Explicit provider labels (`ipa` / `script`) still win over the hint, and the Unicode-block regex remains only as a fallback for legacy or hint-less entries.
+
 On a fresh workspace, the first run of **Borrowing detection (CLEF)** now opens a guided **Configure CLEF** modal instead of failing on a missing config file. The modal lets you:
 
 - pick 1–2 primary contact languages
@@ -277,6 +279,7 @@ The saved config lives at `config/sil_contact_languages.json`; optional extra ca
 ### Current CLEF endpoints
 
 - `GET /api/clef/config` — read the current CLEF language configuration
+- `GET /api/clef/catalog` — read the bundled CLEF language catalog, including per-language ISO 15924 script hints
 - `GET /api/clef/sources-report` — read corpus-wide provider provenance for populated reference forms
 - `POST /api/clef/config` — save the CLEF language configuration
 - `POST /api/clef/form-selections` — persist which reference forms should count toward similarity scoring

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -107,6 +107,7 @@ The current batch flow includes:
 - preflight pipeline-state checks
 - overwrite warnings
 - explicit ordered steps: **normalize → STT → ORTH → IPA**
+- per-step **Keep / Overwrite** scope toggles when selected speakers already have finalized output
 - step-level failure isolation
 - rerun-failed support
 - a walk-away batch report with expandable tracebacks
@@ -238,6 +239,15 @@ It is implemented as a provider-registry workflow under `python/compare/provider
 
 When a lexical item might reflect contact influence rather than straightforward inheritance, CLEF can fetch comparison data from multiple external and local sources, then surface that evidence during Compare-mode review.
 
+On a fresh workspace, the first run of **Borrowing detection (CLEF)** now opens a guided **Configure CLEF** modal instead of failing on a missing config file. The modal lets you:
+
+- pick 1–2 primary contact languages
+- search a bundled SIL/ISO language catalog
+- enable or disable provider groups before auto-population
+- save the language setup only, or **Save & populate** immediately
+
+The saved config lives at `config/sil_contact_languages.json`; optional extra catalog entries can be provided through `config/sil_catalog_extra.json`.
+
 ### Current provider set (10)
 
 | Provider | Source type |
@@ -255,6 +265,8 @@ When a lexical item might reflect contact influence rather than straightforward 
 
 ### Current CLEF endpoints
 
+- `GET /api/clef/config` — read the current CLEF language configuration
+- `POST /api/clef/config` — save the CLEF language configuration
 - `POST /api/compute/contact-lexemes` — start a contact-lexeme fetch job
 - `GET /api/contact-lexemes/coverage` — inspect current provider coverage
 


### PR DESCRIPTION
## Summary
- audit merged PRs #201-#212 and fold the user-facing changes into top-level docs
- document the WebSocket job-streaming sidecar, guided CLEF configuration flow, per-step Keep/Overwrite run-modal semantics, and the newer CLEF provenance / retry / dynamic-similarity / form-selection / script-hint behavior
- refresh contributor-facing docs so runtime setup, architecture, CLEF extension notes, and the MCP/agent roadmap match current code

## PRs audited
- #201 feat: add websocket job streaming for STT
- #202 feat(clef): guided configure modal for Borrowing detection
- #203 feat(run-modal): explicit per-step scope (keep vs overwrite)
- #205 fix(clef): gate Reference Forms + surface populate in header
- #206 fix(clef): surface empty populate + harden write path
- #207 feat(clef): Retry with different providers button on empty-populate banner
- #208 fix(clef): surface real similarity scores + auto-recompute after populate
- #209 feat(clef): provider provenance + Sources Report modal
- #210 feat(clef): dynamic similarity columns from CLEF primary_contact_languages
- #211 feat(clef): multi-form Reference Forms + selection persistence
- #212 feat(clef): per-language ISO 15924 script hints

## Files updated
- `README.md`
- `docs/api-reference.md`
- `docs/user-guide.md`
- `docs/getting-started.md`
- `docs/developer-guide.md`
- `docs/architecture.md`
- `docs/mcp_agent_roadmap.md`

## Verification
- `git diff --check`
- code-grounded inspection of:
  - `python/server.py`
  - `src/components/compute/ClefConfigModal.tsx`
  - `src/components/shared/TranscriptionRunModal.tsx`
  - `src/ParseUI.tsx`
  - `src/api/client.ts`
- content checks for:
  - WebSocket streaming (`PARSE_WS_PORT`, `ws://.../ws/jobs/{jobId}`)
  - MCP safety metadata / `meta["x-parse"]`
  - CLEF config / provenance / selection endpoints (`/api/clef/config`, `/api/clef/catalog`, `/api/clef/providers`, `/api/clef/sources-report`, `/api/clef/form-selections`)
  - guided CLEF setup / `Save & populate` / retry banner / dynamic similarity columns / multi-form selections
  - per-language ISO 15924 `script` hints for Reference Forms routing
  - per-step `Keep / Overwrite` scope controls
