### PR TITLE
feat(annotate): Boundaries lane + Tier 1 diagnostic script

### DIFF
--- a/scripts/benchmark_tier1_boundaries.py
+++ b/scripts/benchmark_tier1_boundaries.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Benchmark Tier 1 (STT) word-boundary accuracy via Tier 2 refinement deltas.
+
+Aggregates existing `.stt.json` and `.aligned.json` artifacts in a workspace
+(or an explicit pair) and reports:
+
+    1. confidence distribution from forced-alignment CTC scores (aligned `confidence` field)
+    2. onset/offset boundary shift between Tier 1 and Tier 2 in ms,
+       and the fraction of words whose worst edge shift exceeds --padding-ms
+       (the same pad currently applied at forced_align.py:_slice_window)
+    3. method-count histogram straight from `alignment.methodCounts`
+       (proportional-fallback rate = Tier 2 failure rate)
+
+No ground truth required; no pipeline re-runs. Read-only over JSON artifacts.
+
+Usage:
+    # Whole workspace (resolves <workspace>/stt_output/<speaker>.stt.json
+    # and sibling .aligned.json):
+    python scripts/benchmark_tier1_boundaries.py --workspace /path/to/workspace
+
+    # Single pair:
+    python scripts/benchmark_tier1_boundaries.py \\
+        --stt stt_output/Fail02.stt.json \\
+        --aligned stt_output/Fail02.aligned.json
+
+    # Custom padding threshold (default 100 ms = forced_align.py default):
+    python scripts/benchmark_tier1_boundaries.py --workspace . --padding-ms 150
+
+    # Save full per-pair JSON for downstream plotting:
+    python scripts/benchmark_tier1_boundaries.py --workspace . --json-out results.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _iter_words(artifact: Dict[str, Any]) -> Iterable[Tuple[int, int, Dict[str, Any]]]:
+    """Yield (seg_idx, word_idx, word_dict) for every nested word in a STT/aligned artifact."""
+    for seg_idx, seg in enumerate(artifact.get("segments") or []):
+        words = seg.get("words") if isinstance(seg, dict) else None
+        if not isinstance(words, list):
+            continue
+        for word_idx, w in enumerate(words):
+            if isinstance(w, dict):
+                yield seg_idx, word_idx, w
+
+
+def _resolve_pairs(
+    workspace: Optional[Path],
+    explicit_stt: Optional[Path],
+    explicit_aligned: Optional[Path],
+) -> List[Tuple[str, Path, Path]]:
+    """Return list of (label, stt_path, aligned_path) tuples."""
+    if explicit_stt and explicit_aligned:
+        return [(explicit_stt.stem.removesuffix(".stt"), explicit_stt, explicit_aligned)]
+
+    if not workspace:
+        return []
+
+    stt_dir = workspace / "stt_output"
+    if not stt_dir.is_dir():
+        return []
+
+    pairs: List[Tuple[str, Path, Path]] = []
+    # Layout A: <speaker>.stt.json + <speaker>.aligned.json (server.py:4578, 4626)
+    for stt_path in sorted(stt_dir.glob("*.stt.json")):
+        speaker = stt_path.name[: -len(".stt.json")]
+        aligned_path = stt_dir / f"{speaker}.aligned.json"
+        if aligned_path.is_file():
+            pairs.append((speaker, stt_path, aligned_path))
+
+    # Layout B: <speaker>/stt.json + <speaker>/aligned.json (server.py:4579 fallback)
+    for sub in sorted(p for p in stt_dir.iterdir() if p.is_dir()):
+        stt_path = sub / "stt.json"
+        aligned_path = sub / "aligned.json"
+        if stt_path.is_file() and aligned_path.is_file():
+            pairs.append((sub.name, stt_path, aligned_path))
+
+    return pairs
+
+
+def _percentile(values: List[float], pct: float) -> Optional[float]:
+    if not values:
+        return None
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    k = (len(s) - 1) * (pct / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    frac = k - lo
+    return s[lo] * (1 - frac) + s[hi] * frac
+
+
+def _summarise(values: List[float], label: str) -> Dict[str, Any]:
+    if not values:
+        return {"label": label, "n": 0}
+    return {
+        "label": label,
+        "n": len(values),
+        "mean": round(statistics.fmean(values), 4),
+        "median": round(statistics.median(values), 4),
+        "p10": round(_percentile(values, 10) or 0.0, 4),
+        "p25": round(_percentile(values, 25) or 0.0, 4),
+        "p75": round(_percentile(values, 75) or 0.0, 4),
+        "p90": round(_percentile(values, 90) or 0.0, 4),
+        "p95": round(_percentile(values, 95) or 0.0, 4),
+        "max": round(max(values), 4),
+        "min": round(min(values), 4),
+    }
+
+
+def analyse_pair(
+    stt_path: Path,
+    aligned_path: Path,
+    padding_ms: float,
+) -> Dict[str, Any]:
+    stt = _load_json(stt_path)
+    aligned = _load_json(aligned_path)
+
+    # Index Tier 1 words by (seg_idx, word_idx)
+    tier1_index: Dict[Tuple[int, int], Dict[str, Any]] = {
+        (si, wi): w for si, wi, w in _iter_words(stt)
+    }
+
+    confidences: List[float] = []
+    onset_shifts_ms: List[float] = []
+    offset_shifts_ms: List[float] = []
+    max_edge_shifts_ms: List[float] = []
+    paired = 0
+    unpaired_aligned = 0
+    methods_walked: Dict[str, int] = {}
+
+    for si, wi, w2 in _iter_words(aligned):
+        method = str(w2.get("method") or "unknown")
+        methods_walked[method] = methods_walked.get(method, 0) + 1
+
+        c = w2.get("confidence")
+        if isinstance(c, (int, float)):
+            confidences.append(float(c))
+
+        w1 = tier1_index.get((si, wi))
+        if not w1:
+            unpaired_aligned += 1
+            continue
+        s1, e1 = w1.get("start"), w1.get("end")
+        s2, e2 = w2.get("start"), w2.get("end")
+        if not all(isinstance(v, (int, float)) for v in (s1, e1, s2, e2)):
+            continue
+        on_ms = abs(float(s2) - float(s1)) * 1000.0
+        off_ms = abs(float(e2) - float(e1)) * 1000.0
+        onset_shifts_ms.append(on_ms)
+        offset_shifts_ms.append(off_ms)
+        max_edge_shifts_ms.append(max(on_ms, off_ms))
+        paired += 1
+
+    method_counts_meta = (aligned.get("alignment") or {}).get("methodCounts") or {}
+    total_method = sum(method_counts_meta.values()) if method_counts_meta else 0
+    method_pct = (
+        {k: round(100.0 * v / total_method, 2) for k, v in method_counts_meta.items()}
+        if total_method
+        else {}
+    )
+
+    over_pad = sum(1 for v in max_edge_shifts_ms if v > padding_ms)
+    over_pad_pct = round(100.0 * over_pad / len(max_edge_shifts_ms), 2) if max_edge_shifts_ms else 0.0
+
+    low_conf_06 = (
+        round(100.0 * sum(1 for c in confidences if c < 0.6) / len(confidences), 2)
+        if confidences
+        else None
+    )
+    low_conf_05 = (
+        round(100.0 * sum(1 for c in confidences if c < 0.5) / len(confidences), 2)
+        if confidences
+        else None
+    )
+
+    return {
+        "stt_path": str(stt_path),
+        "aligned_path": str(aligned_path),
+        "paired_words": paired,
+        "unpaired_aligned_words": unpaired_aligned,
+        "tier1_total_words": len(tier1_index),
+        "confidence": _summarise(confidences, "confidence"),
+        "confidence_below_0.6_pct": low_conf_06,
+        "confidence_below_0.5_pct": low_conf_05,
+        "onset_shift_ms": _summarise(onset_shifts_ms, "onset_shift_ms"),
+        "offset_shift_ms": _summarise(offset_shifts_ms, "offset_shift_ms"),
+        "max_edge_shift_ms": _summarise(max_edge_shifts_ms, "max_edge_shift_ms"),
+        "padding_ms": padding_ms,
+        "max_edge_shift_over_padding_pct": over_pad_pct,
+        "method_counts_artifact": method_counts_meta,
+        "method_pct_artifact": method_pct,
+        "method_counts_walked": methods_walked,
+    }
+
+
+def _format_summary_table(per_pair: List[Dict[str, Any]], padding_ms: float) -> str:
+    lines: List[str] = []
+    header = (
+        f"{'speaker':<24} {'n':>6} {'conf_med':>9} {'<0.6%':>7} "
+        f"{'onset_p90':>10} {'offset_p90':>11} {'edge_p90':>9} "
+        f"{'>'+str(int(padding_ms))+'ms%':>9} {'fallback%':>10}"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+    for r in per_pair:
+        speaker = Path(r["stt_path"]).name.replace(".stt.json", "")[:24]
+        n = r["paired_words"]
+        conf_med = r["confidence"].get("median")
+        low = r["confidence_below_0.6_pct"]
+        on90 = r["onset_shift_ms"].get("p90")
+        off90 = r["offset_shift_ms"].get("p90")
+        edge90 = r["max_edge_shift_ms"].get("p90")
+        over = r["max_edge_shift_over_padding_pct"]
+        fb = r["method_pct_artifact"].get("proportional-fallback", 0.0)
+        lines.append(
+            f"{speaker:<24} {n:>6} "
+            f"{(f'{conf_med:.3f}' if conf_med is not None else '-'):>9} "
+            f"{(f'{low:.1f}' if low is not None else '-'):>7} "
+            f"{(f'{on90:.1f}' if on90 is not None else '-'):>10} "
+            f"{(f'{off90:.1f}' if off90 is not None else '-'):>11} "
+            f"{(f'{edge90:.1f}' if edge90 is not None else '-'):>9} "
+            f"{over:>8.1f}% "
+            f"{fb:>9.1f}%"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--workspace", type=Path, help="PARSE workspace root containing stt_output/")
+    p.add_argument("--stt", type=Path, help="Explicit Tier 1 .stt.json (use with --aligned)")
+    p.add_argument("--aligned", type=Path, help="Explicit Tier 2 .aligned.json (use with --stt)")
+    p.add_argument(
+        "--padding-ms",
+        type=float,
+        default=100.0,
+        help="Edge-shift threshold; matches forced_align _slice_window pad (default 100)",
+    )
+    p.add_argument("--json-out", type=Path, help="Write full structured results to this path")
+    args = p.parse_args(argv)
+
+    if not args.workspace and not (args.stt and args.aligned):
+        p.error("provide --workspace OR both --stt and --aligned")
+
+    pairs = _resolve_pairs(args.workspace, args.stt, args.aligned)
+    if not pairs:
+        print("No (.stt.json, .aligned.json) pairs found.", file=sys.stderr)
+        if args.workspace:
+            print(f"  Looked under: {args.workspace / 'stt_output'}", file=sys.stderr)
+        return 2
+
+    per_pair: List[Dict[str, Any]] = []
+    for label, stt_path, aligned_path in pairs:
+        try:
+            per_pair.append(analyse_pair(stt_path, aligned_path, args.padding_ms))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[skip] {label}: {exc}", file=sys.stderr)
+
+    aggregate = {
+        "padding_ms": args.padding_ms,
+        "pair_count": len(per_pair),
+        "total_paired_words": sum(r["paired_words"] for r in per_pair),
+    }
+
+    print(f"# Tier 1 boundary benchmark — {aggregate['pair_count']} speaker(s), "
+          f"{aggregate['total_paired_words']} paired words, padding={args.padding_ms} ms\n")
+    print(_format_summary_table(per_pair, args.padding_ms))
+    print()
+    print("Legend:")
+    print("  conf_med           median CTC confidence (Tier 2)")
+    print("  <0.6%              % of words with confidence < 0.6")
+    print("  onset/offset_p90   p90 |Tier2 - Tier1| boundary shift in ms")
+    print("  edge_p90           p90 of max(onset, offset) shift per word")
+    print(f"  >{int(args.padding_ms)}ms%             % of words whose worst-edge shift > padding (truncation risk)")
+    print("  fallback%          % of words using proportional-fallback (alignment failed)")
+
+    if args.json_out:
+        args.json_out.write_text(
+            json.dumps({"aggregate": aggregate, "per_pair": per_pair}, indent=2),
+            encoding="utf-8",
+        )
+        print(f"\nFull results: {args.json_out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -5170,12 +5170,13 @@ function JobLogsModal({ jobId, onClose }: { jobId: string | null; onClose: () =>
 }
 
 // Visual order mirrors TranscriptionLanes.tsx: phone IPA → word IPA → STT → ORTH.
-const LANE_ORDER: LaneKind[] = ['ipa_phone', 'ipa', 'stt', 'ortho'];
+const LANE_ORDER: LaneKind[] = ['ipa_phone', 'ipa', 'stt', 'ortho', 'boundaries'];
 const LANE_DISPLAY: Record<LaneKind, { label: string; hint: string }> = {
   ipa_phone: { label: 'Phones tier', hint: 'Phone-level IPA' },
   ipa: { label: 'IPA tier', hint: 'Word/lexeme IPA' },
   stt: { label: 'STT segments', hint: 'Coarse transcript' },
   ortho: { label: 'Ortho tier', hint: 'Orthographic' },
+  boundaries: { label: 'Boundaries', hint: 'Tier 2 word edges, colored by Tier 1 ↔ Tier 2 shift' },
 };
 
 function LexemeSearchBlock({ speaker, conceptId }: { speaker: string; conceptId: string | number }) {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -57,10 +57,22 @@ export interface AnnotationRecord {
   source_audio_duration_sec?: number;
 }
 
+export interface SttWord {
+  word: string;
+  start: number;
+  end: number;
+  prob?: number;
+}
+
 export interface SttSegment {
   start: number;
   end: number;
   text: string;
+  /** Optional Tier 1 word-level boundaries from faster-whisper word_timestamps.
+   * Already returned by `/api/stt-segments/<speaker>`; previously stripped from
+   * the type. Consumed by the Boundaries lane to compare Tier 1 vs Tier 2
+   * (forced-aligned) word boundaries. */
+  words?: SttWord[];
 }
 
 export interface SttSegmentsPayload {

--- a/src/components/annotate/TranscriptionLanes.tsx
+++ b/src/components/annotate/TranscriptionLanes.tsx
@@ -26,17 +26,60 @@ interface LaneStrip {
    * the same offset survives migration because `ensureSttTier` copies
    * segments verbatim in order. */
   sourceIndices?: number[];
+  /** Per-interval color override aligned to `intervals[]`. Used by the
+   * Boundaries lane to color each Tier 2 word by its shift from the matching
+   * Tier 1 word (or by Tier 2 confidence when no Tier 1 partner exists).
+   * When unset, the lane's single color from the store is used. */
+  intervalColors?: (string | undefined)[];
   /** True for the STT strip when the record hasn't yet migrated STT into
    * `record.tiers.stt`. Edit-path handlers must call `ensureSttTier` before
    * opening the inline editor / context menu so the tier entry exists. */
   needsMigration?: boolean;
   status?: "idle" | "loading" | "loaded" | "error";
+  /** Custom empty-state message; falls back to a generic per-tier hint. */
+  emptyHint?: string;
 }
 
 // Lane order is hard-coded top-to-bottom and intentionally independent of
 // each tier's numeric display_order (which only governs Praat export sort).
-// Per the 4-lane viewer spec: phone IPA → word IPA → STT → ORTH.
-const LANE_ORDER: LaneKind[] = ["ipa_phone", "ipa", "stt", "ortho"];
+// Phone IPA → word IPA → STT → ORTH → Boundaries (diagnostic overlay).
+const LANE_ORDER: LaneKind[] = ["ipa_phone", "ipa", "stt", "ortho", "boundaries"];
+
+/** Tier 2 forced-align ±pad window; matches forced_align.py:_slice_window
+ * default. A Tier 1 word boundary off by more than this frequently means the
+ * CTC slice cut the phoneme — the case the Boundaries lane flags red. */
+const BOUNDARY_PAD_MS = 100;
+const BOUNDARY_GREEN_MS = 50;
+
+const BND_COLOR_GREEN = "#059669";
+const BND_COLOR_AMBER = "#d97706";
+const BND_COLOR_RED = "#dc2626";
+const BND_COLOR_UNKNOWN = "#64748b";
+
+function boundaryColor(
+  tier2: { start: number; end: number; confidence?: number; source?: string },
+  tier1: { start: number; end: number } | undefined,
+): string {
+  if (tier2.source === "short_clip_fallback") return BND_COLOR_RED;
+  if (
+    tier1 &&
+    Number.isFinite(tier1.start) &&
+    Number.isFinite(tier1.end) &&
+    !(tier1.start === 0 && tier1.end === 0)
+  ) {
+    const onMs = Math.abs(tier2.start - tier1.start) * 1000;
+    const offMs = Math.abs(tier2.end - tier1.end) * 1000;
+    const edgeMs = Math.max(onMs, offMs);
+    if (edgeMs > BOUNDARY_PAD_MS) return BND_COLOR_RED;
+    if (edgeMs >= BOUNDARY_GREEN_MS) return BND_COLOR_AMBER;
+    return BND_COLOR_GREEN;
+  }
+  const conf = tier2.confidence;
+  if (typeof conf !== "number") return BND_COLOR_UNKNOWN;
+  if (conf < 0.4) return BND_COLOR_RED;
+  if (conf < 0.7) return BND_COLOR_AMBER;
+  return BND_COLOR_GREEN;
+}
 
 const LANE_HEIGHT_PX = 28;
 export const LABEL_COL_PX = 56;
@@ -108,6 +151,7 @@ export function TranscriptionLanes({
     ipa: null,
     stt: null,
     ortho: null,
+    boundaries: null,
   });
 
   useEffect(() => {
@@ -239,6 +283,48 @@ export function TranscriptionLanes({
     for (const kind of LANE_ORDER) {
       if (!lanes[kind].visible) continue;
 
+      if (kind === "boundaries") {
+        const segs: SttSegment[] = sttBySpeaker[speaker] ?? [];
+        const tier1Words: Array<{ start: number; end: number; text: string }> = [];
+        for (const seg of segs) {
+          for (const w of seg.words ?? []) {
+            tier1Words.push({ start: w.start, end: w.end, text: w.word });
+          }
+        }
+        const tier2Ivs = (record?.tiers?.ortho_words?.intervals ?? []) as Array<{
+          start: number;
+          end: number;
+          text: string;
+          confidence?: number;
+          source?: "forced_align" | "short_clip_fallback";
+        }>;
+
+        const intervals: Array<{ start: number; end: number; text: string }> = [];
+        const intervalColors: (string | undefined)[] = [];
+        tier2Ivs.forEach((iv, i) => {
+          if (!iv.text || !iv.text.trim()) return;
+          intervals.push({ start: iv.start, end: iv.end, text: iv.text });
+          intervalColors.push(boundaryColor(iv, tier1Words[i]));
+        });
+
+        const hasTier2 = intervals.length > 0;
+        const emptyHint = hasTier2
+          ? undefined
+          : tier1Words.length > 0
+            ? "Run ORTH alignment to populate Tier 2 boundaries"
+            : `Run Orthographic STT for ${speaker}`;
+
+        out.push({
+          kind: "boundaries",
+          label: LANE_LABELS.boundaries,
+          intervals,
+          intervalColors,
+          emptyHint,
+          // No sourceIndices → strip is read-only (clicks seek, no editor).
+        });
+        continue;
+      }
+
       // STT migration: if record.tiers.stt has entries, that is the editable
       // source of truth. Otherwise fall back to the API-cached sttBySpeaker
       // for legacy records that haven't been touched since the new tier
@@ -322,7 +408,9 @@ export function TranscriptionLanes({
         const isEmpty = strip.intervals.length === 0;
         let emptyMsg = "";
         if (isEmpty) {
-          if (strip.kind === "stt") {
+          if (strip.emptyHint) {
+            emptyMsg = strip.emptyHint;
+          } else if (strip.kind === "stt") {
             emptyMsg =
               strip.status === "loading"
                 ? "Loading STT…"
@@ -373,6 +461,7 @@ export function TranscriptionLanes({
                 <div className="relative h-full" style={{ width: innerWidth }}>
                   {visible.map((iv, slotIdx) => {
                     const sourceIdx = visibleSourceIndices?.[slotIdx];
+                    const absIdx = firstIdx + slotIdx;
                     const left = iv.start * pxPerSec;
                     const width = Math.max(1, (iv.end - iv.start) * pxPerSec);
                     const showLabel = width >= MIN_LABEL_WIDTH_PX;
@@ -386,14 +475,15 @@ export function TranscriptionLanes({
                       isEditable &&
                       editing?.kind === strip.kind &&
                       editing?.index === sourceIdx;
+                    const ivColor = strip.intervalColors?.[absIdx] ?? color;
 
                     const baseStyle: React.CSSProperties = {
                       left,
                       width,
-                      backgroundColor: withAlpha(color, isSelected ? 0.28 : 0.14),
-                      borderLeft: `2px solid ${color}`,
+                      backgroundColor: withAlpha(ivColor, isSelected ? 0.28 : 0.14),
+                      borderLeft: `2px solid ${ivColor}`,
                       color: "#334155",
-                      ...({ ["--tw-ring-color"]: color } as React.CSSProperties),
+                      ...({ ["--tw-ring-color"]: ivColor } as React.CSSProperties),
                     };
 
                     if (isEditing && sourceIdx !== undefined) {

--- a/src/stores/transcriptionLanesStore.ts
+++ b/src/stores/transcriptionLanesStore.ts
@@ -6,7 +6,7 @@ import { getSttSegments } from "../api/client";
 // Lane identities visible in the transcription viewer. The visual top-to-bottom
 // order is hard-coded in TranscriptionLanes.tsx (LANE_ORDER), independent of
 // the canonical numeric display_order used for Praat export.
-export type LaneKind = "ipa_phone" | "ipa" | "stt" | "ortho";
+export type LaneKind = "ipa_phone" | "ipa" | "stt" | "ortho" | "boundaries";
 
 export interface LaneConfig {
   visible: boolean;
@@ -43,6 +43,7 @@ export const LANE_LABELS: Record<LaneKind, string> = {
   ipa: "IPA",
   stt: "STT",
   ortho: "ORTH",
+  boundaries: "BND",
 };
 
 const DEFAULT_LANES: Record<LaneKind, LaneConfig> = {
@@ -50,6 +51,7 @@ const DEFAULT_LANES: Record<LaneKind, LaneConfig> = {
   ipa: { visible: true, color: "#059669" },       // emerald — word/lexeme IPA
   stt: { visible: true, color: "#6366f1" },       // indigo
   ortho: { visible: true, color: "#d97706" },     // amber
+  boundaries: { visible: false, color: "#dc2626" }, // off by default; lane fill is per-interval
   // To surface the sentence tier as a lane later: add "sentence" to LaneKind,
   // LANE_LABELS above, LANE_ORDER in TranscriptionLanes.tsx, and uncomment:
   // sentence: { visible: false, color: "#0ea5e9" }, // sky — sentence grouping
@@ -116,12 +118,13 @@ export const useTranscriptionLanesStore = create<TranscriptionLanesStore>()(
     }),
     {
       name: "parse.transcription-lanes",
-      // Bumped to v2 when ipa_phone was added — old persisted lane configs lack
-      // the new key. The migrate fn fills it in with the default rather than
-      // letting the lookup return undefined and crash the renderer.
+      // Bumped to v3 when boundaries was added (v2 added ipa_phone). Old
+      // persisted lane configs lack newer keys; migrate fills them with the
+      // default rather than letting the lookup return undefined and crash
+      // the renderer.
       storage: createJSONStorage(() => localStorage),
       partialize: (state): PersistedState => ({ lanes: state.lanes }),
-      version: 2,
+      version: 3,
       migrate: (persisted: unknown, fromVersion: number): PersistedState => {
         const fallback: PersistedState = { lanes: DEFAULT_LANES };
         if (!persisted || typeof persisted !== "object") return fallback;
@@ -133,6 +136,7 @@ export const useTranscriptionLanesStore = create<TranscriptionLanesStore>()(
               ipa: raw.ipa ?? DEFAULT_LANES.ipa,
               stt: raw.stt ?? DEFAULT_LANES.stt,
               ortho: raw.ortho ?? DEFAULT_LANES.ortho,
+              boundaries: DEFAULT_LANES.boundaries,
             },
           };
         }


### PR DESCRIPTION
## Summary

- Adds a new **Boundaries** lane (off by default) below the existing IPA / STT / ORTH lanes. It renders Tier 2 forced-aligned word intervals colored by the max-edge shift to the paired Tier 1 word: green < 50 ms, amber 50–100 ms, red > 100 ms or `source = short_clip_fallback`. Falls back to coloring by Tier 2 `confidence` when no Tier 1 partner exists.
- Adds [`scripts/benchmark_tier1_boundaries.py`](scripts/benchmark_tier1_boundaries.py): a corpus-aggregating diagnostic over existing `.stt.json` + `.aligned.json` pairs that reports CTC confidence distribution, onset / offset / max-edge shift percentiles, % of words whose worst-edge shift exceeds the configured padding, and `alignment.methodCounts` straight from the artifact. No pipeline re-runs.

## Why

The current STT → forced-align path uses a ±100 ms CTC slice window ([`forced_align.py:_slice_window`](python/ai/forced_align.py)). When Tier 1 word boundaries are off by more than that, the slice cuts the phoneme — the failure mode visible qualitatively in `coarse_transcripts/Fail02.json` (multiple opening words with `start=end=0.0`). Both this lane and the script exist to surface that failure mode in two complementary ways: visually, in-place during IPA review; and quantitatively, across a workspace.

The lane is intentionally read-only for this PR. Boundary correction UX (drag-to-adjust, accept-all, re-run-Tier-2-on-segment) is deferred until the lane has been used on real data and the right interaction is clear.

## What changed

- `src/api/types.ts` — `SttSegment` gains an optional `words?: SttWord[]` matching what `/api/stt-segments/<speaker>` already returns (previously stripped from the type).
- `src/stores/transcriptionLanesStore.ts` — `LaneKind` adds `"boundaries"`; store schema bumps to v3 with a migration that fills the new key with the default (`visible: false`) on existing localStorage.
- `src/components/annotate/TranscriptionLanes.tsx` — `boundaries` strip-builder pairs Tier 1 (`segments[].words[]`) and Tier 2 (`tiers.ortho_words.intervals`) by linear index, computes per-interval color, and renders read-only intervals with empty-state hints distinguishing "run STT" vs "run ORTH".
- `src/ParseUI.tsx` — adds `boundaries` to the right-drawer `LANE_ORDER` + `LANE_DISPLAY` so the toggle appears in the existing controls section.
- `scripts/benchmark_tier1_boundaries.py` — new diagnostic CLI.

No backend changes. No new dependencies.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `vitest run` — 272/272 pass
- [x] Live preview confirms the persisted Zustand store migrates to v3 with the new `boundaries` entry on existing localStorage
- [ ] **Visual verification of the rendered lane requires a workspace with completed Tier 2 ortho_words** (the same data blocker discussed in the PR thread). The preview's local workspace is empty; no `.aligned.json` exists on the PC either. Expect to verify on Fail02 once Tier 2 alignment runs on it.
- [ ] Run `python3 scripts/benchmark_tier1_boundaries.py --workspace <ws>` once the above lands and share the output.

## Notes for reviewer

- The lane comes off by default to avoid changing any existing user's view on first load after upgrade.
- Per-interval color is applied via a new optional `LaneStrip.intervalColors[]` field; existing lanes pass nothing and keep their single-color behavior unchanged.
- Render uses `firstIdx + slotIdx` absolute indexing so per-interval colors stay aligned through virtualization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)