### PR TITLE
feat(clef): multi-form Reference Forms + selection persistence

### DIFF
--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -4750,7 +4750,7 @@ class ParseChatTools:
         if isinstance(contact_override_raw, list):
             contact_override = [str(item).strip().lower() for item in contact_override_raw if str(item).strip()]
 
-        contact_languages_from_config, refs_by_concept = cognate_compute_module.load_contact_language_data(
+        contact_languages_from_config, refs_by_concept, form_selections_by_concept = cognate_compute_module.load_contact_language_data(
             self.sil_config_path
         )
         contact_languages = contact_override or contact_languages_from_config
@@ -4810,6 +4810,7 @@ class ParseChatTools:
                 concepts=concept_specs,
                 contact_languages=contact_languages,
                 refs_by_concept=refs_by_concept,
+                form_selections_by_concept=form_selections_by_concept,
             )
 
         if speaker_filter:

--- a/python/compare/cognate_compute.py
+++ b/python/compare/cognate_compute.py
@@ -502,15 +502,33 @@ def _append_contact_ref(
     by_lang[language_code] = _dedupe_non_empty_strings(existing + forms)
 
 
-def load_contact_language_data(path: Path) -> Tuple[List[str], Dict[str, Dict[str, List[str]]]]:
+def load_contact_language_data(
+    path: Path,
+) -> Tuple[List[str], Dict[str, Dict[str, List[str]]], Dict[str, Dict[str, List[str]]]]:
+    """Load the SIL contact-language config.
+
+    Returns ``(selected_languages, refs_by_concept, form_selections_by_concept)``.
+
+    ``form_selections_by_concept`` mirrors ``_meta.form_selections`` --
+    the per-(concept, lang) allow-list the user set in the Reference
+    Forms panel. The inner value per concept/lang is either:
+
+        * missing key       -> no explicit selection; every populated ref
+          is used (default, preserves pre-selection compute behaviour)
+        * non-empty list    -> only those form strings contribute
+        * empty list ``[]`` -> user deliberately deselected every form;
+          similarity for that pair is skipped downstream
+
+    :func:`filter_refs_by_selection` applies the mask at scoring time.
+    """
     if not path.exists():
         _warn(f"Contact language config not found: {path}")
-        return (list(PREFERRED_CONTACT_LANGUAGES), {})
+        return (list(PREFERRED_CONTACT_LANGUAGES), {}, {})
 
     raw = _load_json(path)
     if not isinstance(raw, dict):
         _warn(f"Contact language config is not an object: {path}")
-        return (list(PREFERRED_CONTACT_LANGUAGES), {})
+        return (list(PREFERRED_CONTACT_LANGUAGES), {}, {})
 
     language_codes = [
         code for code, data in raw.items()
@@ -561,7 +579,59 @@ def load_contact_language_data(path: Path) -> Tuple[List[str], Dict[str, Dict[st
             for concept_key, raw_forms in scoped.items():
                 _append_contact_ref(refs_by_concept, concept_key, code, raw_forms)
 
-    return (selected_languages, refs_by_concept)
+    # Parse _meta.form_selections -> {concept_key: {lang: [form,...]}}.
+    # Concept keys are normalised the same way refs_by_concept keys its
+    # data so "water" and "#water:WATER" both route to the same concept.
+    form_selections_by_concept: Dict[str, Dict[str, List[str]]] = {}
+    selections_raw = meta.get("form_selections") if isinstance(meta, dict) else None
+    if isinstance(selections_raw, dict):
+        for concept_key, per_lang in selections_raw.items():
+            if not isinstance(concept_key, str) or not isinstance(per_lang, dict):
+                continue
+            normalized_concept = _normalize_concept_key(concept_key)
+            if not normalized_concept:
+                continue
+            concept_entry: Dict[str, List[str]] = {}
+            for lang_code, forms in per_lang.items():
+                if not isinstance(lang_code, str):
+                    continue
+                code_text = lang_code.strip().lower()
+                if not code_text:
+                    continue
+                if isinstance(forms, list):
+                    concept_entry[code_text] = _dedupe_non_empty_strings(forms)
+            if concept_entry:
+                form_selections_by_concept[normalized_concept] = concept_entry
+
+    return (selected_languages, refs_by_concept, form_selections_by_concept)
+
+
+def filter_refs_by_selection(
+    refs: List[str],
+    selection: Optional[List[str]],
+) -> Tuple[List[str], bool]:
+    """Apply a user form-selection mask to a list of populated refs.
+
+    Returns ``(filtered_refs, explicit_empty)``:
+
+        * ``selection is None``: no explicit selection for this pair,
+          so return ``refs`` unchanged; ``explicit_empty`` is False.
+        * ``selection == []``: user deselected every form -- return
+          empty list with ``explicit_empty`` True so callers can
+          distinguish "no refs available" from "user opted out".
+        * non-empty selection: keep only refs whose normalised string
+          appears in the allow-list. Unknown selection entries (e.g.
+          forms removed by a re-populate) are silently ignored.
+    """
+    if selection is None:
+        return (list(refs), False)
+    if not selection:
+        return ([], True)
+
+    allowed = {_normalize_space(item) for item in selection if isinstance(item, str)}
+    allowed.discard("")
+    filtered = [ref for ref in refs if _normalize_space(ref) in allowed]
+    return (filtered, False)
 
 
 def _levenshtein_distance(left: str, right: str) -> int:
@@ -752,8 +822,20 @@ def compute_similarity_scores(
     concepts: Sequence[ConceptSpec],
     contact_languages: Sequence[str],
     refs_by_concept: Mapping[str, Mapping[str, List[str]]],
+    form_selections_by_concept: Optional[Mapping[str, Mapping[str, List[str]]]] = None,
 ) -> Dict[str, Dict[str, Dict[str, SimilarityScore]]]:
+    """Compute per-(concept, speaker, lang) similarity scores.
+
+    When ``form_selections_by_concept`` is provided, the user's Reference
+    Forms selection mask is applied before taking the per-ref ``min`` --
+    i.e. only selected forms contribute to the best-match score (max
+    similarity = min edit distance). An empty selection list for a
+    (concept, lang) pair means "none selected", and similarity is
+    skipped for that pair (``has_reference_data`` stays True so the UI
+    can distinguish "user opted out" from "no refs available").
+    """
     similarity: Dict[str, Dict[str, Dict[str, SimilarityScore]]] = {}
+    selections = form_selections_by_concept or {}
 
     for concept in concepts:
         concept_id = concept.concept_id
@@ -764,16 +846,39 @@ def compute_similarity_scores(
         refs_for_concept = _resolve_contact_refs(concept, refs_by_concept)
         concept_scores: Dict[str, Dict[str, SimilarityScore]] = {}
 
+        # Selections are keyed by normalised concept id, so a key written
+        # as "water" or "#water:WATER" routes to the same concept spec.
+        concept_selection: Mapping[str, List[str]] = {}
+        for selection_key in (concept_id, concept.label):
+            normalized = _normalize_concept_key(selection_key) if selection_key else ""
+            if not normalized:
+                continue
+            candidate = selections.get(normalized)
+            if isinstance(candidate, Mapping):
+                concept_selection = candidate
+                break
+
         for record in records:
             speaker_scores: Dict[str, SimilarityScore] = {}
             for language_code in contact_languages:
                 refs = refs_for_concept.get(language_code, [])
                 has_reference_data = bool(refs)
-                if has_reference_data:
-                    distance = min(_normalized_edit_distance(record.ipa, ref) for ref in refs)
-                    score: Optional[float] = round(float(distance), 3)
+
+                selection = concept_selection.get(language_code) if concept_selection else None
+                filtered_refs, explicit_empty = filter_refs_by_selection(refs, selection)
+
+                if explicit_empty:
+                    # User deliberately deselected every form for this
+                    # (concept, lang) -- flag similarity as unavailable
+                    # so the UI can show "selection disabled" rather
+                    # than a fake score.
+                    score: Optional[float] = None
+                elif filtered_refs:
+                    distance = min(_normalized_edit_distance(record.ipa, ref) for ref in filtered_refs)
+                    score = round(float(distance), 3)
                 else:
                     score = None
+
                 speaker_scores[language_code] = {
                     "score": score,
                     "has_reference_data": has_reference_data,
@@ -1132,7 +1237,7 @@ def _parse_cli_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
 
 def _run_compute_command(args: argparse.Namespace) -> int:
     try:
-        contact_languages_from_config, refs_by_concept = load_contact_language_data(args.sil_config)
+        contact_languages_from_config, refs_by_concept, form_selections_by_concept = load_contact_language_data(args.sil_config)
 
         contact_languages_override = [
             token.strip().lower()
@@ -1154,6 +1259,7 @@ def _run_compute_command(args: argparse.Namespace) -> int:
             concepts=concepts,
             contact_languages=contact_languages,
             refs_by_concept=refs_by_concept,
+            form_selections_by_concept=form_selections_by_concept,
         )
 
     except RuntimeError as exc:

--- a/python/compare/test_form_selections.py
+++ b/python/compare/test_form_selections.py
@@ -1,0 +1,231 @@
+"""Tests for the Reference Forms selection mask.
+
+Covers the three legs of ``filter_refs_by_selection`` semantics, the
+round-trip through ``load_contact_language_data``, and the resulting
+``compute_similarity_scores`` behaviour when selections are active.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+try:
+    from .cognate_compute import (
+        ConceptSpec,
+        FormRecord,
+        compute_similarity_scores,
+        filter_refs_by_selection,
+        load_contact_language_data,
+    )
+except ImportError:  # pragma: no cover -- direct-invoke fallback
+    from cognate_compute import (  # type: ignore
+        ConceptSpec,
+        FormRecord,
+        compute_similarity_scores,
+        filter_refs_by_selection,
+        load_contact_language_data,
+    )
+
+
+# ---------------------------------------------------------------------------
+# filter_refs_by_selection
+# ---------------------------------------------------------------------------
+
+def test_filter_refs_by_selection_none_returns_refs_unchanged():
+    refs = ["maːʔ", "ماء", "muya"]
+    filtered, explicit_empty = filter_refs_by_selection(refs, None)
+    assert filtered == refs
+    # Returns a *copy* so callers can mutate freely.
+    assert filtered is not refs
+    assert explicit_empty is False
+
+
+def test_filter_refs_by_selection_empty_is_explicit_opt_out():
+    refs = ["maːʔ", "ماء"]
+    filtered, explicit_empty = filter_refs_by_selection(refs, [])
+    assert filtered == []
+    assert explicit_empty is True
+
+
+def test_filter_refs_by_selection_subset_keeps_only_allowed():
+    refs = ["maːʔ", "ماء", "muya"]
+    filtered, explicit_empty = filter_refs_by_selection(refs, ["ماء"])
+    assert filtered == ["ماء"]
+    assert explicit_empty is False
+
+
+def test_filter_refs_by_selection_ignores_unknown_entries():
+    # A selection carrying a form no longer in ``refs`` (maybe removed by
+    # a later re-populate) should just be dropped, not surfaced as an
+    # explicit-empty signal.
+    refs = ["maːʔ"]
+    filtered, explicit_empty = filter_refs_by_selection(refs, ["stale-form"])
+    assert filtered == []
+    assert explicit_empty is False
+
+
+def test_filter_refs_by_selection_normalises_whitespace():
+    refs = ["  maːʔ  "]
+    filtered, explicit_empty = filter_refs_by_selection(refs, ["maːʔ"])
+    assert filtered == ["  maːʔ  "]
+    assert explicit_empty is False
+
+
+# ---------------------------------------------------------------------------
+# load_contact_language_data
+# ---------------------------------------------------------------------------
+
+def _write_sil_config(tmp_path: Path, payload: dict) -> Path:
+    p = tmp_path / "sil_contact_languages.json"
+    p.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return p
+
+
+def test_load_contact_language_data_returns_empty_selections_by_default(tmp_path):
+    path = _write_sil_config(tmp_path, {
+        "_meta": {"primary_contact_languages": ["ar"]},
+        "ar": {"name": "Arabic", "concepts": {"water": ["maːʔ"]}},
+    })
+    _, _, selections = load_contact_language_data(path)
+    assert selections == {}
+
+
+def test_load_contact_language_data_parses_form_selections(tmp_path):
+    path = _write_sil_config(tmp_path, {
+        "_meta": {
+            "primary_contact_languages": ["ar", "fa"],
+            "form_selections": {
+                "water": {
+                    "ar": ["ماء"],
+                    "fa": [],   # explicit opt-out
+                },
+            },
+        },
+        "ar": {"name": "Arabic", "concepts": {"water": ["ماء", "maːʔ"]}},
+        "fa": {"name": "Persian", "concepts": {"water": ["آب"]}},
+    })
+    _, _, selections = load_contact_language_data(path)
+    assert selections == {
+        "water": {
+            "ar": ["ماء"],
+            "fa": [],
+        },
+    }
+
+
+def test_load_contact_language_data_normalises_concept_keys(tmp_path):
+    path = _write_sil_config(tmp_path, {
+        "_meta": {
+            "primary_contact_languages": ["ar"],
+            "form_selections": {
+                "#water:Water": {"ar": ["ماء"]},
+            },
+        },
+        "ar": {"name": "Arabic", "concepts": {"water": ["ماء"]}},
+    })
+    _, _, selections = load_contact_language_data(path)
+    assert "water" in selections
+    assert selections["water"]["ar"] == ["ماء"]
+
+
+def test_load_contact_language_data_skips_malformed_selection_shapes(tmp_path):
+    path = _write_sil_config(tmp_path, {
+        "_meta": {
+            "primary_contact_languages": ["ar"],
+            "form_selections": {
+                "water": "not-a-dict",
+                "fire": {"ar": "not-a-list"},
+                "": {"ar": ["stale"]},
+            },
+        },
+        "ar": {"name": "Arabic", "concepts": {"water": ["ماء"]}},
+    })
+    _, _, selections = load_contact_language_data(path)
+    assert selections == {}
+
+
+# ---------------------------------------------------------------------------
+# compute_similarity_scores honours the mask
+# ---------------------------------------------------------------------------
+
+def _make_records(speaker: str, concept_id: str, ipa: str) -> dict:
+    return {concept_id: [FormRecord(
+        speaker=speaker,
+        concept_id=concept_id,
+        concept_label="",
+        ipa=ipa,
+        ortho="",
+        start_sec=0.0,
+        end_sec=1.0,
+    )]}
+
+
+def test_compute_similarity_scores_without_selection_uses_all_refs():
+    records = _make_records("SPK-01", "water", "maːʔ")
+    refs = {"water": {"ar": ["ماء", "maːʔ"]}}
+    scores = compute_similarity_scores(
+        forms_by_concept=records,
+        concepts=[ConceptSpec(concept_id="water", label="water")],
+        contact_languages=["ar"],
+        refs_by_concept=refs,
+    )
+    assert scores["water"]["SPK-01"]["ar"]["has_reference_data"] is True
+    assert scores["water"]["SPK-01"]["ar"]["score"] == 0.0
+
+
+def test_compute_similarity_scores_selection_filters_refs():
+    # Exact-match IPA ref is deselected -> only the Arabic-script ref is
+    # considered, so the edit distance jumps from 0.0 to 1.0.
+    records = _make_records("SPK-01", "water", "maːʔ")
+    refs = {"water": {"ar": ["ماء", "maːʔ"]}}
+    selections = {"water": {"ar": ["ماء"]}}
+    scores = compute_similarity_scores(
+        forms_by_concept=records,
+        concepts=[ConceptSpec(concept_id="water", label="water")],
+        contact_languages=["ar"],
+        refs_by_concept=refs,
+        form_selections_by_concept=selections,
+    )
+    assert scores["water"]["SPK-01"]["ar"]["score"] == 1.0
+
+
+def test_compute_similarity_scores_empty_selection_skips_similarity():
+    records = _make_records("SPK-01", "water", "maːʔ")
+    refs = {"water": {"ar": ["ماء", "maːʔ"]}}
+    selections = {"water": {"ar": []}}
+    scores = compute_similarity_scores(
+        forms_by_concept=records,
+        concepts=[ConceptSpec(concept_id="water", label="water")],
+        contact_languages=["ar"],
+        refs_by_concept=refs,
+        form_selections_by_concept=selections,
+    )
+    cell = scores["water"]["SPK-01"]["ar"]
+    # refs exist on disk, but user deselected everything -> score is
+    # skipped while has_reference_data remains True so the UI can
+    # distinguish this from "no refs available".
+    assert cell["has_reference_data"] is True
+    assert cell["score"] is None
+
+
+def test_compute_similarity_scores_selection_routes_by_concept_label():
+    # The ConceptSpec here has a numeric concept_id + English label.
+    # Selections written against the English label (what the UI uses as
+    # its stable key) should still apply to records keyed by the
+    # numeric id.
+    records = _make_records("SPK-01", "42", "maːʔ")
+    refs = {"42": {"ar": ["ماء", "maːʔ"]}}
+    selections = {"water": {"ar": ["ماء"]}}   # deselect the exact IPA match
+    scores = compute_similarity_scores(
+        forms_by_concept=records,
+        concepts=[ConceptSpec(concept_id="42", label="water")],
+        contact_languages=["ar"],
+        refs_by_concept=refs,
+        form_selections_by_concept=selections,
+    )
+    # Label "water" matched the selection, exact IPA was filtered out,
+    # so the best remaining ref is the Arabic-script "ماء" -> distance 1.0.
+    assert scores["42"]["SPK-01"]["ar"]["score"] == 1.0

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -47,7 +47,7 @@ import { SpeakerImport } from './components/compare/SpeakerImport';
 import { ClefConfigModal, type ClefConfigModalTab } from './components/compute/ClefConfigModal';
 import { ClefPopulateSummaryBanner } from './components/compute/ClefPopulateSummaryBanner';
 import { ClefSourcesReportModal } from './components/compute/ClefSourcesReportModal';
-import { getClefConfig, getContactLexemeCoverage } from './api/client';
+import { getClefConfig, getContactLexemeCoverage, saveClefFormSelections } from './api/client';
 import type { ClefConfigStatus } from './api/types';
 
 type ConceptTag = 'untagged' | 'review' | 'confirmed' | 'problematic';
@@ -276,77 +276,188 @@ function buildSpeakerForm(
   };
 }
 
-interface ReferenceFormDisplay {
+// ---------------------------------------------------------------------------
+// Reference-form parsing + classification (display-only; no transliteration)
+// ---------------------------------------------------------------------------
+// The Reference Forms panel renders every form the providers wrote for a
+// (concept, language), letting the user pick which ones contribute to the
+// similarity score. The functions below are pure *display* helpers: they
+// never transliterate script to IPA. A bare string is routed to either the
+// ``script`` slot or the ``ipa`` slot based on a conservative Unicode-range
+// check, and the raw text is preserved verbatim. See ``classifyRawFormString``
+// for the allowed non-Latin scripts. No character substitution happens
+// anywhere in this pipeline.
+
+// Unicode blocks we explicitly recognise as "not IPA" for display tagging.
+// A bare string containing any char in these blocks is routed to the
+// script slot; everything else (Latin + IPA extensions + diacritics) goes
+// to the ipa slot. This is a tag, not a transformation -- the raw text is
+// preserved as-is regardless of which slot it lands in.
+const NON_LATIN_SCRIPT_RE = /[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u07C0-\u07FF\u0780-\u07BF\u0900-\u097F\u0A80-\u0AFF\u0B80-\u0BFF\u0E00-\u0E7F\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF\uFB50-\uFDFF\uFE70-\uFEFF]/;
+
+/** Classify a bare reference-form string as script vs IPA for display.
+ *  This is a display hint only -- the returned object always carries the
+ *  *same* raw text in whichever slot it lands. No transliteration ever
+ *  happens here. Strings containing any recognised non-Latin script char
+ *  go into the ``script`` slot; everything else is treated as IPA
+ *  (matches the contract of providers like Grokipedia / ASJP that
+ *  promise phonetic output). */
+function classifyRawFormString(raw: string): { script: string; ipa: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { script: '', ipa: '' };
+  if (NON_LATIN_SCRIPT_RE.test(trimmed)) {
+    return { script: trimmed, ipa: '' };
+  }
+  return { script: '', ipa: trimmed };
+}
+
+export interface ReferenceFormEntry {
+  /** Exact raw source string. Used as the stable selection key so
+   *  ``_meta.form_selections`` persists verbatim across reloads. */
+  raw: string;
   script: string;
   ipa: string;
   audioUrl: string | null;
-  available: boolean;
+  /** Provenance sources when available (``wikidata``, ``asjp``, ...).
+   *  Empty for bare-string legacy entries and rolled-up non-provenance
+   *  shapes that had no explicit source list. */
+  sources: string[];
 }
 
-function parseReferenceForm(raw: unknown): ReferenceFormDisplay {
+function _parseOneEntry(raw: unknown): ReferenceFormEntry | null {
   if (typeof raw === 'string') {
-    return { script: '', ipa: raw.trim(), audioUrl: null, available: raw.trim().length > 0 };
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const { script, ipa } = classifyRawFormString(trimmed);
+    return { raw: trimmed, script, ipa, audioUrl: null, sources: [] };
   }
 
-  if (Array.isArray(raw)) {
-    return raw.length > 0 ? parseReferenceForm(raw[0]) : { script: '', ipa: '', audioUrl: null, available: false };
-  }
+  if (!isRecord(raw)) return null;
 
-  if (!isRecord(raw)) {
-    return { script: '', ipa: '', audioUrl: null, available: false };
-  }
-
-  // Provenance shape ({form, sources}) is what the CLEF populate flow
-  // now writes. The "form" string is the phonetic rendering, so route
-  // it into the ipa slot to match the bare-string legacy behaviour --
-  // the Reference Forms card renders the same text in both cases, only
-  // the stored shape differs.
+  // Provenance shape: { form: <string>, sources: [<provider>, ...] }.
+  // The ``form`` value is the verbatim provider output; we still tag it
+  // by Unicode range so e.g. an LLM response that slipped into Arabic
+  // script doesn't display in the IPA slot.
   if (typeof raw.form === 'string' && Array.isArray(raw.sources)) {
-    const trimmed = raw.form.trim();
-    return { script: '', ipa: trimmed, audioUrl: null, available: trimmed.length > 0 };
+    const trimmed = (raw.form as string).trim();
+    if (!trimmed) return null;
+    const sources = (raw.sources as unknown[]).filter((s): s is string => typeof s === 'string');
+    const { script, ipa } = classifyRawFormString(trimmed);
+    const audioUrl = typeof raw.audioUrl === 'string' && raw.audioUrl.trim() ? raw.audioUrl : null;
+    return { raw: trimmed, script, ipa, audioUrl, sources };
   }
 
-  const script = [raw.script, raw.orthography, raw.form, raw.text].find((value) => typeof value === 'string' && value.trim().length > 0);
-  const ipa = [raw.ipa, raw.phonetic, raw.transcription].find((value) => typeof value === 'string' && value.trim().length > 0);
-  const audioUrl = [raw.audioUrl, raw.audio, raw.url].find((value) => typeof value === 'string' && value.trim().length > 0);
+  // Structured provider objects with explicit field labels. Trust the
+  // label: if the provider wrote ``ipa: "foo"`` we display "foo" as IPA
+  // even if it contains script-range chars -- that's their claim.
+  const scriptVal = [raw.script, raw.orthography, raw.text].find(
+    (v) => typeof v === 'string' && (v as string).trim().length > 0,
+  ) as string | undefined;
+  const ipaVal = [raw.ipa, raw.phonetic, raw.transcription].find(
+    (v) => typeof v === 'string' && (v as string).trim().length > 0,
+  ) as string | undefined;
+  const audioUrl = [raw.audioUrl, raw.audio, raw.url].find(
+    (v) => typeof v === 'string' && (v as string).trim().length > 0,
+  ) as string | undefined;
+
+  // A bare ``form`` field with no sources array -- treat as a generic
+  // string and classify by Unicode range (matches the bare-string path).
+  if (!scriptVal && !ipaVal && typeof raw.form === 'string' && (raw.form as string).trim()) {
+    const trimmed = (raw.form as string).trim();
+    const { script, ipa } = classifyRawFormString(trimmed);
+    return {
+      raw: trimmed,
+      script,
+      ipa,
+      audioUrl: audioUrl ?? null,
+      sources: [],
+    };
+  }
+
+  if (!scriptVal && !ipaVal) return null;
+
+  // Selection keys against structured objects prefer the IPA text (it's
+  // the canonical similarity-scoring string), falling back to script.
+  const rawKey = (ipaVal ?? scriptVal ?? '').trim();
+  if (!rawKey) return null;
 
   return {
-    script: typeof script === 'string' ? script : '',
-    ipa: typeof ipa === 'string' ? ipa : '',
-    audioUrl: typeof audioUrl === 'string' ? audioUrl : null,
-    available: Boolean(script || ipa),
+    raw: rawKey,
+    script: scriptVal ?? '',
+    ipa: ipaVal ?? '',
+    audioUrl: audioUrl ?? null,
+    sources: [],
   };
 }
 
-/** Resolve reference forms for a concept across a dynamic set of language
- *  codes (driven by the user's CLEF primary_contact_languages). Checks the
- *  enrichments.reference_forms map first; falls back to the per-workspace
- *  SIL contact-language config (what `Save & populate` writes into) so the
- *  cards surface real data regardless of which store the fetcher wrote to. */
-function resolveReferenceForms(
+/** Parse any provider-shaped reference data into an ordered list of
+ *  display entries. Accepts the legacy string/array/object shapes the
+ *  Reference Forms pipeline has seen. Duplicates (by raw text) collapse
+ *  so a form fetched by multiple providers shows up once. */
+export function parseReferenceFormList(raw: unknown): ReferenceFormEntry[] {
+  const out: ReferenceFormEntry[] = [];
+  const seen = new Set<string>();
+  const push = (entry: ReferenceFormEntry | null) => {
+    if (!entry || seen.has(entry.raw)) return;
+    seen.add(entry.raw);
+    out.push(entry);
+  };
+  if (Array.isArray(raw)) {
+    for (const item of raw) push(_parseOneEntry(item));
+  } else {
+    push(_parseOneEntry(raw));
+  }
+  return out;
+}
+
+/** List-shaped resolver that preserves every
+ *  provider-returned form instead of collapsing to the first one. Drives
+ *  the Reference Forms panel's multi-form display + selection UI. Keyed
+ *  by primary contact-language code; absent codes mean no populated
+ *  forms were found (or the fallback SIL entry was empty too). */
+export function resolveReferenceFormLists(
   enrichments: Record<string, unknown>,
   silConcepts: Record<string, Record<string, unknown>>,
   concept: Concept,
-  codes: string[],
-): Record<string, ReferenceFormDisplay> {
+  codes: readonly string[],
+): Record<string, ReferenceFormEntry[]> {
   const root = isRecord(enrichments.reference_forms) ? enrichments.reference_forms as Record<string, unknown> : null;
   const conceptEntry = root ? root[concept.key] ?? root[concept.name] : null;
   const conceptRecord = isRecord(conceptEntry) ? conceptEntry : {};
 
-  const out: Record<string, ReferenceFormDisplay> = {};
+  const out: Record<string, ReferenceFormEntry[]> = {};
   for (const code of codes) {
-    const primary = parseReferenceForm(conceptRecord[code]);
-    if (primary.available) {
+    const primary = parseReferenceFormList(conceptRecord[code]);
+    if (primary.length > 0) {
       out[code] = primary;
       continue;
     }
-    // SIL config stores forms as {concept_en: [ipa, ...]} keyed by
-    // language code. parseReferenceForm already handles string / array /
-    // object shapes so we can pass the value straight through.
     const silForConcept = silConcepts[code]?.[concept.name];
-    out[code] = parseReferenceForm(silForConcept);
+    const fallback = parseReferenceFormList(silForConcept);
+    if (fallback.length > 0) out[code] = fallback;
   }
   return out;
+}
+
+/** Read the user's persisted form-selection allow-list for one
+ *  (concept, lang) out of ``clefStatus.meta.form_selections``. Returns
+ *  ``null`` when no explicit selection exists for that pair -- the
+ *  caller should treat that as "every populated form is selected"
+ *  (the default). Returns ``[]`` for explicit opt-out. */
+export function resolveFormSelection(
+  clefMeta: Record<string, unknown> | null | undefined,
+  conceptEn: string,
+  langCode: string,
+): string[] | null {
+  const selections = clefMeta && isRecord(clefMeta.form_selections)
+    ? (clefMeta.form_selections as Record<string, unknown>)
+    : null;
+  if (!selections) return null;
+  const perConcept = selections[conceptEn];
+  if (!isRecord(perConcept)) return null;
+  const entry = perConcept[langCode];
+  if (!Array.isArray(entry)) return null;
+  return entry.filter((v): v is string => typeof v === 'string');
 }
 
 /** Map a language code to a display tone + text direction for the
@@ -2069,6 +2180,39 @@ export function ParseUI() {
     void refreshClefStatus();
   }, [refreshClefStatus]);
 
+  // Optimistic overlay for Reference Forms selections. Clicks in the
+  // panel update this map immediately while the POST writes through to
+  // ``_meta.form_selections``. Keyed by ``"<concept_en>|<lang_code>"``
+  // so re-selecting across concepts doesn't clobber in-flight saves. A
+  // ``null`` value means "no explicit selection" (use every populated
+  // form); a ``string[]`` is the exact allow-list; empty array means
+  // "none selected" -- similarity will be skipped for that pair. Matches
+  // the backend contract in ``_api_post_clef_form_selections``.
+  const [localFormSelections, setLocalFormSelections] = useState<Record<string, string[] | null>>({});
+  const saveFormSelection = useCallback(
+    async (conceptEn: string, langCode: string, forms: string[]) => {
+      const key = `${conceptEn}|${langCode}`;
+      setLocalFormSelections((prev) => ({ ...prev, [key]: forms }));
+      try {
+        await saveClefFormSelections({ concept_en: conceptEn, lang_code: langCode, forms });
+        // Pull fresh meta so a reload or other consumer sees authoritative
+        // state, not just the optimistic overlay. The overlay stays in
+        // place meanwhile so there's no flash between save + refresh.
+        await refreshClefStatus();
+      } catch (err) {
+        // On error, drop the optimistic entry so the UI falls back to
+        // whatever ``clefStatus.meta.form_selections`` reports.
+        setLocalFormSelections((prev) => {
+          const next = { ...prev };
+          delete next[key];
+          return next;
+        });
+        console.error('[clef] form selection save failed:', err);
+      }
+    },
+    [refreshClefStatus],
+  );
+
   const handleComputeRun = useCallback(() => {
     if (computeMode === 'contact-lexemes' && clefConfigured !== true) {
       setClefModalOpen(true);
@@ -2905,8 +3049,8 @@ export function ParseUI() {
   };
 
   const concept = concepts.find(c => c.id === conceptId) ?? concepts[0] ?? { id: 1, key: '1', name: '—', tag: 'untagged' as ConceptTag };
-  const referenceForms = useMemo(
-    () => resolveReferenceForms(enrichmentData, silConcepts, concept, primaryContactCodes),
+  const referenceFormLists = useMemo(
+    () => resolveReferenceFormLists(enrichmentData, silConcepts, concept, primaryContactCodes),
     [concept, enrichmentData, silConcepts, primaryContactCodes],
   );
   const borrowingCandidates = useMemo<unknown>(() => {
@@ -3693,41 +3837,145 @@ export function ParseUI() {
               {/* Reference forms — gated on the user's CLEF configuration.
                   Hidden entirely when no primary contact languages are
                   set; renders exactly one card per configured primary
-                  otherwise. The data source falls back from enrichments
-                  to the SIL contact-language config so forms surface as
-                  soon as "Save & populate" finishes, not only after a
-                  full enrichments recompute. */}
+                  otherwise. Each card lists every populated form with
+                  a checkbox so the user picks which forms contribute
+                  to the similarity score. Selections persist into
+                  ``_meta.form_selections`` via the backend; default is
+                  "all selected". No orthography -> IPA conversion
+                  happens -- forms are tagged by Unicode block (see
+                  ``classifyRawFormString``) and displayed verbatim. */}
               {primaryContactCodes.length > 0 && (
                 <SectionCard title="Reference forms">
                   <div className={`grid gap-4 ${primaryContactCodes.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
                     {primaryContactCodes.map((code, idx) => {
                       const { tone, dir } = referenceCardStyle(code, idx);
                       const label = contactLanguageNames[code] ?? code.toUpperCase();
-                      const data = referenceForms[code] ?? { script: '', ipa: '', audioUrl: null, available: false };
+                      const entries = referenceFormLists[code] ?? [];
+                      const selectionKey = `${concept.name}|${code}`;
+                      const persistedSelection = resolveFormSelection(clefStatus?.meta, concept.name, code);
+                      const localSelection = selectionKey in localFormSelections ? localFormSelections[selectionKey] : undefined;
+                      // Effective selection: local overlay takes precedence
+                      // over persisted meta; null from either means "no
+                      // explicit selection" -> all forms active by default.
+                      const effective: string[] | null = localSelection !== undefined ? localSelection : persistedSelection;
+                      const allSelected = effective === null;
+                      const selectedSet = new Set(effective ?? []);
+                      const isSelected = (rawForm: string) => allSelected || selectedSet.has(rawForm);
+                      const selectedCount = allSelected ? entries.length : entries.filter((e) => selectedSet.has(e.raw)).length;
+
+                      // Click handlers -- each call writes the next explicit
+                      // list (never null) so we always persist intent. "Select
+                      // all" writes the full list of raw strings rather than
+                      // passing null so the selection survives even if a
+                      // future populate adds new forms and the user re-opens
+                      // this concept without re-clicking.
+                      const rawAll = entries.map((e) => e.raw);
+                      const onToggle = (rawForm: string) => {
+                        const current = new Set(allSelected ? rawAll : rawAll.filter((r) => selectedSet.has(r)));
+                        if (current.has(rawForm)) current.delete(rawForm);
+                        else current.add(rawForm);
+                        // Preserve the entries' natural order in the persisted list.
+                        void saveFormSelection(concept.name, code, rawAll.filter((r) => current.has(r)));
+                      };
+                      const onSelectAll = () => { void saveFormSelection(concept.name, code, rawAll.slice()); };
+                      const onSelectNone = () => { void saveFormSelection(concept.name, code, []); };
+
                       return (
                         <div key={code} className="rounded-lg border border-slate-100 bg-slate-50/40 p-4" data-testid={`reference-form-${code}`}>
-                          <div className="flex items-center justify-between">
+                          <div className="flex items-center justify-between gap-2">
                             <span className={`text-[10px] font-semibold uppercase tracking-wider ${tone}`}>
                               {label} <span className="ml-1 font-mono text-slate-300">({code})</span>
                             </span>
-                            <button
-                              title={data.audioUrl ? `Play ${label} reference audio` : 'Reference audio not available'}
-                              onClick={() => {
-                                if (!data.audioUrl) return;
-                                void new Audio(data.audioUrl).play().catch(() => {});
-                              }}
-                              className="text-slate-300 hover:text-slate-500"
-                            >
-                              <Volume2 className="h-3.5 w-3.5"/>
-                            </button>
+                            {entries.length > 0 && (
+                              <div className="flex items-center gap-2 text-[10px] text-slate-400">
+                                <span data-testid={`reference-form-${code}-count`}>{selectedCount}/{entries.length} selected</span>
+                                {entries.length > 1 && (
+                                  <>
+                                    <button
+                                      type="button"
+                                      className="text-slate-500 hover:text-slate-800 underline-offset-2 hover:underline"
+                                      data-testid={`reference-form-${code}-select-all`}
+                                      onClick={onSelectAll}
+                                    >
+                                      All
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="text-slate-500 hover:text-slate-800 underline-offset-2 hover:underline"
+                                      data-testid={`reference-form-${code}-select-none`}
+                                      onClick={onSelectNone}
+                                    >
+                                      None
+                                    </button>
+                                  </>
+                                )}
+                              </div>
+                            )}
                           </div>
-                          {data.available ? (
-                            <>
-                              <div className="mt-2 font-serif text-2xl text-slate-900" dir={dir}>{data.script || '—'}</div>
-                              <div className="mt-1 font-mono text-[11px] text-slate-400">/{data.ipa || '—'}/</div>
-                            </>
-                          ) : (
+                          {entries.length === 0 ? (
                             <div className="mt-2 text-sm text-slate-400">No reference data</div>
+                          ) : (
+                            <ul className="mt-2 space-y-1.5">
+                              {entries.map((entry, entryIdx) => {
+                                const selected = isSelected(entry.raw);
+                                return (
+                                  <li
+                                    key={entry.raw}
+                                    data-testid={`reference-form-${code}-entry-${entryIdx}`}
+                                    data-selected={selected}
+                                    className={
+                                      'flex items-start gap-3 rounded-md border px-2.5 py-1.5 transition-colors ' +
+                                      (selected
+                                        ? 'border-slate-300 bg-white'
+                                        : 'border-transparent bg-slate-100/50 opacity-60')
+                                    }
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={selected}
+                                      onChange={() => onToggle(entry.raw)}
+                                      data-testid={`reference-form-${code}-checkbox-${entryIdx}`}
+                                      className="mt-1 h-3.5 w-3.5 cursor-pointer accent-slate-700"
+                                      aria-label={`Select ${entry.raw}`}
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                      <div className="flex items-baseline gap-2">
+                                        <span className="text-[10px] uppercase tracking-wider text-slate-400">Script</span>
+                                        <span className="font-serif text-lg text-slate-900" dir={entry.script ? dir : 'ltr'}>
+                                          {entry.script || '—'}
+                                        </span>
+                                      </div>
+                                      <div className="mt-0.5 flex items-baseline gap-2">
+                                        <span className="text-[10px] uppercase tracking-wider text-slate-400">IPA</span>
+                                        <span className="font-mono text-[12px] text-slate-600">
+                                          {entry.ipa ? `/${entry.ipa}/` : '—'}
+                                        </span>
+                                      </div>
+                                      {entry.sources.length > 0 && (
+                                        <div className="mt-0.5 text-[10px] font-mono text-slate-400">
+                                          {entry.sources.join(', ')}
+                                        </div>
+                                      )}
+                                    </div>
+                                    {entry.audioUrl && (
+                                      <button
+                                        type="button"
+                                        title="Play reference audio"
+                                        onClick={() => { void new Audio(entry.audioUrl!).play().catch(() => {}); }}
+                                        className="text-slate-300 hover:text-slate-500"
+                                      >
+                                        <Volume2 className="h-3.5 w-3.5"/>
+                                      </button>
+                                    )}
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          )}
+                          {entries.length > 0 && effective !== null && effective.length === 0 && (
+                            <div className="mt-2 text-[11px] text-amber-600" data-testid={`reference-form-${code}-opt-out-warning`}>
+                              No forms selected — similarity for {label} will be skipped.
+                            </div>
                           )}
                         </div>
                       );

--- a/src/__tests__/referenceFormLists.test.ts
+++ b/src/__tests__/referenceFormLists.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import {
+  parseReferenceFormList,
+  resolveReferenceFormLists,
+  resolveFormSelection,
+} from '../ParseUI';
+
+// The single-form helpers in ParseUI power the Reference Forms panel's
+// multi-form display + selection UI. These tests lock in the
+// no-transliteration contract (Unicode-block classification only) and
+// the round-trip through provenance / legacy shapes.
+
+describe('parseReferenceFormList', () => {
+  it('routes bare Arabic-script strings to the script slot', () => {
+    const entries = parseReferenceFormList(['ماء']);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      raw: 'ماء',
+      script: 'ماء',
+      ipa: '',
+      audioUrl: null,
+      sources: [],
+    });
+  });
+
+  it('routes bare Latin/IPA strings to the ipa slot without touching the text', () => {
+    const entries = parseReferenceFormList(['maːʔ']);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].raw).toBe('maːʔ');
+    expect(entries[0].ipa).toBe('maːʔ');
+    expect(entries[0].script).toBe('');
+  });
+
+  it('handles the provenance {form, sources} shape verbatim', () => {
+    const entries = parseReferenceFormList([
+      { form: 'maːʔ', sources: ['wikidata', 'asjp'] },
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].raw).toBe('maːʔ');
+    expect(entries[0].ipa).toBe('maːʔ');
+    expect(entries[0].sources).toEqual(['wikidata', 'asjp']);
+  });
+
+  it('classifies the provenance form by Unicode block too (no auto-conversion)', () => {
+    // A provider writing script text into the "form" field shouldn't
+    // silently get promoted to IPA just because the shape is new.
+    const entries = parseReferenceFormList([
+      { form: 'ماء', sources: ['wiktionary'] },
+    ]);
+    expect(entries[0].script).toBe('ماء');
+    expect(entries[0].ipa).toBe('');
+  });
+
+  it('dedupes by raw text across multiple items', () => {
+    const entries = parseReferenceFormList([
+      { form: 'maːʔ', sources: ['asjp'] },
+      'maːʔ',   // duplicate of the same string
+      'muya',
+    ]);
+    expect(entries.map((e) => e.raw)).toEqual(['maːʔ', 'muya']);
+  });
+
+  it('trusts explicit field labels even when they contain script chars', () => {
+    // If a provider labels a field "ipa", we display it as IPA even
+    // when the string contains script-range chars -- that is the
+    // provider's claim and overrides the Unicode classifier.
+    const entries = parseReferenceFormList([{ ipa: 'māʔ', script: 'ماء' }]);
+    expect(entries[0].ipa).toBe('māʔ');
+    expect(entries[0].script).toBe('ماء');
+  });
+
+  it('returns an empty list for null/undefined/empty inputs', () => {
+    expect(parseReferenceFormList(null)).toEqual([]);
+    expect(parseReferenceFormList(undefined)).toEqual([]);
+    expect(parseReferenceFormList([])).toEqual([]);
+    expect(parseReferenceFormList([''])).toEqual([]);
+  });
+});
+
+describe('resolveReferenceFormLists', () => {
+  const concept = { id: 1, key: '1', name: 'water', tag: 'untagged' as const };
+
+  it('prefers enrichments.reference_forms over the SIL fallback', () => {
+    const enrichments = {
+      reference_forms: {
+        water: {
+          ar: [{ form: 'maːʔ', sources: ['wikidata'] }, { form: 'ماء', sources: ['wiktionary'] }],
+        },
+      },
+    };
+    const silConcepts = {
+      ar: { water: ['stale'] },
+    };
+    const lists = resolveReferenceFormLists(enrichments, silConcepts, concept, ['ar']);
+    expect(lists.ar.map((e) => e.raw)).toEqual(['maːʔ', 'ماء']);
+  });
+
+  it('falls back to the SIL contact-language config when enrichments are empty', () => {
+    const enrichments = {};
+    const silConcepts = {
+      ar: { water: [{ form: 'maːʔ', sources: ['asjp'] }] },
+    };
+    const lists = resolveReferenceFormLists(enrichments, silConcepts, concept, ['ar']);
+    expect(lists.ar).toHaveLength(1);
+    expect(lists.ar[0].sources).toEqual(['asjp']);
+  });
+
+  it('omits languages with no populated forms at all', () => {
+    const lists = resolveReferenceFormLists({}, {}, concept, ['ar', 'fa']);
+    expect(lists).toEqual({});
+  });
+});
+
+describe('resolveFormSelection', () => {
+  it('returns null when no selection is set (default = all selected)', () => {
+    expect(resolveFormSelection({}, 'water', 'ar')).toBeNull();
+    expect(resolveFormSelection({ form_selections: {} }, 'water', 'ar')).toBeNull();
+    expect(resolveFormSelection({ form_selections: { fire: {} } }, 'water', 'ar')).toBeNull();
+  });
+
+  it('returns an empty array for explicit opt-out', () => {
+    const meta = { form_selections: { water: { ar: [] } } };
+    expect(resolveFormSelection(meta, 'water', 'ar')).toEqual([]);
+  });
+
+  it('returns the allow-list for explicit subset selections', () => {
+    const meta = { form_selections: { water: { ar: ['ماء'] } } };
+    expect(resolveFormSelection(meta, 'water', 'ar')).toEqual(['ماء']);
+  });
+
+  it('filters out non-string entries defensively', () => {
+    const meta = { form_selections: { water: { ar: ['ماء', 42, null] } } };
+    expect(resolveFormSelection(meta, 'water', 'ar')).toEqual(['ماء']);
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -788,6 +788,23 @@ export async function getClefSourcesReport(): Promise<ClefSourcesReport> {
   return apiFetch<ClefSourcesReport>("/api/clef/sources-report");
 }
 
+/** Persist the user's reference-form selection for one (concept, language).
+ *  The server merges into ``_meta.form_selections`` without touching any
+ *  other entries. Pass an empty ``forms`` array to mark "none selected"
+ *  for that pair (similarity is skipped downstream); omit a pair from
+ *  the config entirely by never calling this for it -- the absence of a
+ *  key is the "all populated forms selected" default. */
+export async function saveClefFormSelections(payload: {
+  concept_en: string;
+  lang_code: string;
+  forms: string[];
+}): Promise<{ success: boolean; concept_en: string; lang_code: string; forms: string[] }> {
+  return apiFetch("/api/clef/form-selections", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
 // Normalize
 export async function startNormalize(speaker: string, sourceWav?: string): Promise<{ job_id: string }> {
   const body: Record<string, string> = { speaker };


### PR DESCRIPTION
## Summary

- Reference Forms panel now lists every populated form per language with a checkbox per form. The user picks which forms contribute to the similarity score.
- Selections persist to `sil_contact_languages.json._meta.form_selections` via a new `POST /api/clef/form-selections` endpoint and are honoured by `compute_similarity_scores`.
- Fixes a latent bug on main: PR #209 added the endpoint and the 3-tuple unpack in `server.py` but the compute wiring was missing, so any CLEF compute would have crashed at "Loading contact language data".
- No orthography → IPA auto-conversion. Bare strings are tagged by Unicode-block classification; the raw text is preserved verbatim in whichever slot it lands.

## Commits

1. **`d5c75b8` — honour `_meta.form_selections` in similarity compute**
   - `load_contact_language_data` returns a third element (`form_selections_by_concept`) parsed from `_meta.form_selections`.
   - New `filter_refs_by_selection(refs, selection)` helper: `None` = all refs, `[]` = opt-out, subset = allow-list.
   - `compute_similarity_scores` accepts optional `form_selections_by_concept`. Routing prefers `concept_id`, falls back to English `label` so UI-keyed selections still apply when records are keyed by numeric id.
   - Explicit-empty selection returns `score=None` with `has_reference_data=True` so the UI can distinguish opt-out from missing data.
   - Updates the `chat_tools.py` call site.
   - 13 new tests in `python/compare/test_form_selections.py`.

2. **`768b54f` — multi-form Reference Forms panel with selection**
   - New `parseReferenceFormList` + `classifyRawFormString` + `resolveReferenceFormLists` + `resolveFormSelection` helpers in `src/ParseUI.tsx`.
   - Reference Forms card reworked: per-form checkbox, `Script:` / `IPA:` lines, provenance sources shown under each form, `All` / `None` / `N/M selected` header for multi-form cards, amber "similarity skipped" hint on explicit opt-out.
   - Optimistic `localFormSelections` overlay so clicks feel immediate; `refreshClefStatus` pulls authoritative meta on save. On error, the overlay is dropped so the UI falls back to the server's view.
   - New `saveClefFormSelections` in `src/api/client.ts`.
   - 14 new unit tests in `src/__tests__/referenceFormLists.test.ts`.

## Data model

`sil_contact_languages.json._meta.form_selections`:

\`\`\`json
{
  "_meta": {
    "form_selections": {
      "water": {
        "ar": ["ماء"],
        "fa": []
      }
    }
  }
}
\`\`\`

Semantics:
- Missing concept key / missing lang key → all populated forms selected (default).
- Empty array `[]` → explicit opt-out; similarity skipped for that pair.
- Non-empty subset → only those exact form strings contribute to the min edit-distance.

## Aggregation

\"Max similarity\" = min edit-distance (existing behaviour). The selection mask filters refs *before* the `min()`, so picking a subset just narrows which refs compete for the best match.

## No auto-conversion guarantee

- `classifyRawFormString` only *tags* by Unicode block — Arabic/Hebrew/Syriac/etc. → script slot, Latin + IPA extensions → IPA slot. Characters are never substituted.
- Provider objects with explicit `ipa` or `script` labels are trusted verbatim regardless of what chars they contain.
- Grepped the Reference Forms data path end-to-end for the existing `_simple_arabic_to_ipa` helper (in `cross_speaker_match.py`) — it's only invoked on stored speaker-annotation IPA as a legacy compat shim and is not reachable from anything in the CLEF populate / Reference Forms pipeline.

## Test plan

- [x] `pytest python/compare/test_form_selections.py` — 13/13 passing (filter semantics, meta parsing, malformed shapes, compute end-to-end, concept-label routing).
- [x] `vitest run` — 262/262 passing (40 files), including the 14 new frontend tests.
- [x] `tsc --noEmit` — clean.
- [ ] **Manual preview verification:** the running preview servers are all rooted in the stale `/Users/lucasardelean/PARSE/` UI-mockup clone per memory; a preview against `/tmp/PARSE-audit/` couldn't be exercised from this session. UI changes should be verified manually: (1) open a configured workspace, (2) on a concept with multiple refs per language, toggle a checkbox and confirm the similarity score updates after the auto-chained compute, (3) "None" on a language should show the amber \"similarity skipped\" hint and the sim column should report `—`, (4) re-saving CLEF config should leave selections intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)