### PR TITLE
docs: refresh MCP roadmap as current status

### DIFF
--- a/docs/mcp_agent_roadmap.md
+++ b/docs/mcp_agent_roadmap.md
@@ -1,66 +1,95 @@
-# MCP / Agent Integration Roadmap
+# MCP / Agent Integration Status
 
-Future improvements to make PARSE a first-class citizen in agent-driven workflows.
+This document is now primarily a **status record**, not a speculative roadmap. The core MCP and external-agent work originally proposed here has been shipped on `main`; what remains is a short list of optional hardening and deployment extensions.
 
 ---
 
-## 1. Expose all 50 ParseChatTools via MCP
+## Current state at a glance
+
+PARSE now ships a full workstation-local external-agent surface:
+
+- **50** in-app `ParseChatTools`
+- **32** default MCP task tools
+- **3** workflow macros
+- **36** tools on the default adapter surface including `mcp_get_exposure_mode`
+- **54** tools on the full adapter surface when `expose_all_tools=true`
+- **OpenAPI 3.1** docs at `GET /openapi.json`, `GET /docs`, and `GET /redoc`
+- **HTTP MCP bridge** on the main PARSE server
+- **stdio MCP adapter** for MCP-native clients
+- **publishable `parse-mcp` package scaffold** for Python / framework integrations
+- **generic job observability** over HTTP, MCP, and WebSocket streaming
+
+In other words: PARSE is already usable as an agent-facing workstation API, not just an internal browser app.
+
+---
+
+## 1. Tool exposure via MCP
 
 **Status:** ✅ Complete
 
-**Shipped:**
-- `python/adapters/mcp_adapter.py` exposes a curated **32-tool default task surface** by default.
-- Task 3 adds 3 workflow macros on top of that base, so the current default adapter surface is **36 tools total** including `mcp_get_exposure_mode`.
-- Opt-in config at `config/mcp_config.json` (or fallback root `mcp_config.json`) enables the full **50-tool** `ParseChatTools` surface; with the 3 workflow macros and `mcp_get_exposure_mode`, the current full adapter surface is **54 tools total**:
+**Shipped on `main`:**
+- `python/adapters/mcp_adapter.py` exposes a curated **32-tool** default task surface.
+- `python/ai/workflow_tools.py` adds **3** workflow macros on top of that base.
+- `mcp_get_exposure_mode` is always available so clients can inspect the active exposure mode.
+- `config/mcp_config.json` (or fallback root `mcp_config.json`) can opt into full exposure:
 
 ```json
 { "expose_all_tools": true }
 ```
 
-**Notes:**
-- Default behavior remains curated for external agents rather than mirroring the entire in-app chat surface.
-- The internal chat dock still uses `ParseChatTools` directly; this task only changes MCP exposure.
-- Newly exposed tools now also include the generic job observability trio (`jobs_list`, `job_status`, `job_logs`) alongside the earlier write/export/pipeline helpers.
-- `mcp_get_exposure_mode` lets external agents self-inspect whether the active MCP server is running in the default or full-exposure mode.
+**Current totals:**
+- default adapter surface: **36** tools total
+- full adapter surface: **54** tools total
+
+**Why this matters:**
+PARSE no longer requires external agents to tunnel through the browser chat dock to reach core workstation actions.
 
 ---
 
-## 2. Richer, safer tool definitions
-
-- Strict JSON schemas and detailed parameter descriptions for every tool (MCP supports this natively).
-- Expose dry-run / preview mode on all mutating tools (many already have it internally).
-- Add `preconditions` and `postconditions` fields so agents can reason safely:
-  > "this tool requires a loaded project and at least one audio file"
-
----
-
-## 3. High-level composite / workflow tools
+## 2. Machine-readable tool contracts and safety metadata
 
 **Status:** ✅ Complete
 
-**Shipped:**
-- Added `python/ai/workflow_tools.py` with a dedicated `WorkflowTools` class.
-- New macros are exposed via MCP with their own `ChatToolSpec` metadata:
-  - `run_full_annotation_pipeline(speaker_id, concept_list, dryRun=False)`
-  - `prepare_compare_mode(concept_range, speakers, dryRun=False)`
-  - `export_complete_lingpy_dataset(with_contact_lexemes=True, dryRun=False)`
-- The macros orchestrate existing low-level tool handlers directly rather than duplicating business logic:
-  - annotation workflow: `stt_start` → `stt_status` → `forced_align_start` → `forced_align_status` → `ipa_transcribe_acoustic_start` → `ipa_transcribe_acoustic_status`
-  - compare prep: `speakers_list`, `annotation_read`, `cognate_compute_preview`, `cross_speaker_match_preview`
-  - export bundle: `contact_lexeme_lookup`, `export_lingpy_tsv`, `export_nexus`
-- Each macro publishes machine-readable preconditions/postconditions and supports `dryRun` where appropriate.
-- MCP adapter now exposes the workflow macros in both default and full-exposure modes.
+**Shipped on `main`:**
+- MCP-visible tools publish strict JSON Schemas from `ChatToolSpec.parameters`.
+- Tool metadata includes `meta["x-parse"]` safety annotations with:
+  - `mutability`
+  - `supports_dry_run`
+  - `dry_run_parameter`
+  - `preconditions`
+  - `postconditions`
+- Long-running starters are marked as `stateful_job`.
+- Mutating and job-starting tools expose dry-run previews where supported.
 
-Macros are easier to discover, easier to prompt, and safer to execute.
+**Why this matters:**
+Agents can now inspect execution risk and workflow semantics programmatically instead of inferring them from prose.
 
 ---
 
-## 4. Observability & control layer
+## 3. Composite / workflow tools
 
 **Status:** ✅ Complete
 
-**Shipped:**
-- Generic HTTP observability endpoints:
+**Shipped on `main`:**
+- `python/ai/workflow_tools.py` provides high-level macros with their own MCP-visible schemas and safety metadata.
+- Current workflow macros:
+  - `run_full_annotation_pipeline`
+  - `prepare_compare_mode`
+  - `export_complete_lingpy_dataset`
+- These wrap existing low-level handlers rather than duplicating business logic.
+- All three workflow tools support `dryRun` and publish machine-readable preconditions/postconditions.
+
+**Why this matters:**
+External agents can invoke meaningful workstation-level tasks directly instead of hand-assembling every low-level call sequence themselves.
+
+---
+
+## 4. Observability and job control
+
+**Status:** ✅ Complete
+
+**Shipped on `main`:**
+- Generic HTTP job endpoints:
   - `GET /api/jobs`
   - `GET /api/jobs/{jobId}`
   - `GET /api/jobs/{jobId}/logs`
@@ -68,69 +97,90 @@ Macros are easier to discover, easier to prompt, and safer to execute.
   - `jobs_list`
   - `job_status`
   - `job_logs`
-- Shared job payloads now include structured progress, `errorCode`, `logCount`, and lock metadata.
-- Heavy job starters can carry a `callbackUrl`, so external automation can receive the final generic job payload on `complete` / `error`.
-- Speaker-scoped lock metadata prevents humans and agents from mutating the same resources silently in parallel.
+- Structured job payloads now include progress, `errorCode`, `logCount`, and lock metadata.
+- Heavy job starters can emit callback payloads through `callbackUrl`.
+- Speaker-scoped lock metadata helps prevent silent concurrent mutation.
 
-These changes make long-running PARSE jobs inspectable across the UI, HTTP automation, and MCP clients with one consistent status shape.
+**Why this matters:**
+The same job can now be monitored coherently from the browser UI, HTTP automation, or an MCP client.
 
 ---
 
-## 5. Standardize the external API surface
+## 5. Standardized external HTTP surface
 
 **Status:** ✅ Complete
 
-**Shipped:**
-- `python/server.py` now serves a full **OpenAPI 3.1** document at `GET /openapi.json` plus interactive docs at `GET /docs` and `GET /redoc`.
-- Added a read/write **HTTP MCP bridge** on the same server:
+**Shipped on `main`:**
+- `GET /openapi.json` serves an **OpenAPI 3.1** document.
+- `GET /docs` and `GET /redoc` expose interactive HTTP documentation.
+- The PARSE server now includes an **HTTP MCP bridge**:
   - `GET /api/mcp/exposure`
   - `GET /api/mcp/tools`
   - `GET /api/mcp/tools/{toolName}`
   - `POST /api/mcp/tools/{toolName}`
-- Added shared schema/discovery helpers under `python/external_api/` so the HTTP MCP bridge and stdio adapter reuse the same MCP metadata source of truth.
-- Added the official publishable **`parse-mcp`** package scaffold under `python/packages/parse_mcp/` with:
+- Shared schema/discovery helpers under `python/external_api/` keep HTTP and stdio MCP surfaces aligned.
+- The repository now contains a publishable **`python/packages/parse_mcp/`** scaffold with:
   - `ParseMcpClient`
   - LangChain wrappers
   - LlamaIndex wrappers
   - CrewAI wrappers
-- Added `docs/mcp-schema.md` and expanded `README.md` / `docs/api-reference.md` to document:
-  - the MCP schema
-  - exposure modes
-  - the local authentication model
-  - the OpenAPI endpoints
+- Agent-relevant non-MCP helper routes are also documented and shipped, including:
+  - `GET/POST /api/clef/config`
+  - `GET /api/clef/catalog`
+  - `GET /api/clef/providers`
+  - `GET /api/clef/sources-report`
+  - `POST /api/clef/form-selections`
 
-**Notes:**
-- Existing HTTP and MCP tool behavior remains unchanged; Task 5 standardizes discoverability, schemas, and packaging around the current surface.
-- The local PARSE HTTP API remains workstation-local and is **not bearer-protected**. Provider credentials continue to be managed separately via `/api/auth/*` and local `config/auth_tokens.json`.
+**Why this matters:**
+PARSE now has a coherent external HTTP surface for both direct automation and MCP-backed wrappers.
 
 ---
 
-## 6. Streaming responses (WebSocket)
+## 6. Streaming job updates
 
 **Status:** ✅ Complete
 
-**Shipped:**
-- Added an additive WebSocket sidecar in `python/external_api/streaming.py` rather than migrating the custom HTTP server to a new framework.
+**Shipped on `main`:**
+- `python/external_api/streaming.py` adds a WebSocket sidecar without replacing the existing custom HTTP server.
 - The sidecar runs on `PARSE_WS_PORT` with default port `8767`.
-- Per-job subscription endpoint:
+- Subscription path:
   - `ws://<host>:<ws_port>/ws/jobs/{jobId}`
-- Current v1 event types:
+- Current v1 events:
   - `job.snapshot`
   - `job.progress`
   - `job.log`
   - `stt.segment`
   - `job.complete`
   - `job.error`
-- First supported realtime workflow is STT:
-  - live job progress updates
-  - provisional partial segment packets while decoding
-- Existing HTTP polling and callback flows remain fully supported and are still the compatibility baseline.
+- Generic events are reusable across job types; `stt.segment` is the additive STT-specific packet.
+
+**Why this matters:**
+External agents no longer need to rely exclusively on polling for long-running job feedback.
 
 ---
 
-## 7. Future / nice-to-have
+## 7. What is actually still future work?
 
-| Idea | Value |
-|------|-------|
-| Built-in sandbox / permission system | Scope an agent to a single speaker: `"agent can only edit speaker X"` |
-| Remote / cloud mode | Run PARSE headless on a GPU server; agents connect via MCP over the internet |
+Most of the original roadmap has landed. The real remaining work is now narrower and mostly optional:
+
+| Remaining idea | Why it could still matter |
+|---|---|
+| Built-in permission / sandbox scopes | Limit an agent to specific speakers, exports, or mutating operations |
+| Remote or multi-user deployment mode | Support headless/cloud PARSE instances beyond a single trusted workstation |
+| Richer webhook/event subscriptions | Push selected job/tool events into external orchestration systems without polling |
+| Additional packaged clients/examples | Lower friction for framework-specific integrations beyond the current scaffold |
+
+These are no longer prerequisites for PARSE agent integration; they are follow-on hardening and expansion work.
+
+---
+
+## Bottom line
+
+The historical roadmap in this file is **largely complete**. If you are looking for the current external-agent surface, treat the following as the primary live references instead:
+
+- `docs/mcp-schema.md`
+- `docs/api-reference.md`
+- `docs/getting-started-external-agents.md`
+- `python/adapters/mcp_adapter.py`
+- `python/external_api/`
+- `python/packages/parse_mcp/`


### PR DESCRIPTION
## Summary
- rewrite `docs/mcp_agent_roadmap.md` from a mostly-future roadmap into a current-state status document
- mark the MCP / external-agent core milestones as shipped and code-ground them with current tool counts, APIs, and packaging
- narrow the true future-work section to optional hardening / deployment extensions

## Test Plan
- git diff --check
- verified current tool counts from live Python modules
- spot-checked shipped surfaces in `python/server.py`, `python/external_api/`, and `python/packages/parse_mcp/`
