### PR TITLE
fix: tolerate late IPA interop thread config

### DIFF
--- a/docs/debugging/ipa-threading-error-findings.md
+++ b/docs/debugging/ipa-threading-error-findings.md
@@ -153,13 +153,13 @@ Error: cannot set number of interop threads after parallel work has started or s
 
 This proves that `torch.set_num_interop_threads()` is not a normal per-call option — it is effectively an early/one-shot global setting.
 
-## Demonstration B — the real PARSE code path reproduces the failure
+## Demonstration B — the real PARSE code path reproduced the failure before the fix
 
 To avoid downloading the full wav2vec2 stack while still exercising the repository code path, I ran the real `Aligner.load(..., device='cpu')` function with:
 - **real** PyTorch from `/usr/bin/python3`, and
 - **fake** transformers classes injected via `sys.modules`.
 
-Reproducer:
+Historical reproducer (run before the fix in this PR):
 
 ```python
 import pathlib
@@ -226,7 +226,65 @@ Traceback (most recent call last):
 RuntimeError: Error: cannot set number of interop threads after parallel work has started or set_num_interop_threads called
 ```
 
-This is the strongest evidence in the investigation: it reproduces the **same error string** at the **same repository call site** (`forced_align.py` line 183) without needing the full production model load.
+This is the strongest evidence in the investigation: it reproduced the **same error string** at the **same repository call site** (`forced_align.py` line 183) without needing the full production model load.
+
+---
+
+## Fix implemented in this PR
+
+The bug fix keeps the CPU single-thread preference but stops treating late
+PyTorch inter-op configuration as fatal.
+
+New helper in `python/ai/forced_align.py`:
+
+```python
+def _configure_torch_cpu_thread_limits(torch_module: Any) -> None:
+    global _CPU_THREAD_LIMITS_CONFIGURED
+    if _CPU_THREAD_LIMITS_CONFIGURED:
+        return
+
+    with _CPU_THREAD_LIMITS_LOCK:
+        if _CPU_THREAD_LIMITS_CONFIGURED:
+            return
+
+        torch_module.set_num_threads(1)
+        try:
+            torch_module.set_num_interop_threads(1)
+        except RuntimeError as exc:
+            if "cannot set number of interop threads" not in str(exc):
+                raise
+            print(
+                "[ALIGN] torch interop threads already configured; continuing with existing setting.",
+                file=sys.stderr,
+                flush=True,
+            )
+        _CPU_THREAD_LIMITS_CONFIGURED = True
+```
+
+And `Aligner.load()` now does:
+
+```python
+if resolved_device == "cpu":
+    _configure_torch_cpu_thread_limits(torch)
+```
+
+### Why this is the right fix
+
+- It addresses the real root cause: `set_num_interop_threads()` is a one-shot
+  global setting, but the aligner was trying to set it inside a late lazy load.
+- It preserves the original intent (`set_num_threads(1)` on CPU).
+- It makes the late lazy-load path safe in the long-lived threaded server.
+- It avoids repeating the same failing `set_num_interop_threads()` call after
+  the first successful or already-frozen attempt.
+
+### Post-fix demonstration
+
+After the fix, the same style of subprocess repro succeeds instead of crashing:
+
+```text
+[ALIGN] torch interop threads already configured; continuing with existing setting. current=1
+ALIGNER_OK cpu
+```
 
 ---
 
@@ -236,11 +294,12 @@ File added:
 
 - `python/ai/test_forced_align_threading.py`
 
-What it confirms:
+What it now confirms:
 
 1. `resolve_device()` forces CPU on WSL.
 2. The CPU branch of `Aligner.load()` calls `torch.set_num_threads(1)` and `torch.set_num_interop_threads(1)`.
-3. The real repository code path reproduces the exact RuntimeError in a subprocess using real PyTorch.
+3. If PyTorch reports that inter-op threads are already frozen, PARSE now treats that condition as benign and still loads the aligner.
+4. The real repository code path now succeeds in a subprocess using real PyTorch even when `torch.set_num_interop_threads(1)` has already been called.
 
 Recommended command:
 
@@ -248,19 +307,19 @@ Recommended command:
 pytest python/ai/test_forced_align_threading.py -q
 ```
 
-Observed result on this machine:
+Observed result on this machine after the fix:
 
 ```text
-...                                                                      [100%]
-3 passed in 1.64s
+....                                                                     [100%]
+4 passed in 1.90s
 ```
 
 Additional validation run before shipping this branch:
 
 ```text
 pytest python/ai/test_forced_align.py python/ai/test_forced_align_threading.py -q
-.............                                                            [100%]
-13 passed in 1.75s
+..............                                                           [100%]
+14 passed in 1.88s
 
 npm run test -- --run
 40 passed / 272 tests
@@ -275,11 +334,12 @@ npm run test -- --run
 
 ### Confirmed
 
-- The failure is in the **lazy aligner loader**, not in speaker-specific IPA decoding.
+- The failure originated in the **lazy aligner loader**, not in speaker-specific IPA decoding.
 - Under this runtime, wav2vec2 IPA is on the **CPU** branch.
 - That CPU branch calls `torch.set_num_interop_threads(1)`.
-- The exact repository code path can reproduce the same RuntimeError.
-- The current placement of that call inside a late lazy loader is unsafe in a long-lived threaded server process.
+- Before this fix, the exact repository code path reproduced the same RuntimeError.
+- After this fix, the same code path tolerates the already-frozen inter-op setting and continues loading the aligner.
+- The original placement of the raw `set_num_interop_threads(1)` call inside a late lazy loader was unsafe in a long-lived threaded server process.
 
 ### Important nuance
 
@@ -296,8 +356,8 @@ Together, those facts are sufficient to explain why this call site is brittle an
 
 ## Practical conclusion
 
-The IPA error means:
+The pre-fix IPA error meant:
 
-> PARSE is trying to configure PyTorch's global inter-op thread policy too late, inside a lazy-loaded CPU wav2vec2 aligner, after the long-lived server process has already reached a state where PyTorch no longer allows that setting to change.
+> PARSE was trying to configure PyTorch's global inter-op thread policy too late, inside a lazy-loaded CPU wav2vec2 aligner, after the long-lived server process had already reached a state where PyTorch no longer allowed that setting to change.
 
-That is why STT and orthography can complete while IPA fails consistently at aligner initialization.
+This fix changes that late lazy-load path from **fatal** to **tolerant** for the specific already-frozen inter-op-thread condition, while preserving the CPU single-thread preference that motivated the original code.

--- a/docs/debugging/ipa-threading-error-findings.md
+++ b/docs/debugging/ipa-threading-error-findings.md
@@ -1,0 +1,303 @@
+# PARSE IPA threading error — findings, proof, and reproducible demonstrations
+
+## Executive summary
+
+The recurring IPA failure is **not** a speaker-data problem and **not** a wav2vec2 decoding problem.
+It is a **late PyTorch global-thread-configuration failure** in the lazy IPA aligner loader.
+
+In the current PARSE runtime:
+
+1. `server.py` reaches IPA as the last step of the full pipeline.
+2. `_get_ipa_aligner()` lazy-loads the wav2vec2 aligner on first IPA use.
+3. Under WSL, `forced_align.resolve_device()` forces the aligner to **CPU**.
+4. The CPU branch of `Aligner.load()` calls:
+   - `torch.set_num_threads(1)`
+   - `torch.set_num_interop_threads(1)`
+5. PyTorch rejects that inter-op thread call once the process has already fixed that setting or already started the relevant parallel work.
+
+That is why the error repeats speaker after speaker: the aligner never finishes loading successfully, so PARSE retries the same failing lazy-load path on the next speaker.
+
+---
+
+## Exact traceback
+
+```text
+Traceback (most recent call last):
+  File "/home/lucas/gh/ardeleanlucas/parse/python/server.py", line 5565, in _compute_full_pipeline
+    sub_result = _compute_speaker_ipa(
+                 ^^^^^^^^^^^^^^^^^^^^^
+  File "/home/lucas/gh/ardeleanlucas/parse/python/server.py", line 4396, in _compute_speaker_ipa
+    aligner = _get_ipa_aligner()
+              ^^^^^^^^^^^^^^^^^^
+  File "/home/lucas/gh/ardeleanlucas/parse/python/server.py", line 4261, in _get_ipa_aligner
+    _IPA_ALIGNER = Aligner.load(device=_ipa_device)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/home/lucas/gh/ardeleanlucas/parse/python/ai/forced_align.py", line 183, in load
+    torch.set_num_interop_threads(1)
+RuntimeError: Error: cannot set number of interop threads after parallel work has started or set_num_interop_threads called
+```
+
+---
+
+## Source-level proof
+
+### 1) The full pipeline reaches IPA last
+
+`python/server.py`:
+
+```python
+elif step == "ipa":
+    sub_result = _compute_speaker_ipa(
+        job_id,
+        {"speaker": speaker, "overwrite": overwrites.get("ipa", False)},
+    )
+```
+
+This means the IPA stage is entered **after** the earlier pipeline activity in the same long-lived server process.
+
+### 2) IPA lazy-loads the aligner inside the server process
+
+`python/server.py`:
+
+```python
+def _get_ipa_aligner() -> Any:
+    global _IPA_ALIGNER
+    if _IPA_ALIGNER is not None:
+        return _IPA_ALIGNER
+    ...
+    _IPA_ALIGNER = Aligner.load(device=_ipa_device)
+    return _IPA_ALIGNER
+```
+
+So the wav2vec2 aligner is not configured at process startup; it is loaded **on demand**, late in the job lifecycle.
+
+### 3) WSL forces wav2vec2 IPA onto CPU
+
+`python/ai/forced_align.py`:
+
+```python
+def resolve_device(requested: Optional[str] = None) -> str:
+    if requested == "cpu":
+        return "cpu"
+    if _is_wsl():
+        return "cpu"
+    ...
+```
+
+Actual command run on this machine:
+
+```bash
+$ /usr/bin/python3 - <<'PY'
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path('/home/lucas/gh/ardeleanlucas/parse/python')))
+import ai.forced_align as fa
+print(fa.resolve_device('cuda'))
+PY
+cpu
+```
+
+Even though `config/ai_config.json` requests `"wav2vec2": {"device": "cuda"}`, the current WSL runtime forces this path to CPU.
+
+### 4) The CPU branch calls PyTorch's global thread setters
+
+`python/ai/forced_align.py`:
+
+```python
+resolved_device = resolve_device(device)
+...
+if resolved_device == "cpu":
+    torch.set_num_threads(1)
+    torch.set_num_interop_threads(1)
+```
+
+That second call is the one raising in the traceback.
+
+---
+
+## Why this is a runtime-order bug, not a data bug
+
+This failure happens **before** any speaker-specific IPA output is produced.
+The exception is raised during aligner initialization, not during phoneme decoding of a particular interval.
+
+So the bug is not:
+- malformed audio,
+- bad timestamps,
+- corrupt annotations,
+- invalid IPA tokens,
+- or a model inference result.
+
+It is a **process-global configuration timing error**.
+
+---
+
+## Reproducible demonstrations
+
+## Demonstration A — the exact PyTorch error appears when the inter-op setting is already frozen
+
+Minimal PyTorch proof:
+
+```bash
+$ /usr/bin/python3 - <<'PY'
+import torch
+
+torch.set_num_interop_threads(1)
+try:
+    torch.set_num_interop_threads(1)
+except RuntimeError as exc:
+    print(type(exc).__name__)
+    print(str(exc))
+PY
+RuntimeError
+Error: cannot set number of interop threads after parallel work has started or set_num_interop_threads called
+```
+
+This proves that `torch.set_num_interop_threads()` is not a normal per-call option — it is effectively an early/one-shot global setting.
+
+## Demonstration B — the real PARSE code path reproduces the failure
+
+To avoid downloading the full wav2vec2 stack while still exercising the repository code path, I ran the real `Aligner.load(..., device='cpu')` function with:
+- **real** PyTorch from `/usr/bin/python3`, and
+- **fake** transformers classes injected via `sys.modules`.
+
+Reproducer:
+
+```python
+import pathlib
+import sys
+import types
+import torch
+
+sys.path.insert(0, '/home/lucas/gh/ardeleanlucas/parse/python')
+
+fake_transformers = types.ModuleType('transformers')
+
+class _FakeTokenizer:
+    pad_token = '<pad>'
+    @classmethod
+    def from_pretrained(cls, model_name):
+        return cls()
+    def get_vocab(self):
+        return {'<pad>': 0, 'a': 1}
+
+class _FakeFeatureExtractor:
+    @classmethod
+    def from_pretrained(cls, model_name):
+        return cls()
+
+class _FakeProcessor:
+    def __init__(self, feature_extractor=None, tokenizer=None):
+        self.feature_extractor = feature_extractor
+        self.tokenizer = tokenizer
+    @classmethod
+    def from_pretrained(cls, model_name):
+        return cls(feature_extractor=_FakeFeatureExtractor(), tokenizer=_FakeTokenizer())
+
+class _FakeModel:
+    @classmethod
+    def from_pretrained(cls, model_name):
+        return cls()
+    def to(self, device):
+        return self
+    def eval(self):
+        return self
+
+fake_transformers.Wav2Vec2CTCTokenizer = _FakeTokenizer
+fake_transformers.Wav2Vec2FeatureExtractor = _FakeFeatureExtractor
+fake_transformers.Wav2Vec2Processor = _FakeProcessor
+fake_transformers.Wav2Vec2ForCTC = _FakeModel
+sys.modules['transformers'] = fake_transformers
+
+from ai.forced_align import Aligner
+
+torch.set_num_interop_threads(1)
+Aligner.load(model_name='dummy', device='cpu')
+```
+
+Observed output on this machine:
+
+```text
+RuntimeError
+Error: cannot set number of interop threads after parallel work has started or set_num_interop_threads called
+Traceback (most recent call last):
+  File "/tmp/parse_ipa_thread_repro.py", line 51, in <module>
+    Aligner.load(model_name='dummy', device='cpu')
+  File "/home/lucas/gh/worktrees/parse/ipa-threading-proof/python/ai/forced_align.py", line 183, in load
+    torch.set_num_interop_threads(1)
+RuntimeError: Error: cannot set number of interop threads after parallel work has started or set_num_interop_threads called
+```
+
+This is the strongest evidence in the investigation: it reproduces the **same error string** at the **same repository call site** (`forced_align.py` line 183) without needing the full production model load.
+
+---
+
+## Confirmation test added to the repo
+
+File added:
+
+- `python/ai/test_forced_align_threading.py`
+
+What it confirms:
+
+1. `resolve_device()` forces CPU on WSL.
+2. The CPU branch of `Aligner.load()` calls `torch.set_num_threads(1)` and `torch.set_num_interop_threads(1)`.
+3. The real repository code path reproduces the exact RuntimeError in a subprocess using real PyTorch.
+
+Recommended command:
+
+```bash
+pytest python/ai/test_forced_align_threading.py -q
+```
+
+Observed result on this machine:
+
+```text
+...                                                                      [100%]
+3 passed in 1.64s
+```
+
+Additional validation run before shipping this branch:
+
+```text
+pytest python/ai/test_forced_align.py python/ai/test_forced_align_threading.py -q
+.............                                                            [100%]
+13 passed in 1.75s
+
+npm run test -- --run
+40 passed / 272 tests
+
+./node_modules/.bin/tsc --noEmit
+(exit 0)
+```
+
+---
+
+## What we can say with high confidence
+
+### Confirmed
+
+- The failure is in the **lazy aligner loader**, not in speaker-specific IPA decoding.
+- Under this runtime, wav2vec2 IPA is on the **CPU** branch.
+- That CPU branch calls `torch.set_num_interop_threads(1)`.
+- The exact repository code path can reproduce the same RuntimeError.
+- The current placement of that call inside a late lazy loader is unsafe in a long-lived threaded server process.
+
+### Important nuance
+
+PyTorch's message merges two possibilities into one string:
+
+- parallel work has already started, **or**
+- `set_num_interop_threads()` was already called.
+
+The reproduction above definitively proves the **one-shot / already-fixed** branch.
+The PARSE architecture definitively proves the **late lazy-load** part.
+Together, those facts are sufficient to explain why this call site is brittle and why the error repeats across speakers.
+
+---
+
+## Practical conclusion
+
+The IPA error means:
+
+> PARSE is trying to configure PyTorch's global inter-op thread policy too late, inside a lazy-loaded CPU wav2vec2 aligner, after the long-lived server process has already reached a state where PyTorch no longer allows that setting to change.
+
+That is why STT and orthography can complete while IPA fails consistently at aligner initialization.

--- a/python/ai/forced_align.py
+++ b/python/ai/forced_align.py
@@ -32,6 +32,7 @@ import argparse
 import json
 import platform
 import sys
+import threading
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -61,6 +62,56 @@ def resolve_device(requested: Optional[str] = None) -> str:
         return requested or ("cuda" if torch.cuda.is_available() else "cpu")
     except ImportError:
         return "cpu"
+
+
+_CPU_THREAD_LIMITS_CONFIGURED = False
+_CPU_THREAD_LIMITS_LOCK = threading.Lock()
+
+
+def _configure_torch_cpu_thread_limits(torch_module: Any) -> None:
+    """Best-effort one-time CPU thread configuration for wav2vec2 alignment.
+
+    ``torch.set_num_interop_threads()`` is effectively a process-global
+    one-shot setting: PyTorch raises once the value has already been fixed or
+    once the process has progressed far enough that the inter-op pool can no
+    longer be reconfigured. In PARSE's long-lived server this can happen before
+    the lazy IPA loader runs, especially when WSL forces wav2vec2 onto CPU.
+
+    We still want the CPU path to prefer single-threaded inference to avoid the
+    historical thread-exhaustion issue, but a late lazy load must not crash the
+    entire IPA step merely because inter-op threads were already configured.
+    """
+    global _CPU_THREAD_LIMITS_CONFIGURED
+    if _CPU_THREAD_LIMITS_CONFIGURED:
+        return
+
+    with _CPU_THREAD_LIMITS_LOCK:
+        if _CPU_THREAD_LIMITS_CONFIGURED:
+            return
+
+        torch_module.set_num_threads(1)
+        try:
+            torch_module.set_num_interop_threads(1)
+        except RuntimeError as exc:
+            message = str(exc)
+            if "cannot set number of interop threads" not in message:
+                raise
+            current_interop = None
+            getter = getattr(torch_module, "get_num_interop_threads", None)
+            if callable(getter):
+                try:
+                    current_interop = getter()
+                except Exception:
+                    current_interop = None
+            suffix = " current={0}".format(current_interop) if current_interop is not None else ""
+            print(
+                "[ALIGN] torch interop threads already configured; continuing with existing setting.{0}".format(
+                    suffix
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
+        _CPU_THREAD_LIMITS_CONFIGURED = True
 
 try:
     from .provider import SegmentWithWords, WordSpan
@@ -178,9 +229,13 @@ class Aligner:
         # call. With 3500+ sequential calls in a single server process this
         # exhausts thread stack space and raises RuntimeError: can't start new
         # thread. Single-threaded mode is slower per-call but stable.
+        #
+        # ``set_num_interop_threads`` is process-global and effectively
+        # one-shot; in the long-lived PARSE server the lazy IPA load can happen
+        # after PyTorch has already frozen that setting. Treat that specific
+        # late-configuration condition as benign and keep loading the aligner.
         if resolved_device == "cpu":
-            torch.set_num_threads(1)
-            torch.set_num_interop_threads(1)
+            _configure_torch_cpu_thread_limits(torch)
 
         # Explicit tokenizer + feature_extractor load. If this path
         # raises, fall back to the legacy auto-dispatch as a last resort

--- a/python/ai/test_forced_align_threading.py
+++ b/python/ai/test_forced_align_threading.py
@@ -1,0 +1,224 @@
+"""Characterisation tests for the recurring PARSE IPA threading failure.
+
+These tests document the current failure mode rather than fixing it:
+
+- WSL forces wav2vec2 IPA alignment onto CPU.
+- The CPU branch of ``Aligner.load()`` configures PyTorch's global thread
+  settings.
+- The real repository code path raises the exact observed RuntimeError once
+  PyTorch considers inter-op thread configuration frozen for the process.
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import textwrap
+import types
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ai import forced_align as fa
+
+
+class _FakeTokenizer:
+    pad_token = "<pad>"
+
+    @classmethod
+    def from_pretrained(cls, model_name: str) -> "_FakeTokenizer":
+        return cls()
+
+    def get_vocab(self) -> dict[str, int]:
+        return {"<pad>": 0, "a": 1}
+
+
+class _FakeFeatureExtractor:
+    @classmethod
+    def from_pretrained(cls, model_name: str) -> "_FakeFeatureExtractor":
+        return cls()
+
+
+class _FakeProcessor:
+    def __init__(self, feature_extractor=None, tokenizer=None) -> None:
+        self.feature_extractor = feature_extractor
+        self.tokenizer = tokenizer
+
+    @classmethod
+    def from_pretrained(cls, model_name: str) -> "_FakeProcessor":
+        return cls(feature_extractor=_FakeFeatureExtractor(), tokenizer=_FakeTokenizer())
+
+
+class _FakeModel:
+    def __init__(self, events: list[tuple[str, object]]) -> None:
+        self._events = events
+
+    def to(self, device: str) -> "_FakeModel":
+        self._events.append(("to", device))
+        return self
+
+    def eval(self) -> "_FakeModel":
+        self._events.append(("eval", None))
+        return self
+
+
+class _FakeModelFactory:
+    def __init__(self, events: list[tuple[str, object]]) -> None:
+        self._events = events
+
+    def from_pretrained(self, model_name: str) -> _FakeModel:
+        self._events.append(("from_pretrained", model_name))
+        return _FakeModel(self._events)
+
+
+def _build_fake_torch_module() -> types.ModuleType:
+    fake_torch = types.ModuleType("torch")
+    fake_torch.calls = []  # type: ignore[attr-defined]
+
+    def _record(name: str):
+        def inner(value: int) -> None:
+            fake_torch.calls.append((name, value))  # type: ignore[attr-defined]
+
+        return inner
+
+    fake_torch.set_num_threads = _record("set_num_threads")  # type: ignore[attr-defined]
+    fake_torch.set_num_interop_threads = _record("set_num_interop_threads")  # type: ignore[attr-defined]
+    return fake_torch
+
+
+def _build_fake_transformers_module() -> tuple[types.ModuleType, list[tuple[str, object]]]:
+    fake_transformers = types.ModuleType("transformers")
+    model_events: list[tuple[str, object]] = []
+
+    fake_transformers.Wav2Vec2CTCTokenizer = _FakeTokenizer  # type: ignore[attr-defined]
+    fake_transformers.Wav2Vec2FeatureExtractor = _FakeFeatureExtractor  # type: ignore[attr-defined]
+    fake_transformers.Wav2Vec2Processor = _FakeProcessor  # type: ignore[attr-defined]
+    fake_transformers.Wav2Vec2ForCTC = _FakeModelFactory(model_events)  # type: ignore[attr-defined]
+    return fake_transformers, model_events
+
+
+def _system_python_has_torch() -> bool:
+    python_bin = pathlib.Path("/usr/bin/python3")
+    if not python_bin.exists():
+        return False
+    probe = subprocess.run(
+        [str(python_bin), "-c", "import torch"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return probe.returncode == 0
+
+
+REAL_TORCH_SUBPROCESS_AVAILABLE = _system_python_has_torch()
+
+
+def test_resolve_device_forces_cpu_on_wsl_even_if_cuda_requested(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fa, "_is_wsl", lambda: True)
+    assert fa.resolve_device("cuda") == "cpu"
+    assert fa.resolve_device(None) == "cpu"
+
+
+def test_aligner_load_cpu_path_sets_thread_limits_before_model_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_torch = _build_fake_torch_module()
+    fake_transformers, model_events = _build_fake_transformers_module()
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+    aligner = fa.Aligner.load(model_name="dummy", device="cpu")
+
+    assert aligner.device == "cpu"
+    assert fake_torch.calls[:2] == [  # type: ignore[attr-defined]
+        ("set_num_threads", 1),
+        ("set_num_interop_threads", 1),
+    ]
+    assert model_events == [
+        ("from_pretrained", "dummy"),
+        ("to", "cpu"),
+        ("eval", None),
+    ]
+
+
+@pytest.mark.skipif(
+    not REAL_TORCH_SUBPROCESS_AVAILABLE,
+    reason="requires /usr/bin/python3 with torch installed",
+)
+def test_real_repo_cpu_load_reproduces_exact_pytorch_interop_error(tmp_path: pathlib.Path) -> None:
+    repo_python = pathlib.Path(__file__).resolve().parents[1]
+    script = tmp_path / "forced_align_thread_repro.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""
+            import pathlib
+            import sys
+            import types
+            import torch
+
+            sys.path.insert(0, {str(repo_python)!r})
+
+            fake_transformers = types.ModuleType('transformers')
+
+            class _FakeTokenizer:
+                pad_token = '<pad>'
+                @classmethod
+                def from_pretrained(cls, model_name):
+                    return cls()
+                def get_vocab(self):
+                    return {{'<pad>': 0, 'a': 1}}
+
+            class _FakeFeatureExtractor:
+                @classmethod
+                def from_pretrained(cls, model_name):
+                    return cls()
+
+            class _FakeProcessor:
+                def __init__(self, feature_extractor=None, tokenizer=None):
+                    self.feature_extractor = feature_extractor
+                    self.tokenizer = tokenizer
+                @classmethod
+                def from_pretrained(cls, model_name):
+                    return cls(feature_extractor=_FakeFeatureExtractor(), tokenizer=_FakeTokenizer())
+
+            class _FakeModel:
+                @classmethod
+                def from_pretrained(cls, model_name):
+                    return cls()
+                def to(self, device):
+                    return self
+                def eval(self):
+                    return self
+
+            fake_transformers.Wav2Vec2CTCTokenizer = _FakeTokenizer
+            fake_transformers.Wav2Vec2FeatureExtractor = _FakeFeatureExtractor
+            fake_transformers.Wav2Vec2Processor = _FakeProcessor
+            fake_transformers.Wav2Vec2ForCTC = _FakeModel
+            sys.modules['transformers'] = fake_transformers
+
+            from ai.forced_align import Aligner
+
+            torch.set_num_interop_threads(1)
+            Aligner.load(model_name='dummy', device='cpu')
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["/usr/bin/python3", str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "forced_align.py" in combined
+    assert "torch.set_num_interop_threads(1)" in combined
+    assert (
+        "RuntimeError: Error: cannot set number of interop threads after parallel work has started "
+        "or set_num_interop_threads called"
+    ) in combined

--- a/python/ai/test_forced_align_threading.py
+++ b/python/ai/test_forced_align_threading.py
@@ -123,6 +123,7 @@ def test_resolve_device_forces_cpu_on_wsl_even_if_cuda_requested(monkeypatch: py
 def test_aligner_load_cpu_path_sets_thread_limits_before_model_load(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(fa, "_CPU_THREAD_LIMITS_CONFIGURED", False)
     fake_torch = _build_fake_torch_module()
     fake_transformers, model_events = _build_fake_transformers_module()
 
@@ -143,11 +144,40 @@ def test_aligner_load_cpu_path_sets_thread_limits_before_model_load(
     ]
 
 
+def test_aligner_load_cpu_path_tolerates_preconfigured_interop_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fa, "_CPU_THREAD_LIMITS_CONFIGURED", False)
+    fake_torch = _build_fake_torch_module()
+
+    def _fail(_: int) -> None:
+        raise RuntimeError(
+            "Error: cannot set number of interop threads after parallel work has started "
+            "or set_num_interop_threads called"
+        )
+
+    fake_torch.set_num_interop_threads = _fail  # type: ignore[attr-defined]
+    fake_transformers, model_events = _build_fake_transformers_module()
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+    aligner = fa.Aligner.load(model_name="dummy", device="cpu")
+
+    assert aligner.device == "cpu"
+    assert fake_torch.calls == [("set_num_threads", 1)]  # type: ignore[attr-defined]
+    assert model_events == [
+        ("from_pretrained", "dummy"),
+        ("to", "cpu"),
+        ("eval", None),
+    ]
+
+
 @pytest.mark.skipif(
     not REAL_TORCH_SUBPROCESS_AVAILABLE,
     reason="requires /usr/bin/python3 with torch installed",
 )
-def test_real_repo_cpu_load_reproduces_exact_pytorch_interop_error(tmp_path: pathlib.Path) -> None:
+def test_real_repo_cpu_load_tolerates_preconfigured_pytorch_interop_threads(tmp_path: pathlib.Path) -> None:
     repo_python = pathlib.Path(__file__).resolve().parents[1]
     script = tmp_path / "forced_align_thread_repro.py"
     script.write_text(
@@ -201,7 +231,8 @@ def test_real_repo_cpu_load_reproduces_exact_pytorch_interop_error(tmp_path: pat
             from ai.forced_align import Aligner
 
             torch.set_num_interop_threads(1)
-            Aligner.load(model_name='dummy', device='cpu')
+            aligner = Aligner.load(model_name='dummy', device='cpu')
+            print('ALIGNER_DEVICE', getattr(aligner, 'device', '?'))
             """
         ),
         encoding="utf-8",
@@ -215,10 +246,6 @@ def test_real_repo_cpu_load_reproduces_exact_pytorch_interop_error(tmp_path: pat
     )
 
     combined = result.stdout + result.stderr
-    assert result.returncode != 0
-    assert "forced_align.py" in combined
-    assert "torch.set_num_interop_threads(1)" in combined
-    assert (
-        "RuntimeError: Error: cannot set number of interop threads after parallel work has started "
-        "or set_num_interop_threads called"
-    ) in combined
+    assert result.returncode == 0, combined
+    assert "ALIGNER_DEVICE cpu" in combined
+    assert "cannot set number of interop threads" not in combined


### PR DESCRIPTION
## Summary
- fix the wav2vec2 IPA CPU loader so late `torch.set_num_interop_threads(1)` failures no longer abort the IPA step
- add regression coverage proving PARSE now tolerates an already-frozen PyTorch inter-op thread setting
- keep the findings/proof document with pre-fix reproduction, post-fix demonstration, and validation evidence

## Root cause
`Aligner.load()` configured PyTorch CPU thread limits inside a late lazy loader. In the long-lived threaded PARSE server, WSL forces wav2vec2 IPA onto CPU and PyTorch may already have frozen the process-global inter-op thread setting before IPA first runs. The raw `torch.set_num_interop_threads(1)` call then raised and aborted IPA initialization.

## Fix
- add `_configure_torch_cpu_thread_limits()` in `python/ai/forced_align.py`
- make the CPU loader treat the specific already-frozen inter-op-thread RuntimeError as benign
- preserve `set_num_threads(1)` and one-time configuration semantics with a module-level lock/flag

## Validation
- `pytest python/ai/test_forced_align_threading.py -q`
- `pytest python/ai/test_forced_align.py python/ai/test_forced_align_threading.py -q`
- `pytest python/ai/test_ipa_transcribe_acoustic.py -q`
- `npm run test -- --run`
- `./node_modules/.bin/tsc --noEmit`
