### PR TITLE
feat(clef): Retry with different providers button on empty-populate banner

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -44,7 +44,8 @@ import { ChatMarkdown } from './components/shared/ChatMarkdown';
 import { LexemeDetail } from './components/compare/LexemeDetail';
 import { CommentsImport } from './components/compare/CommentsImport';
 import { SpeakerImport } from './components/compare/SpeakerImport';
-import { ClefConfigModal } from './components/compute/ClefConfigModal';
+import { ClefConfigModal, type ClefConfigModalTab } from './components/compute/ClefConfigModal';
+import { ClefPopulateSummaryBanner } from './components/compute/ClefPopulateSummaryBanner';
 import { getClefConfig, getContactLexemeCoverage } from './api/client';
 import type { ClefConfigStatus } from './api/types';
 
@@ -1952,6 +1953,12 @@ export function ParseUI() {
   const [computeMode, setComputeMode] = useState('cognates');
   const { start: startComputeJob, state: computeJobState, reset: resetComputeJob } = useComputeJob(computeMode);
   const [clefModalOpen, setClefModalOpen] = useState(false);
+  // Which tab ClefConfigModal should open on. Defaults to "languages"; the
+  // empty-populate banner's "Retry with different providers" action flips
+  // this to "populate" so the user lands directly on the provider picker.
+  // Reset to "languages" on close so the next gear/Run click lands on the
+  // languages tab again.
+  const [clefInitialTab, setClefInitialTab] = useState<ClefConfigModalTab>('languages');
   // Full CLEF status so the Reference Forms section can render exactly
   // the user's configured primary languages (not a hardcoded Arabic +
   // Persian pair). `null` means "not yet loaded" so the UI can render a
@@ -3582,44 +3589,14 @@ export function ParseUI() {
                   concepts outside ASJP's list, etc.) instead of silently
                   showing "complete" and an empty Reference Forms grid. */}
               {populateSummary && primaryContactCodes.length > 0 && (
-                <div
-                  className={
-                    "mb-4 flex items-start gap-2 rounded-md border px-3 py-2 text-[11px] " +
-                    (populateSummary.state === 'ok'
-                      ? "border-emerald-200 bg-emerald-50 text-emerald-800"
-                      : "border-amber-200 bg-amber-50 text-amber-800")
-                  }
-                  data-testid="clef-populate-summary"
-                >
-                  {populateSummary.state === 'ok' ? (
-                    <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0"/>
-                  ) : (
-                    <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0"/>
-                  )}
-                  <div className="flex-1">
-                    <div className="font-semibold">
-                      {populateSummary.state === 'ok'
-                        ? `Populated ${populateSummary.totalFilled} reference form${populateSummary.totalFilled === 1 ? '' : 's'}`
-                        : 'Populate finished with 0 reference forms'}
-                    </div>
-                    {Object.keys(populateSummary.perLang).length > 0 && (
-                      <div className="mt-0.5 font-mono text-[10px] opacity-80">
-                        {Object.entries(populateSummary.perLang).map(([c, n]) => `${c}: ${n}`).join(' · ')}
-                      </div>
-                    )}
-                    {populateSummary.warning && (
-                      <div className="mt-1">{populateSummary.warning}</div>
-                    )}
-                  </div>
-                  <button
-                    onClick={() => setPopulateSummary(null)}
-                    className="shrink-0 rounded p-0.5 hover:bg-black/5"
-                    title="Dismiss"
-                    aria-label="Dismiss populate summary"
-                  >
-                    <X className="h-3 w-3"/>
-                  </button>
-                </div>
+                <ClefPopulateSummaryBanner
+                  summary={populateSummary}
+                  onDismiss={() => setPopulateSummary(null)}
+                  onRetryWithProviders={() => {
+                    setClefInitialTab('populate');
+                    setClefModalOpen(true);
+                  }}
+                />
               )}
 
               {/* Reference forms — gated on the user's CLEF configuration.
@@ -4270,7 +4247,11 @@ export function ParseUI() {
       />
       <ClefConfigModal
         open={clefModalOpen}
-        onClose={() => setClefModalOpen(false)}
+        initialTab={clefInitialTab}
+        onClose={() => {
+          setClefModalOpen(false);
+          setClefInitialTab('languages');
+        }}
         onSaved={() => {
           // Save-only (no populate): just refresh our cached CLEF status
           // so the Reference Forms panel re-renders with the new primary

--- a/src/components/compute/ClefConfigModal.tsx
+++ b/src/components/compute/ClefConfigModal.tsx
@@ -9,6 +9,8 @@ import {
 } from "../../api/client";
 import type { ClefCatalogEntry, ClefConfigStatus, ClefProviderEntry } from "../../api/types";
 
+export type ClefConfigModalTab = "languages" | "populate";
+
 interface ClefConfigModalProps {
   open: boolean;
   onClose: () => void;
@@ -23,13 +25,19 @@ interface ClefConfigModalProps {
    *  batch pipeline. The modal closes immediately after this fires; it
    *  does not poll the job itself. */
   onPopulateStarted?: (jobId: string) => void;
+  /** Tab to show when the modal opens. Defaults to "languages". The
+   *  "Retry with different providers" affordance on the empty-populate
+   *  banner sets this to "populate" so the user lands directly on the
+   *  provider checkboxes. Re-seeded on every open so a later plain-Run
+   *  click still lands on the languages tab. */
+  initialTab?: ClefConfigModalTab;
 }
 
-type Tab = "languages" | "populate";
+type Tab = ClefConfigModalTab;
 
 const MAX_PRIMARY = 2;
 
-export function ClefConfigModal({ open, onClose, onSaved, onPopulateStarted }: ClefConfigModalProps) {
+export function ClefConfigModal({ open, onClose, onSaved, onPopulateStarted, initialTab = "languages" }: ClefConfigModalProps) {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -44,7 +52,7 @@ export function ClefConfigModal({ open, onClose, onSaved, onPopulateStarted }: C
   const [customName, setCustomName] = useState("");
   const [search, setSearch] = useState("");
 
-  const [tab, setTab] = useState<Tab>("languages");
+  const [tab, setTab] = useState<Tab>(initialTab);
   const [selectedProviders, setSelectedProviders] = useState<Set<string>>(new Set());
   const [overwrite, setOverwrite] = useState(false);
 
@@ -85,6 +93,7 @@ export function ClefConfigModal({ open, onClose, onSaved, onPopulateStarted }: C
 
   useEffect(() => {
     if (!open) return;
+    setTab(initialTab);
     let cancelled = false;
     setLoading(true);
     setError(null);

--- a/src/components/compute/ClefPopulateSummaryBanner.tsx
+++ b/src/components/compute/ClefPopulateSummaryBanner.tsx
@@ -1,0 +1,75 @@
+import { AlertCircle, CheckCircle2, RefreshCw, X } from "lucide-react";
+
+export interface PopulateSummary {
+  state: "ok" | "empty" | "error";
+  totalFilled: number;
+  perLang: Record<string, number>;
+  warning: string | null;
+}
+
+interface ClefPopulateSummaryBannerProps {
+  summary: PopulateSummary;
+  onDismiss: () => void;
+  /** Fired when the user clicks "Retry with different providers" on the
+   *  non-ok banner. The parent should open ClefConfigModal with the
+   *  populate tab preselected so providers can be toggled and a new job
+   *  dispatched through the same path as the initial run. */
+  onRetryWithProviders: () => void;
+}
+
+export function ClefPopulateSummaryBanner({
+  summary,
+  onDismiss,
+  onRetryWithProviders,
+}: ClefPopulateSummaryBannerProps) {
+  const isOk = summary.state === "ok";
+  return (
+    <div
+      className={
+        "mb-4 flex items-start gap-2 rounded-md border px-3 py-2 text-[11px] " +
+        (isOk
+          ? "border-emerald-200 bg-emerald-50 text-emerald-800"
+          : "border-amber-200 bg-amber-50 text-amber-800")
+      }
+      data-testid="clef-populate-summary"
+    >
+      {isOk ? (
+        <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      ) : (
+        <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      )}
+      <div className="flex-1">
+        <div className="font-semibold">
+          {isOk
+            ? `Populated ${summary.totalFilled} reference form${summary.totalFilled === 1 ? "" : "s"}`
+            : "Populate finished with 0 reference forms"}
+        </div>
+        {Object.keys(summary.perLang).length > 0 && (
+          <div className="mt-0.5 font-mono text-[10px] opacity-80">
+            {Object.entries(summary.perLang).map(([c, n]) => `${c}: ${n}`).join(" · ")}
+          </div>
+        )}
+        {summary.warning && <div className="mt-1">{summary.warning}</div>}
+        {!isOk && (
+          <div className="mt-2">
+            <button
+              onClick={onRetryWithProviders}
+              className="inline-flex items-center gap-1 rounded border border-amber-300 bg-white px-2 py-0.5 text-[11px] font-semibold text-amber-800 hover:bg-amber-100"
+              data-testid="clef-populate-retry"
+            >
+              <RefreshCw className="h-3 w-3" /> Retry with different providers
+            </button>
+          </div>
+        )}
+      </div>
+      <button
+        onClick={onDismiss}
+        className="shrink-0 rounded p-0.5 hover:bg-black/5"
+        title="Dismiss"
+        aria-label="Dismiss populate summary"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/compute/__tests__/ClefPopulateSummaryBanner.test.tsx
+++ b/src/components/compute/__tests__/ClefPopulateSummaryBanner.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ClefPopulateSummaryBanner,
+  type PopulateSummary,
+} from "../ClefPopulateSummaryBanner";
+
+vi.mock("../../../api/client", () => ({
+  getClefConfig: vi.fn(async () => ({
+    configured: true,
+    primary_contact_languages: ["eng", "spa"],
+    languages: [
+      { code: "eng", name: "English" },
+      { code: "spa", name: "Spanish" },
+    ],
+    config_path: "",
+    concepts_csv_exists: true,
+    meta: {},
+  })),
+  getClefCatalog: vi.fn(async () => ({
+    languages: [
+      { code: "eng", name: "English" },
+      { code: "spa", name: "Spanish" },
+    ],
+  })),
+  getClefProviders: vi.fn(async () => ({
+    providers: [
+      { id: "ids", name: "IDS" },
+      { id: "wiktionary", name: "Wiktionary" },
+    ],
+  })),
+  saveClefConfig: vi.fn(),
+  startContactLexemeFetch: vi.fn(),
+}));
+
+import { ClefConfigModal } from "../ClefConfigModal";
+
+const emptySummary: PopulateSummary = {
+  state: "empty",
+  totalFilled: 0,
+  perLang: { eng: 0, spa: 0 },
+  warning: "Providers returned 0 forms.",
+};
+
+const okSummary: PopulateSummary = {
+  state: "ok",
+  totalFilled: 42,
+  perLang: { eng: 22, spa: 20 },
+  warning: null,
+};
+
+describe("ClefPopulateSummaryBanner", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows retry button only on non-ok banner and fires onRetryWithProviders on click", () => {
+    const onRetry = vi.fn();
+    render(
+      <ClefPopulateSummaryBanner
+        summary={emptySummary}
+        onDismiss={() => {}}
+        onRetryWithProviders={onRetry}
+      />,
+    );
+    const retry = screen.getByTestId("clef-populate-retry");
+    expect(retry.textContent ?? "").toMatch(/retry with different providers/i);
+    fireEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render retry button on the success banner", () => {
+    render(
+      <ClefPopulateSummaryBanner
+        summary={okSummary}
+        onDismiss={() => {}}
+        onRetryWithProviders={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("clef-populate-retry")).toBeNull();
+  });
+
+  it("clicking retry opens ClefConfigModal on the populate tab", async () => {
+    // Minimal parent that wires the banner -> modal exactly like ParseUI:
+    // the retry handler flips the initialTab state and opens the modal.
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      const [tab, setTab] = useState<"languages" | "populate">("languages");
+      return (
+        <>
+          <ClefPopulateSummaryBanner
+            summary={emptySummary}
+            onDismiss={() => {}}
+            onRetryWithProviders={() => {
+              setTab("populate");
+              setOpen(true);
+            }}
+          />
+          <ClefConfigModal
+            open={open}
+            initialTab={tab}
+            onClose={() => {
+              setOpen(false);
+              setTab("languages");
+            }}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+    fireEvent.click(screen.getByTestId("clef-populate-retry"));
+    // Auto-populate tab button becomes the visible indigo-tabbed one.
+    const populateTab = await waitFor(() =>
+      screen.getByRole("button", { name: /auto-populate/i }),
+    );
+    expect(populateTab.className).toMatch(/text-indigo-700/);
+    // And the languages tab is not active.
+    const langTab = screen.getByRole("button", { name: /1\. languages/i });
+    expect(langTab.className).not.toMatch(/text-indigo-700/);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #206 — adds a **"Retry with different providers"** button on the amber populate-summary banner that appears when CLEF populate finishes with 0 reference forms. Clicking it reopens \`ClefConfigModal\` directly on the **"2. Auto-populate (optional)"** tab so the user can toggle providers and kick off a fresh job through the existing \`crossSpeakerJob.adopt(...)\` path — no backend changes.

- Extracted the inline banner JSX in \`ParseUI.tsx\` into a small \`ClefPopulateSummaryBanner\` component. Banner styling unchanged; the retry button only renders on the non-ok (empty/error) variant, not the emerald success banner.
- \`ClefConfigModal\` now accepts an \`initialTab?: "languages" | "populate"\` prop (default \`"languages"\`) and reseeds the active tab from it on each open — so a later gear/Run click still lands on the Languages tab.
- \`ParseUI\` owns a \`clefInitialTab\` state flipped to \`"populate"\` by the retry handler; reset on modal close.

#206 merged to main while this was in flight, so the PR targets \`main\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — all tests passing, including the new \`ClefPopulateSummaryBanner.test.tsx\` (retry only on non-ok, absent on ok, wiring opens modal on populate tab)
- [ ] Manual: trigger a populate with offline providers, verify amber banner + Retry button, click → modal opens on Auto-populate tab with provider checkboxes editable → Save & populate dispatches a new job that surfaces in the global header chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)