### PR TITLE
feat(clef): dynamic similarity columns from CLEF primary_contact_languages

### DIFF
--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -476,13 +476,26 @@ describe("ParseUI", () => {
     expect(screen.queryByText("رماد")).toBeNull();
   });
 
-  it("shows real Arabic + Persian similarity scores from enrichment .ar/.fa fields and renders em-dash when missing", () => {
+  it("shows real Arabic + Persian similarity scores from enrichment .ar/.fa fields and renders em-dash when missing", async () => {
     // Regression for a typo where persianSim was reading speakerSimilarity.tr
     // (Turkish) instead of .fa (Farsi/Persian). The backend writes under the
     // primary contact-language code -- which is "fa" for Persian -- so the
     // UI column was always 0.00 regardless of compute state.
     // Also covers the missing-score path: a speaker with no similarity entry
     // should render "—" so "not yet computed" reads differently from "0.00".
+    // The column set is driven by the CLEF primary_contact_languages config
+    // now, so this test seeds ar + fa explicitly.
+    mockClefConfig = {
+      configured: true,
+      primary_contact_languages: ["ar", "fa"],
+      languages: [
+        { code: "ar", name: "Arabic" },
+        { code: "fa", name: "Persian" },
+      ],
+      config_path: "",
+      concepts_csv_exists: true,
+      meta: {},
+    };
     mockConfig = {
       project_name: "PARSE",
       language_code: "ku",
@@ -516,6 +529,9 @@ describe("ParseUI", () => {
     // Sanity: both speaker rows are in the DOM.
     expect(screen.getByText("/aw/")).toBeTruthy();
     expect(screen.getByText("/awa/")).toBeTruthy();
+    // CLEF config loads async; wait for the dynamic headers to mount.
+    await waitFor(() => expect(screen.getByTestId("sim-col-header-ar")).toBeTruthy());
+    expect(screen.getByTestId("sim-col-header-fa")).toBeTruthy();
     // Fail01 row carries real values for both columns.
     expect(screen.getByText("0.42")).toBeTruthy();
     expect(screen.getByText("0.81")).toBeTruthy();
@@ -524,6 +540,63 @@ describe("ParseUI", () => {
     // Kzn03 row has no similarity entry -- both columns fall back to "—".
     const dashes = screen.getAllByText("—");
     expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders dynamic similarity columns based on CLEF primary_contact_languages (not hardcoded Arabic/Persian)", async () => {
+    // Success criterion for the dynamic-primary-langs PR: when the user
+    // configures English + Spanish (or any other set), the Speaker forms
+    // table must render those as the similarity columns instead of the
+    // built-in Arabic + Persian pair. The column data binding is driven
+    // by the same primaryContactCodes list that the Reference Forms
+    // cards iterate over, so there is a single source of truth for the
+    // configured languages.
+    mockClefConfig = {
+      configured: true,
+      primary_contact_languages: ["eng", "spa"],
+      languages: [
+        { code: "eng", name: "English" },
+        { code: "spa", name: "Spanish" },
+      ],
+      config_path: "",
+      concepts_csv_exists: true,
+      meta: {},
+    };
+    mockConfig = {
+      project_name: "PARSE",
+      language_code: "ku",
+      speakers: ["Fail01"],
+      concepts: [{ id: "1", label: "water" }],
+      audio_dir: "audio",
+      annotations_dir: "annotations",
+    };
+    mockRecords = {
+      Fail01: makeRecord("Fail01", [
+        { conceptText: "water", ipa: "aw", ortho: "ئاو", start: 1, end: 2 },
+      ]),
+    };
+    mockEnrichmentData = {
+      similarity: {
+        "1": {
+          Fail01: {
+            eng: { score: 0.37, has_reference_data: true },
+            spa: { score: 0.55, has_reference_data: true },
+          },
+        },
+      },
+    };
+
+    render(<ParseUI />);
+
+    await waitFor(() => expect(screen.getByTestId("sim-col-header-eng")).toBeTruthy());
+    expect(screen.getByTestId("sim-col-header-eng").textContent ?? "").toMatch(/english sim\./i);
+    expect(screen.getByTestId("sim-col-header-spa").textContent ?? "").toMatch(/spanish sim\./i);
+    // Old hardcoded labels are gone -- regression guard so no one
+    // accidentally reverts the headers.
+    expect(screen.queryByTestId("sim-col-header-ar")).toBeNull();
+    expect(screen.queryByTestId("sim-col-header-fa")).toBeNull();
+    // Scores render under the new column codes via the dynamic cell testid.
+    expect(screen.getByTestId("sim-cell-Fail01-eng").textContent ?? "").toContain("0.37");
+    expect(screen.getByTestId("sim-cell-Fail01-spa").textContent ?? "").toContain("0.55");
   });
 
   it("renders compare speaker forms from annotation data instead of MOCK_FORMS placeholders", () => {

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -69,7 +69,12 @@ type ConceptSortMode = 'az' | '1n' | 'survey';
 
 interface SpeakerForm {
   speaker: string; ipa: string; ortho: string; utterances: number;
-  arabicSim: number | null; persianSim: number | null;
+  // Similarity scores keyed by the configured CLEF primary contact-language
+  // code (e.g. "ar", "fa", "eng", "spa"). Null means "no score on disk" --
+  // either the cognate compute hasn't run, or there was no reference form
+  // to score against. The table headers are driven by the same key set so
+  // any pair/triple the user configured renders cleanly without a code edit.
+  similarityByLang: Record<string, number | null>;
   cognate: string; flagged: boolean;
   startSec: number | null; endSec: number | null;
 }
@@ -198,6 +203,7 @@ function buildSpeakerForm(
   speaker: string,
   enrichments: Record<string, unknown>,
   flagged: boolean,
+  primaryContactCodes: readonly string[],
 ): SpeakerForm {
   const conceptIntervals = (record?.tiers.concept?.intervals ?? []).filter((interval) => conceptMatchesIntervalText(concept, interval.text));
   const ipaIntervals = record?.tiers.ipa?.intervals ?? [];
@@ -222,8 +228,10 @@ function buildSpeakerForm(
     const score = (cell as Record<string, unknown>).score;
     return typeof score === 'number' ? score : null;
   };
-  const arabicSim = rawSim('ar');
-  const persianSim = rawSim('fa');
+  const similarityByLang: Record<string, number | null> = {};
+  for (const code of primaryContactCodes) {
+    similarityByLang[code] = rawSim(code);
+  }
 
   const overrides = isRecord(enrichments.manual_overrides) ? enrichments.manual_overrides as Record<string, unknown> : null;
   const overrideSets = overrides && isRecord(overrides.cognate_sets) ? overrides.cognate_sets as Record<string, unknown> : null;
@@ -259,8 +267,7 @@ function buildSpeakerForm(
     ipa: matchingIpaIntervals[0]?.text ?? '',
     ortho: orthoText,
     utterances: matchingIpaIntervals.length,
-    arabicSim,
-    persianSim,
+    similarityByLang,
     cognate,
     flagged: speakerFlagged || flagged,
     startSec: primaryConceptInterval ? primaryConceptInterval.start : null,
@@ -2914,8 +2921,9 @@ export function ParseUI() {
       speaker,
       enrichmentData,
       flagged,
+      primaryContactCodes,
     ));
-  }, [annotationRecords, concept, enrichmentData, getTagsForConcept, selectedSpeakers, speakers]);
+  }, [annotationRecords, concept, enrichmentData, getTagsForConcept, selectedSpeakers, speakers, primaryContactCodes]);
   const reviewed = concepts.filter(c => c.tag === 'confirmed').length;
   const total = concepts.length;
 
@@ -3731,8 +3739,15 @@ export function ParseUI() {
                       <tr className="bg-slate-50/70 text-[10px] uppercase tracking-wider text-slate-500">
                         <th className="px-3 py-2 text-left font-semibold">Speaker</th>
                         <th className="px-3 py-2 text-left font-semibold">IPA & utterances</th>
-                        <th className="px-3 py-2 text-left font-semibold">Arabic sim.</th>
-                        <th className="px-3 py-2 text-left font-semibold">Persian sim.</th>
+                        {primaryContactCodes.map((code) => (
+                          <th
+                            key={code}
+                            className="px-3 py-2 text-left font-semibold"
+                            data-testid={`sim-col-header-${code}`}
+                          >
+                            {(contactLanguageNames[code] ?? code.toUpperCase())} sim.
+                          </th>
+                        ))}
                         <th className="px-3 py-2 text-left font-semibold">Cognate</th>
                         <th className="px-3 py-2 text-right font-semibold">Flag</th>
                       </tr>
@@ -3768,8 +3783,15 @@ export function ParseUI() {
                             </div>
                             <div className="text-[10px] text-slate-400">{f.utterances} utterance{f.utterances!==1?'s':''}</div>
                           </td>
-                          <td className="px-3 py-2.5"><SimBar value={f.arabicSim}/></td>
-                          <td className="px-3 py-2.5"><SimBar value={f.persianSim}/></td>
+                          {primaryContactCodes.map((code) => (
+                            <td
+                              key={code}
+                              className="px-3 py-2.5"
+                              data-testid={`sim-cell-${f.speaker}-${code}`}
+                            >
+                              <SimBar value={f.similarityByLang[code] ?? null}/>
+                            </td>
+                          ))}
                           <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
                             <CognateCell
                               speaker={f.speaker}
@@ -3791,7 +3813,8 @@ export function ParseUI() {
                         </tr>
                         {isExpanded && (
                           <tr data-testid={`lexeme-detail-row-${f.speaker}`}>
-                            <td colSpan={6} className="bg-slate-50 p-2">
+                            {/* Speaker + IPA + N sim columns + Cognate + Flag. */}
+                            <td colSpan={4 + primaryContactCodes.length} className="bg-slate-50 p-2">
                               <LexemeDetail
                                 speaker={f.speaker}
                                 conceptId={concept.key}
@@ -3800,8 +3823,6 @@ export function ParseUI() {
                                 ortho={f.ortho}
                                 startSec={f.startSec}
                                 endSec={f.endSec}
-                                arabicSim={f.arabicSim}
-                                persianSim={f.persianSim}
                                 cognateGroup={f.cognate !== '—' ? f.cognate : null}
                                 cognateColor={cognateColor}
                               />

--- a/src/components/compare/ConceptTable.tsx
+++ b/src/components/compare/ConceptTable.tsx
@@ -154,20 +154,6 @@ function getCognateGroup(
   return null;
 }
 
-function getSimilarity(
-  enrichmentData: Record<string, unknown>,
-  conceptId: string,
-  speaker: string,
-  lang: string,
-): number | null {
-  const block = enrichmentData?.similarity as
-    | Record<string, Record<string, Record<string, { score?: number }>>>
-    | undefined;
-  const entry = block?.[conceptId]?.[speaker]?.[lang];
-  if (entry && typeof entry.score === "number") return entry.score;
-  return null;
-}
-
 function expandKey(speaker: string, conceptId: string): string {
   return `${speaker}::${conceptId}`;
 }
@@ -430,8 +416,6 @@ export function ConceptTable({ onPlayEntry }: ConceptTableProps) {
                             ortho={entry.ortho}
                             startSec={entry.startSec}
                             endSec={entry.endSec}
-                            arabicSim={getSimilarity(enrichmentData, concept.id, sp, "ar")}
-                            persianSim={getSimilarity(enrichmentData, concept.id, sp, "fa")}
                             cognateGroup={cognate?.group ?? null}
                             cognateColor={cognate?.color ?? null}
                           />

--- a/src/components/compare/LexemeDetail.tsx
+++ b/src/components/compare/LexemeDetail.tsx
@@ -14,8 +14,6 @@ interface LexemeDetailProps {
   ortho: string;
   startSec: number | null;
   endSec: number | null;
-  arabicSim?: number | null;
-  persianSim?: number | null;
   cognateGroup?: string | null;
   cognateColor?: string | null;
 }


### PR DESCRIPTION
## Summary

The Reference Forms cards were already dynamic, but the **Speaker forms table** still had hard-coded **Arabic sim.** / **Persian sim.** columns. Anyone who configured primaries other than `ar + fa` got mis-labelled columns and no scores — because \`buildSpeakerForm\` read only \`.ar\` and \`.fa\` regardless of what the backend actually wrote.

## What changed

- \`SpeakerForm.arabicSim\` / \`.persianSim\` → **\`similarityByLang: Record<string, number | null>\`**. Any number of primary contact languages round-trips through the builder without code churn.
- \`buildSpeakerForm\` now takes \`primaryContactCodes\` and loops to build the map; cell values still come from the existing \`rawSim\` helper that reads the backend's \`{score, has_reference_data}\` shape.
- Table header row is a \`.map\` over \`primaryContactCodes\` with labels pulled from \`clefStatus.languages[code].name\` — so e.g. configuring eng + spa renders **English sim.** / **Spanish sim.** headers. Falls back to the uppercase code while CLEF status is still loading.
- Table body mirrors the same loop, so cells stay aligned with headers regardless of how many languages are configured. The expanded-detail row's \`colSpan\` scales with \`4 + N\`.
- \`LexemeDetail\` shed its dead \`arabicSim\` / \`persianSim\` props (declared but never read).
- Reference Forms cards were already iterating \`primaryContactCodes\`; this change just aligns the similarity table with that existing pattern so there is a single source of truth for the configured language set.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 248/248 passing
  - Existing PR #208 case now seeds \`mockClefConfig\` with \`primary_contact_languages: ['ar','fa']\` and awaits the dynamic headers before asserting real scores.
  - New case configures eng + spa, asserts **English sim.** / **Spanish sim.** headers render, Arabic/Persian test ids are absent, and scores render under the new \`sim-cell-<speaker>-<code>\` test ids.
- [ ] Manual: reconfigure CLEF to eng + spa → populate → columns + reference cards render English + Spanish end-to-end; switch back to ar + fa → columns recover cleanly.

## Preserves

- The Save & populate → auto-recompute chain from #208 (\`similarityJob\`).
- Null-scores rendering as \`—\` via \`SimBar\`.
- Hidden-when-not-configured gate on Reference Forms (empty \`primary_contact_languages\` still hides the whole section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)