### PR TITLE
fix(clef): show contact-lexemes job in header chip, not drawer

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2261,13 +2261,9 @@ export function ParseUI() {
     [refreshClefStatus],
   );
 
-  const handleComputeRun = useCallback(() => {
-    if (computeMode === 'contact-lexemes' && clefConfigured !== true) {
-      setClefModalOpen(true);
-      return;
-    }
-    void startComputeJob();
-  }, [computeMode, clefConfigured, startComputeJob]);
+  // ``handleComputeRun`` is defined further down (after ``crossSpeakerJob``
+  // is in scope) so it can dispatch the contact-lexemes path through the
+  // header-chip job hook instead of the drawer-tied ``startComputeJob``.
   const [notes, setNotes] = useState('');
   const [borrowingsOpen, setBorrowingsOpen] = useState(true);
   const [panelOpen, setPanelOpen] = useState(true);
@@ -2584,6 +2580,28 @@ export function ParseUI() {
     ...(crossSpeakerJob.state.status !== 'idle' ? [crossSpeakerJob] : []),
     ...(similarityJob.state.status !== 'idle' ? [similarityJob] : []),
   ];
+
+  // Drawer "Run" button. ``contact-lexemes`` (Borrowing detection / CLEF)
+  // routes through ``crossSpeakerJob`` so progress / ETA / completion
+  // surface in the global header chip alongside STT / IPA / forced-align,
+  // not as a duplicate one-line indicator inside the drawer. The
+  // ``onComplete`` hook on ``crossSpeakerJob`` already handles the
+  // populate-summary banner + auto-chained similarity recompute (#208),
+  // so this dispatch keeps both paths (header click via Save & populate,
+  // drawer click via Run) on the same wiring. Other compute modes
+  // (cognates / phonetic similarity) still use the legacy drawer-tied
+  // ``startComputeJob`` since they don't have a useActionJob counterpart.
+  const handleComputeRun = useCallback(() => {
+    if (computeMode === 'contact-lexemes') {
+      if (clefConfigured !== true) {
+        setClefModalOpen(true);
+        return;
+      }
+      void crossSpeakerJob.run();
+      return;
+    }
+    void startComputeJob();
+  }, [computeMode, clefConfigured, startComputeJob, crossSpeakerJob]);
 
   // On mount, adopt any in-flight backend jobs so progress bars survive
   // a page reload. STT (and similar) run in a background thread that
@@ -4351,7 +4369,15 @@ export function ParseUI() {
                     <button
                       className="inline-flex items-center justify-center gap-1 rounded-md bg-indigo-600 py-1.5 text-[11px] font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
                       onClick={handleComputeRun}
-                      disabled={computeJobState.status === 'running'}
+                      // Disable Run while *the relevant* job for the
+                      // current mode is in flight. contact-lexemes routes
+                      // through crossSpeakerJob (header chip); other modes
+                      // still flow through the legacy useComputeJob.
+                      disabled={
+                        computeMode === 'contact-lexemes'
+                          ? crossSpeakerJob.state.status === 'running'
+                          : computeJobState.status === 'running'
+                      }
                     >
                       <Play className="h-3 w-3"/> Run
                     </button>
@@ -4389,7 +4415,13 @@ export function ParseUI() {
                       </div>
                     </div>
                   )}
-                  {computeJobState.status === 'running' && (
+                  {/* For contact-lexemes, progress + errors render in the
+                      global header chip via ``crossSpeakerJob`` (matches
+                      STT / IPA / forced-align / full_pipeline). The
+                      drawer one-liner stays only for legacy compute
+                      modes (cognates / phonetic similarity) that still
+                      flow through ``useComputeJob``. */}
+                  {computeMode !== 'contact-lexemes' && computeJobState.status === 'running' && (
                     <div className="mt-1 text-[10px] text-indigo-600">
                       Running… {Math.round(computeJobState.progress * 100)}%
                       {computeJobState.etaMs !== null && computeJobState.etaMs > 0 && (
@@ -4397,7 +4429,7 @@ export function ParseUI() {
                       )}
                     </div>
                   )}
-                  {computeJobState.status === 'error' && (
+                  {computeMode !== 'contact-lexemes' && computeJobState.status === 'error' && (
                     <div className="mt-1 text-[10px] text-rose-600">{computeJobState.error}</div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

When the user clicked "Run" on the drawer's "Borrowing detection (CLEF)" mode, the progress chip rendered as a one-liner inside the right drawer ("Running… 5% · ~2m 38s left") instead of the global header chip that every other long-running job uses (STT, IPA, forced-align, full pipeline, cross-speaker match, similarity).

Two parallel job-tracking systems were live for the same backend job:
- `useComputeJob('contact-lexemes')` → drawer one-liner.
- `crossSpeakerJob` (`useActionJob`) → header chip.

Only the drawer path fired from the dropdown's "Run" button. The header path was reached only via the CLEF configure modal's "Save & populate" callback. Same backend, two UIs, with the drawer one inconsistent with everything else.

## Fix

Route `handleComputeRun` for `computeMode === 'contact-lexemes'` through `crossSpeakerJob.run()` instead of `startComputeJob()`. That's the same job hook already adopted by the modal's `onPopulateStarted` callback, so:

- The auto-chained populate → similarity recompute (PR [#208](https://github.com/ArdeleanLucas/PARSE/pull/208)) keeps working — it lives in `crossSpeakerJob.onComplete`.
- The 0-forms `populateSummary` banner keeps surfacing.
- `adopt(jobId)` still rehydrates an in-flight job after a page reload via `listActiveJobs()`.

## Drawer cleanup

- The "Running…" / "Error" one-liners now render only for the legacy compute modes (`cognates`, `phonetic similarity`) that still flow through `useComputeJob`. For `contact-lexemes`, the header chip owns the display.
- "Run" button's `disabled` state checks the appropriate job hook based on the active mode.
- Sources Report / Configure / "CLEF configured" status pill all stay in the drawer — they're configuration, not job progress.

`handleComputeRun` had to move below `crossSpeakerJob` so it can close over it; left a stub comment at the original location pointing forward.

## Out of scope

- `cognates` and `phonetic similarity` direct triggers still flow through `useComputeJob` and render in the drawer. Not in the user's brief; would be the natural next step if you want full unification.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `vitest run` — 272/272.
- [ ] Manual UI verification (preview infra still rooted at the stale `/Users/lucasardelean/PARSE/` mockup per memory):
  - Open CLEF-configured workspace.
  - Drawer → Compute → "Borrowing detection (CLEF)" → Run.
  - Confirm: progress chip appears in **header** with "Populating CLEF reference data… N% · ~M:SS left", drawer no longer shows the duplicate one-liner.
  - On completion, the auto-chained "Computing similarity scores…" chip should appear in the header next.
  - With CLEF *not* configured, Run still opens the configure modal.
  - On error, the header chip surfaces the failure (drawer doesn't double-report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)