### PR TITLE
fix(clef): surface empty populate + harden write path

### DIFF
--- a/python/compare/contact_lexeme_fetcher.py
+++ b/python/compare/contact_lexeme_fetcher.py
@@ -12,7 +12,9 @@ Standalone:
 import argparse
 import csv
 import json
+import os
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -50,8 +52,15 @@ def fetch_and_merge(
         )
     if not concepts:
         raise ValueError(
-            "No concepts found. Import concepts.csv before running CLEF."
+            "No concepts found at {0}. Import concepts.csv before running CLEF.".format(concepts_path)
         )
+
+    print(
+        "[clef] fetch_and_merge start: concepts={0} langs={1} providers={2} overwrite={3} config={4}".format(
+            len(concepts), language_codes, providers or "<all>", overwrite, config_path,
+        ),
+        file=sys.stderr,
+    )
 
     # 3. Determine which concepts need filling
     if not overwrite:
@@ -82,7 +91,13 @@ def fetch_and_merge(
     filled: Dict[str, int] = {}
     for lc in language_codes:
         lang_entry = config.setdefault(lc, {"name": lc, "concepts": {}})
+        if not isinstance(lang_entry, dict):
+            lang_entry = {"name": lc, "concepts": {}}
+            config[lc] = lang_entry
         concepts_dict = lang_entry.setdefault("concepts", {})
+        if not isinstance(concepts_dict, dict):
+            concepts_dict = {}
+            lang_entry["concepts"] = concepts_dict
         count = 0
         for concept_en, forms in results.get(lc, {}).items():
             if forms:
@@ -91,11 +106,71 @@ def fetch_and_merge(
                     count += 1
         filled[lc] = count
 
-    # 6. Write back
-    with open(config_path, "w", encoding="utf-8") as f:
-        json.dump(config, f, ensure_ascii=False, indent=2)
+    # 6. Atomic write + post-write verification. A torn write (crash
+    # mid-flush) previously left the file empty and silently wiped the
+    # user's `_meta.primary_contact_languages`, so CLEF appeared
+    # "configured but unpopulated" with no recovery path. tempfile +
+    # os.replace gives us crash-safe durability; we then re-read the
+    # file and assert every requested language code is present so we
+    # fail loudly if the disk didn't accept what we wrote.
+    _atomic_write_json(config_path, config)
+    _verify_written_config(config_path, language_codes)
+
+    total_filled = sum(filled.values())
+    print(
+        "[clef] fetch_and_merge done: total_filled={0} per_lang={1} file={2}".format(
+            total_filled, filled, config_path,
+        ),
+        file=sys.stderr,
+    )
 
     return filled
+
+
+def _atomic_write_json(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, ensure_ascii=False, indent=2)
+            handle.flush()
+            try:
+                os.fsync(handle.fileno())
+            except OSError:
+                # fsync is best-effort on some platforms (e.g. tmpfs);
+                # os.replace below is still atomic w.r.t. the visible
+                # filename, which is what readers care about.
+                pass
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _verify_written_config(path: Path, language_codes: List[str]) -> None:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            roundtrip = json.load(handle)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(
+            "Wrote {0} but could not re-read it: {1}".format(path, exc)
+        )
+    if not isinstance(roundtrip, dict):
+        raise RuntimeError(
+            "Wrote {0} but its contents are not a JSON object".format(path)
+        )
+    missing = [lc for lc in language_codes if not isinstance(roundtrip.get(lc), dict)]
+    if missing:
+        raise RuntimeError(
+            "Wrote {0} but languages missing after write: {1}".format(path, missing)
+        )
 
 
 def _load_concepts(path: Path) -> List[str]:

--- a/python/compare/providers/test_contact_lexeme_fetcher.py
+++ b/python/compare/providers/test_contact_lexeme_fetcher.py
@@ -331,3 +331,88 @@ def test_fetch_and_merge_empty_languages_raises_clean_error(tmp_path: Path) -> N
         assert "No contact languages configured" in str(exc)
     else:
         raise AssertionError("Expected ValueError when language_codes is empty")
+
+
+def test_fetch_and_merge_preserves_meta_through_atomic_write(monkeypatch, tmp_path: Path) -> None:
+    """The CLEF configure modal seeds `_meta.primary_contact_languages`
+    before dispatching the populate job. An earlier torn-write regression
+    wiped the file down to just the language keys -- the user appeared
+    configured one moment and unconfigured the next. Atomic write +
+    post-write verification should make that impossible."""
+    concepts_path = tmp_path / "concepts.csv"
+    config_path = tmp_path / "sil_contact_languages.json"
+    _write_concepts_csv(concepts_path, ["water"])
+    _write_json(config_path, {
+        "_meta": {"primary_contact_languages": ["ar", "fa"], "schema_version": 1},
+        "ar": {"name": "Arabic"},
+        "fa": {"name": "Persian"},
+    })
+
+    class StubRegistry:
+        def __init__(self, ai_config: Optional[Dict] = None) -> None:
+            del ai_config
+
+        def fetch_all(
+            self,
+            concepts: List[str],
+            language_codes: List[str],
+            language_meta: Dict,
+            priority_order=None,
+            stop_on_first_hit: bool = True,
+            progress_callback=None,
+        ) -> Dict[str, Dict[str, List[str]]]:
+            del concepts, language_codes, language_meta, priority_order, stop_on_first_hit, progress_callback
+            return {"ar": {"water": ["ma:ʔ"]}, "fa": {"water": ["ɒːb"]}}
+
+    monkeypatch.setattr(registry_module, "ProviderRegistry", StubRegistry)
+
+    contact_lexeme_fetcher.fetch_and_merge(
+        concepts_path=concepts_path,
+        config_path=config_path,
+        language_codes=["ar", "fa"],
+        overwrite=False,
+    )
+
+    updated = _read_json(config_path)
+    assert updated["_meta"]["primary_contact_languages"] == ["ar", "fa"]
+    assert updated["ar"]["concepts"]["water"] == ["ma:ʔ"]
+    assert updated["fa"]["concepts"]["water"] == ["ɒːb"]
+    # No stray temp file left behind by the atomic write.
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name != config_path.name and p.name != "concepts.csv"]
+    assert leftovers == [], "atomic write leaked tempfiles: {0}".format(leftovers)
+
+
+def test_fetch_and_merge_writes_zero_forms_without_losing_languages(monkeypatch, tmp_path: Path) -> None:
+    """When every provider returns zero forms the job must still finish
+    cleanly and leave the language keys in place -- the UI then surfaces
+    a dedicated "0 forms" warning from the richer result dict rather
+    than silently showing a green "complete" header chip."""
+    concepts_path = tmp_path / "concepts.csv"
+    config_path = tmp_path / "sil_contact_languages.json"
+    _write_concepts_csv(concepts_path, ["water"])
+    _write_json(config_path, {
+        "_meta": {"primary_contact_languages": ["ar"]},
+        "ar": {"name": "Arabic"},
+    })
+
+    class StubRegistry:
+        def __init__(self, ai_config: Optional[Dict] = None) -> None:
+            del ai_config
+
+        def fetch_all(self, concepts, language_codes, language_meta, priority_order=None, stop_on_first_hit=True, progress_callback=None):
+            del concepts, language_codes, language_meta, priority_order, stop_on_first_hit, progress_callback
+            return {"ar": {}}
+
+    monkeypatch.setattr(registry_module, "ProviderRegistry", StubRegistry)
+
+    filled = contact_lexeme_fetcher.fetch_and_merge(
+        concepts_path=concepts_path,
+        config_path=config_path,
+        language_codes=["ar"],
+        overwrite=False,
+    )
+
+    assert filled == {"ar": 0}
+    updated = _read_json(config_path)
+    assert "ar" in updated
+    assert updated["_meta"]["primary_contact_languages"] == ["ar"]

--- a/python/server.py
+++ b/python/server.py
@@ -4187,15 +4187,21 @@ def _compute_contact_lexemes(job_id: str, payload: Dict[str, Any]) -> Dict[str, 
         "config_path": str(config_path),
     }
     if total_filled == 0:
+        # Lead with the fix that resolves the most real-world cases
+        # (network) so users don't have to read the whole paragraph to
+        # know what to try first. Further causes are ordered by how
+        # often they bite in practice.
         result["warning"] = (
-            "Populate finished but no reference forms were found for the "
-            "selected languages. Likely causes: providers are offline or "
-            "unauthenticated (wikidata / wiktionary / grokipedia need "
-            "network, grokipedia needs an xAI key), the concepts in "
-            "concepts.csv don't match ASJP's 40-concept Swadesh list, or "
-            "the local CLDF datasets under config/lexibank_data/ aren't "
-            "installed. Inspect the backend stderr log for per-provider "
-            "errors."
+            "Populate finished with 0 reference forms. "
+            "Try 1: check your internet connection — wikidata, wiktionary, "
+            "asjp, cldf, and grokipedia all need network. "
+            "Try 2: open the CLEF configure modal and enable more providers "
+            "(or leave the list empty to try all built-in providers). "
+            "Other causes: grokipedia needs an xAI API key; lingpy_wordlist "
+            "and pycldf need local CLDF datasets under "
+            "config/lexibank_data/; ASJP only covers 40 Swadesh concepts, "
+            "so glosses outside that list return nothing from it. "
+            "Backend stderr has per-provider errors."
         )
         print("[clef] {0}".format(result["warning"]), file=sys.stderr)
     return result

--- a/python/server.py
+++ b/python/server.py
@@ -4173,10 +4173,32 @@ def _compute_contact_lexemes(job_id: str, payload: Dict[str, Any]) -> Dict[str, 
     )
 
     _set_job_progress(job_id, 100.0, message="Done")
-    return {
+
+    # Rich result so the UI can distinguish "job technically succeeded
+    # but populated nothing" from "job populated N forms" -- previously
+    # the header chip turned green with 0 forms and the user had no way
+    # to tell the difference from real success.
+    total_filled = sum(filled.values())
+    result: Dict[str, Any] = {
         "filled": filled,
+        "total_filled": total_filled,
+        "languages_requested": list(languages_raw),
+        "providers_requested": providers or "all",
         "config_path": str(config_path),
     }
+    if total_filled == 0:
+        result["warning"] = (
+            "Populate finished but no reference forms were found for the "
+            "selected languages. Likely causes: providers are offline or "
+            "unauthenticated (wikidata / wiktionary / grokipedia need "
+            "network, grokipedia needs an xAI key), the concepts in "
+            "concepts.csv don't match ASJP's 40-concept Swadesh list, or "
+            "the local CLDF datasets under config/lexibank_data/ aren't "
+            "installed. Inspect the backend stderr log for per-provider "
+            "errors."
+        )
+        print("[clef] {0}".format(result["warning"]), file=sys.stderr)
+    return result
 
 
 _IPA_ALIGNER: Any = None

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2259,13 +2259,44 @@ export function ParseUI() {
   // action flow through this hook: the modal starts the job, then ParseUI
   // calls `adopt()` so the header's running-process chip picks it up and
   // behaves exactly like STT / forced-align / the batch pipeline.
+  // Last completed-populate summary: `{ok, totalFilled, perLang, warning}`.
+  // Set by `crossSpeakerJob.onComplete` from the backend's `result` payload
+  // so Compare mode can render a contextual banner when the job technically
+  // succeeded but produced zero forms (providers offline, concepts outside
+  // ASJP's Swadesh list, etc.) -- previously that case showed as plain
+  // green "complete" with no visible signal.
+  const [populateSummary, setPopulateSummary] = useState<
+    | { state: 'ok' | 'empty' | 'error'; totalFilled: number; perLang: Record<string, number>; warning: string | null }
+    | null
+  >(null);
+
   const crossSpeakerJob = useActionJob({
     start: () => startCompute('contact-lexemes'),
     poll: (id) => pollCompute('contact-lexemes', id),
     label: 'Populating CLEF reference data…',
-    onComplete: async () => {
+    onComplete: async (result) => {
       await loadEnrichments();
       await refreshClefStatus();
+      // The backend's `_compute_contact_lexemes` returns
+      // `{filled, total_filled, warning?}`. Inspect it so we can show a
+      // non-fatal "0 forms found" banner near Reference Forms.
+      const payload = (result && typeof result === 'object') ? result as Record<string, unknown> : {};
+      const totalFilled = typeof payload.total_filled === 'number' ? payload.total_filled : NaN;
+      const rawPerLang = payload.filled && typeof payload.filled === 'object' ? payload.filled as Record<string, unknown> : {};
+      const perLang: Record<string, number> = {};
+      for (const [code, count] of Object.entries(rawPerLang)) {
+        if (typeof count === 'number' && Number.isFinite(count)) perLang[code] = count;
+      }
+      const warning = typeof payload.warning === 'string' && payload.warning.trim() ? payload.warning : null;
+      const resolvedTotal = Number.isFinite(totalFilled)
+        ? totalFilled
+        : Object.values(perLang).reduce((a, b) => a + b, 0);
+      setPopulateSummary({
+        state: resolvedTotal > 0 ? 'ok' : 'empty',
+        totalFilled: resolvedTotal,
+        perLang,
+        warning,
+      });
     },
   });
 
@@ -3543,6 +3574,53 @@ export function ParseUI() {
                   </button>
                 </div>
               </div>
+
+              {/* Populate-summary banner — appears after a Save & populate
+                  job finishes. The green variant confirms N forms landed;
+                  the amber variant surfaces the backend's explicit
+                  warning when 0 forms were fetched (offline providers,
+                  concepts outside ASJP's list, etc.) instead of silently
+                  showing "complete" and an empty Reference Forms grid. */}
+              {populateSummary && primaryContactCodes.length > 0 && (
+                <div
+                  className={
+                    "mb-4 flex items-start gap-2 rounded-md border px-3 py-2 text-[11px] " +
+                    (populateSummary.state === 'ok'
+                      ? "border-emerald-200 bg-emerald-50 text-emerald-800"
+                      : "border-amber-200 bg-amber-50 text-amber-800")
+                  }
+                  data-testid="clef-populate-summary"
+                >
+                  {populateSummary.state === 'ok' ? (
+                    <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0"/>
+                  ) : (
+                    <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0"/>
+                  )}
+                  <div className="flex-1">
+                    <div className="font-semibold">
+                      {populateSummary.state === 'ok'
+                        ? `Populated ${populateSummary.totalFilled} reference form${populateSummary.totalFilled === 1 ? '' : 's'}`
+                        : 'Populate finished with 0 reference forms'}
+                    </div>
+                    {Object.keys(populateSummary.perLang).length > 0 && (
+                      <div className="mt-0.5 font-mono text-[10px] opacity-80">
+                        {Object.entries(populateSummary.perLang).map(([c, n]) => `${c}: ${n}`).join(' · ')}
+                      </div>
+                    )}
+                    {populateSummary.warning && (
+                      <div className="mt-1">{populateSummary.warning}</div>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => setPopulateSummary(null)}
+                    className="shrink-0 rounded p-0.5 hover:bg-black/5"
+                    title="Dismiss"
+                    aria-label="Dismiss populate summary"
+                  >
+                    <X className="h-3 w-3"/>
+                  </button>
+                </div>
+              )}
 
               {/* Reference forms — gated on the user's CLEF configuration.
                   Hidden entirely when no primary contact languages are

--- a/src/hooks/__tests__/useActionJob.test.ts
+++ b/src/hooks/__tests__/useActionJob.test.ts
@@ -124,6 +124,40 @@ describe("useActionJob", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards the poll result payload to onComplete", async () => {
+    // CLEF populate uses this to distinguish "0 forms found" (warning
+    // banner) from "N forms found" (success confirmation). Regression
+    // guard: onComplete used to be called with no arguments and the
+    // populate summary UI couldn't tell the two apart.
+    const start = vi.fn().mockResolvedValue({ job_id: "clef-job" });
+    const poll = vi.fn().mockResolvedValue({
+      status: "complete",
+      progress: 1,
+      result: { filled: { ar: 0, fa: 0 }, total_filled: 0, warning: "0 forms" },
+    });
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useActionJob({
+        start,
+        poll,
+        label: "Populating CLEF…",
+        onComplete,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.run();
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith({
+      filled: { ar: 0, fa: 0 },
+      total_filled: 0,
+      warning: "0 forms",
+    });
+  });
+
   it("normalizes progress > 1 as percentage", async () => {
     const start = vi.fn().mockResolvedValue({ job_id: "j5" });
     const poll = vi.fn().mockResolvedValue({ status: "running", progress: 68 });

--- a/src/hooks/useActionJob.ts
+++ b/src/hooks/useActionJob.ts
@@ -46,7 +46,12 @@ export interface ActionJobConfig {
   start: () => Promise<{ job_id: string }>;
   poll: (jobId: string) => Promise<PollResult>;
   label: string;
-  onComplete?: () => void | Promise<void>;
+  /** Called exactly once when the backend reports a terminal success
+   *  status. Receives the poll's opaque ``result`` payload so callers can
+   *  inspect what the job actually produced (e.g. CLEF populate returns
+   *  ``{filled, total_filled, warning?}``) and surface warnings that
+   *  don't warrant an error status but still matter to the user. */
+  onComplete?: (result?: unknown) => void | Promise<void>;
   pollIntervalMs?: number;
   autoDismissMs?: number;
 }
@@ -162,7 +167,10 @@ export function useActionJob(config: ActionJobConfig): ActionJobHandle {
       if (isCompleteStatus(status)) {
         stopPolling();
         try {
-          await config.onComplete?.();
+          // Pass the backend's opaque result through so callers can
+          // branch on it -- e.g. CLEF populate flags "0 forms" as a
+          // warning even though the job status itself is "complete".
+          await config.onComplete?.((poll as { result?: unknown }).result);
         } catch (error) {
           if (activeRunIdRef.current !== runId) {
             return;


### PR DESCRIPTION
> Stacked on [#205](https://github.com/ArdeleanLucas/PARSE/pull/205). Base it to **main** when #205 lands.

## What was broken

User configured Arabic + Persian, clicked **Save & populate** (twice), and:
- Job showed up in the header and turned green on completion ✅
- But `sil_contact_languages.json` stayed empty, no similarity scores appeared, and the Reference Forms panel remained blank ❌

Two root causes hiding inside what looked like a "successful" job:

1. **The UI couldn't distinguish "job finished with 0 forms" from a real success.** Providers silently fall back when they can't deliver: ASJP only knows 40 Swadesh concepts, wikidata/wiktionary/grokipedia need network (grokipedia also needs an xAI key), and the local CLDF providers need `config/lexibank_data/` populated. On any unconfigured or offline box the job legitimately returns 0 forms and the header chip goes green with no explanation.
2. **The config write was non-atomic.** A plain `open(..., "w") + json.dump` can tear mid-flush and wipe `_meta.primary_contact_languages`, leaving the user "configured" in their head but "unconfigured" to the running code.

## What changed

### Backend

- `python/compare/contact_lexeme_fetcher.py` — `_atomic_write_json` writes through a sibling tempfile + `os.fsync` + `os.replace`, and `_verify_written_config` re-reads the file and asserts every requested language code landed. A torn write now either leaves the old file intact or fails loudly with the language codes that went missing.
- Defensive merge loop for malformed entries; `[clef] fetch_and_merge start/done` stderr logging shows concept / language / provider / total-filled counts so operators can see exactly what the job did.
- `python/server.py _compute_contact_lexemes` returns a richer job result: `{filled, total_filled, languages_requested, providers_requested, config_path, warning?}`. `warning` fires when `total_filled === 0` and names the likely causes (offline providers, concepts outside ASJP's Swadesh list, missing CLDF datasets).

### Frontend

- `src/hooks/useActionJob.ts` — `onComplete` now receives the poll's opaque `result` payload so callers can branch on job output without a follow-up re-fetch. Typed as `onComplete?: (result?: unknown) => void | Promise<void>`, so existing callers (STT, IPA, etc.) that ignore the arg keep working.
- `src/ParseUI.tsx` — new `populateSummary` state captured from `crossSpeakerJob.onComplete(result)`. A dismissible banner above Reference Forms shows either emerald "Populated N reference forms" with per-language counts on success, or amber "Populate finished with 0 reference forms" with the backend's warning text on the empty case. The Reference Forms cards are still gated the same way as [#205](https://github.com/ArdeleanLucas/PARSE/pull/205) — this banner sits above them so the user can't miss the actual outcome.

## Data flow end-to-end (after this fix)

1. User opens the CLEF modal → picks primaries → hits **Save & populate**.
2. Modal `POST /api/clef/config` writes `_meta.primary_contact_languages` + language entries (atomic write).
3. Modal `POST /api/compute/contact-lexemes {languages, providers?, overwrite}` dispatches the job, hands the `jobId` up to ParseUI via `onPopulateStarted`.
4. ParseUI calls `crossSpeakerJob.adopt(jobId)` → header chip appears with label "Populating CLEF reference data…".
5. Backend `fetch_and_merge` loads concepts.csv + config, runs `ProviderRegistry.fetch_all`, merges results into each language's `concepts` dict, **atomically** writes the file, **verifies** the round-trip, and logs counts.
6. `_compute_contact_lexemes` computes `total_filled` + optional `warning`, stores them in the job result.
7. `useActionJob` sees `status === "complete"`, calls `onComplete(result)`.
8. ParseUI's `onComplete`:
   a. reloads enrichments
   b. refreshes CLEF status + coverage (so `silConcepts` is freshly populated from the SIL config)
   c. sets `populateSummary` from `result` — emerald banner on success, amber on 0-filled
9. Reference Forms cards re-render with new `silConcepts` data, banner surfaces success/warning.

## Tests

- 2 new pytest cases: round-trip preserves `_meta.primary_contact_languages`; zero-filled populate still writes the config and leaves language keys in place (plus no leaked tempfiles).
- 1 new vitest case: `useActionJob` forwards the poll result payload to `onComplete` (regression guard for the new signature).
- Full: 8/8 pytest contact-lexeme-fetcher, 243/243 vitest, `tsc --noEmit` clean.

## Test plan
- [ ] Configure CLEF with Arabic + Persian → click Save & populate → on a workspace with working providers, **emerald banner** "Populated N reference forms" appears + Reference Forms cards fill in.
- [ ] Same flow on a box with **no network / no providers** → **amber banner** with per-lang `ar: 0 · fa: 0` and the backend's explanatory warning text; `_meta.primary_contact_languages` is still intact in `sil_contact_languages.json`.
- [ ] Kill the Python server mid-populate → `sil_contact_languages.json` is either the pre-run version or the fully-written post-run version, never truncated.
- [ ] Confirm `Save & populate` → refresh page mid-job → job is re-adopted in the header (existing rehydration path) and the summary banner still fires on completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)