### PR TITLE
fix(clef): gate Reference Forms + surface populate in header

### DIFF
--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -159,6 +159,28 @@ vi.mock("./stores/uiStore", () => ({
     }),
 }));
 
+// Per-test overrides for the CLEF endpoints. Defaults to "not configured"
+// so the Reference Forms section stays hidden (the production gate). The
+// two reference-forms tests flip these to the configured state.
+let mockClefConfig: {
+  configured: boolean;
+  primary_contact_languages: string[];
+  languages: Array<{ code: string; name: string; family?: string | null; filled?: number; total?: number }>;
+  config_path: string;
+  concepts_csv_exists: boolean;
+  meta: Record<string, unknown>;
+} = {
+  configured: false,
+  primary_contact_languages: [],
+  languages: [],
+  config_path: "",
+  concepts_csv_exists: false,
+  meta: {},
+};
+let mockCoverage: { languages: Record<string, { name: string; total: number; filled: number; empty: number; concepts: Record<string, string[]> }> } = {
+  languages: {},
+};
+
 vi.mock("./api/client", () => ({
   getLingPyExport: vi.fn().mockResolvedValue(''),
   saveApiKey: vi.fn().mockResolvedValue(undefined),
@@ -171,6 +193,8 @@ vi.mock("./api/client", () => ({
   pollSTT: vi.fn().mockResolvedValue({ status: 'running', progress: 0 }),
   pollNormalize: vi.fn().mockResolvedValue({ status: 'running', progress: 0 }),
   pollCompute: vi.fn().mockResolvedValue({ status: 'running', progress: 0 }),
+  getClefConfig: vi.fn(() => Promise.resolve(mockClefConfig)),
+  getContactLexemeCoverage: vi.fn(() => Promise.resolve(mockCoverage)),
 }));
 
 import { ParseUI } from "./ParseUI";
@@ -211,6 +235,17 @@ async function switchToAnnotateMode() {
 
 beforeEach(() => {
   window.localStorage.clear();
+  // Default every test to "CLEF not configured" so the Reference Forms
+  // gate stays closed unless the test opts into the configured state.
+  mockClefConfig = {
+    configured: false,
+    primary_contact_languages: [],
+    languages: [],
+    config_path: "",
+    concepts_csv_exists: false,
+    meta: {},
+  };
+  mockCoverage = { languages: {} };
   mockConfig = {
     project_name: "PARSE",
     language_code: "ku",
@@ -408,7 +443,21 @@ describe("ParseUI", () => {
     expect(mockScrollToTimeAtFraction).toHaveBeenCalledWith(5, 0.33);
   });
 
-  it("renders compare reference forms from enrichment data", () => {
+  it("renders compare reference forms from enrichment data", async () => {
+    // Opt into CLEF-configured state so the Reference Forms section
+    // actually renders. The gate hides the whole section when
+    // primary_contact_languages is empty.
+    mockClefConfig = {
+      configured: true,
+      primary_contact_languages: ["ar", "fa"],
+      languages: [
+        { code: "ar", name: "Arabic" },
+        { code: "fa", name: "Persian" },
+      ],
+      config_path: "",
+      concepts_csv_exists: true,
+      meta: {},
+    };
     mockEnrichmentData = {
       reference_forms: {
         "1": {
@@ -420,7 +469,7 @@ describe("ParseUI", () => {
 
     render(<ParseUI />);
 
-    expect(screen.getByText("ماء")).toBeTruthy();
+    expect(await screen.findByText("ماء")).toBeTruthy();
     expect(screen.getByText("/maːʔ/")).toBeTruthy();
     expect(screen.getByText("آب")).toBeTruthy();
     expect(screen.getByText("/ɒːb/")).toBeTruthy();
@@ -599,9 +648,30 @@ describe("ParseUI", () => {
     expect(screen.queryByText(/\*\*Cannot import speakers/i)).toBeNull();
   });
 
-  it("shows a reference placeholder when enrichmentStore has no reference forms", () => {
+  it("shows a reference placeholder for configured languages with no data", async () => {
+    mockClefConfig = {
+      configured: true,
+      primary_contact_languages: ["ar", "fa"],
+      languages: [
+        { code: "ar", name: "Arabic" },
+        { code: "fa", name: "Persian" },
+      ],
+      config_path: "",
+      concepts_csv_exists: true,
+      meta: {},
+    };
     render(<ParseUI />);
-    expect(screen.getAllByText("No reference data").length).toBeGreaterThanOrEqual(1);
+    const placeholders = await screen.findAllByText("No reference data");
+    expect(placeholders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("hides the Reference Forms section entirely when CLEF is not configured", async () => {
+    render(<ParseUI />);
+    // Wait one tick for the mount effect's getClefConfig() to resolve,
+    // then assert the section's heading and placeholder never appear.
+    await screen.findByRole("button", { name: "Run" });
+    expect(screen.queryByText("Reference forms")).toBeNull();
+    expect(screen.queryByText("No reference data")).toBeNull();
   });
 
   it("restores the xAI provider badge after reload when backend reports provider=xai", async () => {

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -45,7 +45,8 @@ import { LexemeDetail } from './components/compare/LexemeDetail';
 import { CommentsImport } from './components/compare/CommentsImport';
 import { SpeakerImport } from './components/compare/SpeakerImport';
 import { ClefConfigModal } from './components/compute/ClefConfigModal';
-import { getClefConfig } from './api/client';
+import { getClefConfig, getContactLexemeCoverage } from './api/client';
+import type { ClefConfigStatus } from './api/types';
 
 type ConceptTag = 'untagged' | 'review' | 'confirmed' | 'problematic';
 type AppMode = 'annotate' | 'compare' | 'tags';
@@ -282,14 +283,61 @@ function parseReferenceForm(raw: unknown): ReferenceFormDisplay {
   };
 }
 
-function resolveReferenceForms(enrichments: Record<string, unknown>, concept: Concept) {
+/** Resolve reference forms for a concept across a dynamic set of language
+ *  codes (driven by the user's CLEF primary_contact_languages). Checks the
+ *  enrichments.reference_forms map first; falls back to the per-workspace
+ *  SIL contact-language config (what `Save & populate` writes into) so the
+ *  cards surface real data regardless of which store the fetcher wrote to. */
+function resolveReferenceForms(
+  enrichments: Record<string, unknown>,
+  silConcepts: Record<string, Record<string, unknown>>,
+  concept: Concept,
+  codes: string[],
+): Record<string, ReferenceFormDisplay> {
   const root = isRecord(enrichments.reference_forms) ? enrichments.reference_forms as Record<string, unknown> : null;
   const conceptEntry = root ? root[concept.key] ?? root[concept.name] : null;
   const conceptRecord = isRecord(conceptEntry) ? conceptEntry : {};
 
+  const out: Record<string, ReferenceFormDisplay> = {};
+  for (const code of codes) {
+    const primary = parseReferenceForm(conceptRecord[code]);
+    if (primary.available) {
+      out[code] = primary;
+      continue;
+    }
+    // SIL config stores forms as {concept_en: [ipa, ...]} keyed by
+    // language code. parseReferenceForm already handles string / array /
+    // object shapes so we can pass the value straight through.
+    const silForConcept = silConcepts[code]?.[concept.name];
+    out[code] = parseReferenceForm(silForConcept);
+  }
+  return out;
+}
+
+/** Map a language code to a display tone + text direction for the
+ *  Reference Forms cards. Known RTL scripts get `dir="rtl"`; the tone
+ *  cycles over a short palette so two configured primaries always look
+ *  distinct. Falls back to a neutral tone + LTR for anything we don't
+ *  recognise -- good enough until the catalog ships script metadata. */
+const RTL_CODES = new Set([
+  "ar", "arc", "ara",
+  "fa", "pes", "prs",
+  "he", "heb",
+  "ur", "urd",
+  "ckb", "sdh", "sor",
+  "ps", "pus", "pbt",
+  "syr",
+]);
+const CARD_TONES = [
+  "text-rose-500",
+  "text-indigo-500",
+  "text-emerald-500",
+  "text-amber-600",
+];
+function referenceCardStyle(code: string, idx: number): { tone: string; dir: "ltr" | "rtl" } {
   return {
-    arabic: parseReferenceForm(conceptRecord.ar ?? conceptRecord.arabic),
-    persian: parseReferenceForm(conceptRecord.fa ?? conceptRecord.persian),
+    tone: CARD_TONES[idx % CARD_TONES.length],
+    dir: RTL_CODES.has(code.toLowerCase()) ? "rtl" : "ltr",
   };
 }
 
@@ -1904,24 +1952,61 @@ export function ParseUI() {
   const [computeMode, setComputeMode] = useState('cognates');
   const { start: startComputeJob, state: computeJobState, reset: resetComputeJob } = useComputeJob(computeMode);
   const [clefModalOpen, setClefModalOpen] = useState(false);
-  // Cache of CLEF "configured" state so we can route the Run button without
-  // an extra round-trip on every click. Re-fetched on mount + after save.
-  const [clefConfigured, setClefConfigured] = useState<boolean | null>(null);
+  // Full CLEF status so the Reference Forms section can render exactly
+  // the user's configured primary languages (not a hardcoded Arabic +
+  // Persian pair). `null` means "not yet loaded" so the UI can render a
+  // neutral placeholder instead of flashing the configured branch.
+  const [clefStatus, setClefStatus] = useState<ClefConfigStatus | null>(null);
+  // Coverage cache — {[code]: {[concept_en]: string[]}} — so the
+  // Reference Forms cards can surface forms the user just populated via
+  // "Save & populate" without waiting for a full enrichments recompute.
+  const [silConcepts, setSilConcepts] = useState<Record<string, Record<string, unknown>>>({});
+
+  const clefConfigured = clefStatus
+    ? clefStatus.configured && (clefStatus.primary_contact_languages?.length ?? 0) > 0
+    : null;
+  const primaryContactCodes = useMemo(
+    () => (clefStatus?.primary_contact_languages ?? []).map((c) => c.toLowerCase()),
+    [clefStatus],
+  );
+  const contactLanguageNames = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const entry of clefStatus?.languages ?? []) {
+      out[entry.code] = entry.name;
+    }
+    return out;
+  }, [clefStatus]);
 
   const refreshClefStatus = useCallback(async () => {
     try {
-      const s = await getClefConfig();
-      setClefConfigured(s.configured);
+      const [s, coverage] = await Promise.all([
+        getClefConfig(),
+        getContactLexemeCoverage().catch(() => ({ languages: {} as Record<string, { concepts: Record<string, unknown> }> })),
+      ]);
+      setClefStatus(s);
+      const next: Record<string, Record<string, unknown>> = {};
+      for (const [code, lang] of Object.entries(coverage.languages ?? {})) {
+        next[code] = lang.concepts ?? {};
+      }
+      setSilConcepts(next);
     } catch {
-      setClefConfigured(false);
+      setClefStatus({
+        configured: false,
+        primary_contact_languages: [],
+        languages: [],
+        config_path: "",
+        concepts_csv_exists: false,
+        meta: {},
+      });
+      setSilConcepts({});
     }
   }, []);
 
+  // Load CLEF status once on mount so the Reference Forms gate decides
+  // correctly on first render (not only when the user clicks Compute).
   useEffect(() => {
-    if (computeMode === 'contact-lexemes' && clefConfigured === null) {
-      void refreshClefStatus();
-    }
-  }, [computeMode, clefConfigured, refreshClefStatus]);
+    void refreshClefStatus();
+  }, [refreshClefStatus]);
 
   const handleComputeRun = useCallback(() => {
     if (computeMode === 'contact-lexemes' && clefConfigured !== true) {
@@ -2168,11 +2253,20 @@ export function ParseUI() {
     });
   };
 
+  // Single source of truth for the contact-lexemes / CLEF populate job in
+  // the header. Both the "Run Cross-Speaker Match" button (kept for the
+  // legacy compute path) and the CLEF configure modal's Save & populate
+  // action flow through this hook: the modal starts the job, then ParseUI
+  // calls `adopt()` so the header's running-process chip picks it up and
+  // behaves exactly like STT / forced-align / the batch pipeline.
   const crossSpeakerJob = useActionJob({
     start: () => startCompute('contact-lexemes'),
     poll: (id) => pollCompute('contact-lexemes', id),
-    label: 'Matching cross-speaker…',
-    onComplete: loadEnrichments,
+    label: 'Populating CLEF reference data…',
+    onComplete: async () => {
+      await loadEnrichments();
+      await refreshClefStatus();
+    },
   });
 
   const activeJobs = crossSpeakerJob.state.status !== 'idle' ? [crossSpeakerJob] : [];
@@ -2684,8 +2778,8 @@ export function ParseUI() {
 
   const concept = concepts.find(c => c.id === conceptId) ?? concepts[0] ?? { id: 1, key: '1', name: '—', tag: 'untagged' as ConceptTag };
   const referenceForms = useMemo(
-    () => resolveReferenceForms(enrichmentData, concept),
-    [concept, enrichmentData],
+    () => resolveReferenceForms(enrichmentData, silConcepts, concept, primaryContactCodes),
+    [concept, enrichmentData, silConcepts, primaryContactCodes],
   );
   const borrowingCandidates = useMemo<unknown>(() => {
     const borrowingRoot = isRecord(enrichmentData.borrowings) ? enrichmentData.borrowings
@@ -3450,38 +3544,51 @@ export function ParseUI() {
                 </div>
               </div>
 
-              <SectionCard title="Reference forms">
-                <div className="grid grid-cols-2 gap-4">
-                  {[
-                    { label: 'Arabic', tone: 'text-rose-500', dir: 'rtl' as const, data: referenceForms.arabic },
-                    { label: 'Persian', tone: 'text-indigo-500', dir: 'rtl' as const, data: referenceForms.persian },
-                  ].map((entry) => (
-                    <div key={entry.label} className="rounded-lg border border-slate-100 bg-slate-50/40 p-4">
-                      <div className="flex items-center justify-between">
-                        <span className={`text-[10px] font-semibold uppercase tracking-wider ${entry.tone}`}>{entry.label}</span>
-                        <button
-                          title={entry.data.audioUrl ? `Play ${entry.label} reference audio` : 'Reference audio not available'}
-                          onClick={() => {
-                            if (!entry.data.audioUrl) return;
-                            void new Audio(entry.data.audioUrl).play().catch(() => {});
-                          }}
-                          className="text-slate-300 hover:text-slate-500"
-                        >
-                          <Volume2 className="h-3.5 w-3.5"/>
-                        </button>
-                      </div>
-                      {entry.data.available ? (
-                        <>
-                          <div className="mt-2 font-serif text-2xl text-slate-900" dir={entry.dir}>{entry.data.script || '—'}</div>
-                          <div className="mt-1 font-mono text-[11px] text-slate-400">/{entry.data.ipa || '—'}/</div>
-                        </>
-                      ) : (
-                        <div className="mt-2 text-sm text-slate-400">No reference data</div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </SectionCard>
+              {/* Reference forms — gated on the user's CLEF configuration.
+                  Hidden entirely when no primary contact languages are
+                  set; renders exactly one card per configured primary
+                  otherwise. The data source falls back from enrichments
+                  to the SIL contact-language config so forms surface as
+                  soon as "Save & populate" finishes, not only after a
+                  full enrichments recompute. */}
+              {primaryContactCodes.length > 0 && (
+                <SectionCard title="Reference forms">
+                  <div className={`grid gap-4 ${primaryContactCodes.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
+                    {primaryContactCodes.map((code, idx) => {
+                      const { tone, dir } = referenceCardStyle(code, idx);
+                      const label = contactLanguageNames[code] ?? code.toUpperCase();
+                      const data = referenceForms[code] ?? { script: '', ipa: '', audioUrl: null, available: false };
+                      return (
+                        <div key={code} className="rounded-lg border border-slate-100 bg-slate-50/40 p-4" data-testid={`reference-form-${code}`}>
+                          <div className="flex items-center justify-between">
+                            <span className={`text-[10px] font-semibold uppercase tracking-wider ${tone}`}>
+                              {label} <span className="ml-1 font-mono text-slate-300">({code})</span>
+                            </span>
+                            <button
+                              title={data.audioUrl ? `Play ${label} reference audio` : 'Reference audio not available'}
+                              onClick={() => {
+                                if (!data.audioUrl) return;
+                                void new Audio(data.audioUrl).play().catch(() => {});
+                              }}
+                              className="text-slate-300 hover:text-slate-500"
+                            >
+                              <Volume2 className="h-3.5 w-3.5"/>
+                            </button>
+                          </div>
+                          {data.available ? (
+                            <>
+                              <div className="mt-2 font-serif text-2xl text-slate-900" dir={dir}>{data.script || '—'}</div>
+                              <div className="mt-1 font-mono text-[11px] text-slate-400">/{data.ipa || '—'}/</div>
+                            </>
+                          ) : (
+                            <div className="mt-2 text-sm text-slate-400">No reference data</div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </SectionCard>
+              )}
 
               <SectionCard title={`Speaker forms · ${selectedSpeakers.length} selected`}
                 aside={<button className="inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 hover:text-slate-800"><ArrowUpDown className="h-3 w-3"/> Sort by similarity</button>}>
@@ -4086,13 +4193,22 @@ export function ParseUI() {
       <ClefConfigModal
         open={clefModalOpen}
         onClose={() => setClefModalOpen(false)}
-        onSaved={(_primary, populated) => {
-          setClefConfigured(true);
-          if (populated) {
-            void useEnrichmentStore.getState().load();
-          } else {
-            void startComputeJob();
-          }
+        onSaved={() => {
+          // Save-only (no populate): just refresh our cached CLEF status
+          // so the Reference Forms panel re-renders with the new primary
+          // languages. No compute job is started here — the modal's
+          // "Save & populate" button is the only path that triggers work.
+          void refreshClefStatus();
+        }}
+        onPopulateStarted={(jobId) => {
+          // Hand the running contact-lexemes job to crossSpeakerJob so it
+          // surfaces in the global header chip just like STT / IPA /
+          // forced-align / full_pipeline. The onComplete hook on
+          // crossSpeakerJob will reload enrichments + CLEF status when
+          // the backend finishes, so the Reference Forms cards populate
+          // automatically without a manual refresh.
+          void refreshClefStatus();
+          crossSpeakerJob.adopt(jobId);
         }}
       />
       <Modal

--- a/src/components/compute/ClefConfigModal.tsx
+++ b/src/components/compute/ClefConfigModal.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { X, Search, Info, Check, AlertCircle, Play, Loader2 } from "lucide-react";
 import {
   getClefCatalog,
   getClefConfig,
   getClefProviders,
-  pollCompute,
   saveClefConfig,
   startContactLexemeFetch,
 } from "../../api/client";
@@ -13,16 +12,24 @@ import type { ClefCatalogEntry, ClefConfigStatus, ClefProviderEntry } from "../.
 interface ClefConfigModalProps {
   open: boolean;
   onClose: () => void;
-  /** Fired after a successful save + optional populate so the parent can
-   *  trigger the actual compute job if the user wanted "Save & Run". */
-  onSaved?: (primary: string[], populateFinished: boolean) => void;
+  /** Fired after the config is persisted. The parent uses this to refresh
+   *  its cached CLEF status so the Reference Forms panel re-renders with
+   *  the new primary languages. */
+  onSaved?: (primary: string[]) => void;
+  /** Fired when the user picks "Save & populate" and the backend has
+   *  accepted the compute job. The parent should hand the jobId to its
+   *  header-tracked action-job hook via `.adopt(jobId)` so the running
+   *  process appears in the global header exactly like STT / IPA / the
+   *  batch pipeline. The modal closes immediately after this fires; it
+   *  does not poll the job itself. */
+  onPopulateStarted?: (jobId: string) => void;
 }
 
 type Tab = "languages" | "populate";
 
 const MAX_PRIMARY = 2;
 
-export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps) {
+export function ClefConfigModal({ open, onClose, onSaved, onPopulateStarted }: ClefConfigModalProps) {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -41,15 +48,15 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
   const [selectedProviders, setSelectedProviders] = useState<Set<string>>(new Set());
   const [overwrite, setOverwrite] = useState(false);
 
-  const [populating, setPopulating] = useState(false);
-  const [populateProgress, setPopulateProgress] = useState(0);
-  const [populateMessage, setPopulateMessage] = useState("");
+  // The modal no longer polls the populate job locally — the global
+  // header takes over once onPopulateStarted fires. The shared `saving`
+  // flag (declared above) covers the entire save→startJob→close window,
+  // so no separate "populating" state is needed.
   /** Set when populate fails so the UI can switch the primary button from
    *  "Save & populate" to "Retry populate" without throwing away the
    *  user's language picks. Cleared on successful populate or when they
    *  plain-save without populate. */
   const [populateFailed, setPopulateFailed] = useState(false);
-  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [highlightIdx, setHighlightIdx] = useState(0);
 
   const allLanguages = useMemo(() => {
@@ -103,12 +110,6 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
       cancelled = true;
     };
   }, [open]);
-
-  useEffect(() => {
-    return () => {
-      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
-    };
-  }, []);
 
   const togglePrimary = useCallback((code: string) => {
     setPrimary((prev) => {
@@ -170,15 +171,15 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
       setPopulateFailed(false);
       try {
         await saveClefConfig(buildPayload());
+        onSaved?.(primary);
         if (!runPopulate) {
-          onSaved?.(primary, false);
           onClose();
           return;
         }
-        // Kick off the fetcher for the selected primary languages.
-        setPopulating(true);
-        setPopulateProgress(0);
-        setPopulateMessage("Starting…");
+        // Kick off the fetcher for the selected primary languages and
+        // hand the jobId up to the parent -- the global header takes
+        // over progress display from here, matching the UX of other
+        // long-running jobs (STT, forced-align, full pipeline).
         const job = await startContactLexemeFetch({
           languages: primary,
           providers: selectedProviders.size > 0 ? Array.from(selectedProviders) : undefined,
@@ -186,30 +187,8 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
         });
         const id = job.jobId || job.job_id || "";
         if (!id) throw new Error("No job id returned");
-        const poll = async () => {
-          try {
-            const s = await pollCompute("contact-lexemes", id);
-            setPopulateProgress(s.progress ?? 0);
-            setPopulateMessage(s.message ?? "");
-            if (["done", "complete", "error", "failed"].includes(s.status)) {
-              setPopulating(false);
-              if (s.status === "error" || s.status === "failed") {
-                setError(s.error ?? s.message ?? "Populate failed");
-                setPopulateFailed(true);
-              } else {
-                onSaved?.(primary, true);
-                onClose();
-              }
-              return;
-            }
-            pollTimerRef.current = setTimeout(poll, 1500);
-          } catch (e) {
-            setPopulating(false);
-            setError(e instanceof Error ? e.message : "Polling failed");
-            setPopulateFailed(true);
-          }
-        };
-        pollTimerRef.current = setTimeout(poll, 1000);
+        onPopulateStarted?.(id);
+        onClose();
       } catch (e) {
         setError(e instanceof Error ? e.message : "Save failed");
         if (runPopulate) setPopulateFailed(true);
@@ -217,7 +196,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
         setSaving(false);
       }
     },
-    [primary, buildPayload, selectedProviders, overwrite, onSaved, onClose],
+    [primary, buildPayload, selectedProviders, overwrite, onSaved, onPopulateStarted, onClose],
   );
 
   const applyDefaults = useCallback(() => {
@@ -253,7 +232,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
   useEffect(() => {
     if (!open) return;
     function handle(e: KeyboardEvent) {
-      if (populating) return;
+      if (saving) return;
       if (e.key === "Escape") {
         e.preventDefault();
         onClose();
@@ -261,7 +240,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
     }
     window.addEventListener("keydown", handle);
     return () => window.removeEventListener("keydown", handle);
-  }, [open, populating, onClose]);
+  }, [open, saving, onClose]);
 
   // Reset highlight when the filtered list changes size so we never land
   // on a stale out-of-range index.
@@ -274,7 +253,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4"
-      onClick={populating ? undefined : onClose}
+      onClick={saving ? undefined : onClose}
     >
       <div
         className="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-lg bg-white shadow-xl"
@@ -291,7 +270,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
           </div>
           <button
             onClick={onClose}
-            disabled={populating}
+            disabled={saving}
             className="rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600 disabled:opacity-30"
             aria-label="Close"
           >
@@ -573,19 +552,10 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
                 Overwrite existing forms
               </label>
 
-              {populating && (
-                <div className="rounded border border-indigo-200 bg-indigo-50 p-3">
-                  <div className="flex items-center gap-2 text-[11px] font-semibold text-indigo-800">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    Populating… {Math.round(populateProgress)}%
-                  </div>
-                  <div className="mt-1 text-[10px] text-indigo-700">{populateMessage}</div>
-                  <div className="mt-2 h-1.5 overflow-hidden rounded bg-indigo-100">
-                    <div
-                      className="h-full bg-indigo-600 transition-all"
-                      style={{ width: `${populateProgress}%` }}
-                    />
-                  </div>
+              {saving && (
+                <div className="flex items-center gap-2 rounded border border-indigo-200 bg-indigo-50 p-3 text-[11px] font-semibold text-indigo-800">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Dispatching job… live progress will appear in the app header.
                 </div>
               )}
             </div>
@@ -599,7 +569,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
           </span>
           <button
             onClick={applyDefaults}
-            disabled={populating || saving}
+            disabled={saving}
             className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
             title="Preselect a sensible starter pair (English + Spanish). You can still edit before saving."
           >
@@ -607,7 +577,7 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
           </button>
           <button
             onClick={onClose}
-            disabled={populating}
+            disabled={saving}
             className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
             title="Close without configuring. The Run button will reopen this modal next time."
           >
@@ -615,14 +585,14 @@ export function ClefConfigModal({ open, onClose, onSaved }: ClefConfigModalProps
           </button>
           <button
             onClick={() => handleSave(false)}
-            disabled={saving || populating || primary.length === 0}
+            disabled={saving || primary.length === 0}
             className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-40"
           >
             Save
           </button>
           <button
             onClick={() => handleSave(true)}
-            disabled={saving || populating || primary.length === 0}
+            disabled={saving || primary.length === 0}
             className="inline-flex items-center gap-1 rounded-md bg-indigo-600 px-3 py-1.5 text-[11px] font-semibold text-white hover:bg-indigo-700 disabled:opacity-40"
           >
             <Play className="h-3 w-3" /> {populateFailed ? "Retry populate" : "Save & populate"}


### PR DESCRIPTION
## Summary

Follow-up to [#202](https://github.com/ArdeleanLucas/PARSE/pull/202). Two bugs from the screenshot review:

**1. Reference Forms was hardcoded Arabic + Persian and always rendered** — even on a fresh workspace with no CLEF config, the section showed two cards with "No reference data". It's now driven entirely by `_meta.primary_contact_languages` from `/api/clef/config`: completely hidden when no primaries are configured, otherwise one card per configured primary with the language name pulled from the same payload. Data sources: `enrichments.reference_forms` first, then a fallback to the per-workspace SIL contact-language config (what **Save & populate** writes), so fresh forms appear without waiting on a full enrichments recompute.

**2. Save & populate had its own in-modal progress bar** — the other long-running jobs in PARSE (STT, IPA, forced alignment, full pipeline) all surface in the global header chip. CLEF populate now does the same: the modal dispatches the job, hands the `jobId` up via a new `onPopulateStarted` callback, and closes; ParseUI calls `crossSpeakerJob.adopt(jobId)` so the header shows **"Populating CLEF reference data…"** with the standard progress bar + ETA + error UX. The job disappears from the header automatically on complete/error. Enrichments + CLEF status both reload on complete so the Reference Forms cards fill in without a manual refresh.

## Success criteria — status

| # | Criterion | Status |
|---|---|---|
| 1 | Fresh workspace (no CLEF config): Reference Forms hidden | ✅ gated by `primaryContactCodes.length > 0` |
| 2 | Configure Arabic + Persian → only those two cards appear | ✅ cards built from `primary_contact_languages` |
| 3 | Change primary languages → section updates immediately | ✅ `refreshClefStatus()` fires after save |
| 4 | Save & populate shows status in app header | ✅ `crossSpeakerJob.adopt(jobId)` surfaces it |
| 5 | No more hardcoded or stale language lists | ✅ language list + names dynamic |

## Files touched

- `src/ParseUI.tsx` — expanded `clefConfigured` cache into a full `ClefConfigStatus`; added `silConcepts` loader from `/api/contact-lexemes/coverage`; refactored `resolveReferenceForms` to a code-keyed map with SIL fallback; added RTL/tone lookup; gated and dynamically rendered the Reference Forms section; relabeled `crossSpeakerJob` to "Populating CLEF reference data…"; wired `onPopulateStarted` → `crossSpeakerJob.adopt`.
- `src/components/compute/ClefConfigModal.tsx` — dropped local poll loop, progress state, and `pollTimerRef` cleanup; added `onPopulateStarted` prop; modal now dispatches the job and closes while the header owns progress UX.
- `src/ParseUI.test.tsx` — new `getClefConfig` / `getContactLexemeCoverage` mocks with per-test overrides; default every test to "not configured"; two existing reference-forms tests opt into the configured state; one new test pins the gate (section hidden when CLEF has no primary languages).

## Tests

- `npx tsc --noEmit` — clean
- `npx vitest run` — 38 files, 242 tests, all passing (one new)
- `pytest compare/providers/test_contact_lexeme_fetcher.py` — 6/6

## Test plan
- [ ] Fresh workspace, no CLEF config: open Compare → confirm no "Reference forms" section renders at all.
- [ ] Configure CLEF with Arabic + Persian → Reference Forms section appears with exactly two cards (names from `/api/clef/config`); "No reference data" shows only for configured codes.
- [ ] Re-open modal, change primaries to English + Spanish → section immediately reflects the new pair without a reload.
- [ ] Click **Save & populate** → modal closes, header shows "Populating CLEF reference data…" with progress bar + ETA, disappears on completion; Reference Forms cards fill in.
- [ ] Navigate away and back / reload mid-job → header re-adopts the running job via `listActiveJobs()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)