### PR TITLE
fix(batch): preserve job ids across poll disconnects

### DIFF
--- a/src/components/shared/BatchReportModal.tsx
+++ b/src/components/shared/BatchReportModal.tsx
@@ -20,8 +20,13 @@ export interface BatchSpeakerOutcome {
   /** "cancelled" means the user cancelled the batch before this speaker ran.
    *  The speaker's pipeline never started server-side; its result is null. */
   status: "pending" | "running" | "complete" | "error" | "cancelled";
-  /** Whole-speaker error (e.g. network failure before the pipeline job even started). */
+  /** Whole-speaker error (e.g. network failure before the pipeline job even started,
+   *  or a transport disconnect after a job was already queued). */
   error: string | null;
+  /** Backend job id when the speaker reached startCompute successfully. */
+  jobId?: string;
+  /** Which client phase surfaced the top-level error. */
+  errorPhase?: "start" | "poll";
   result: PipelineRunResult | null;
 }
 
@@ -550,6 +555,7 @@ function SpeakerErrorBanner({
   // case we just show the error message and skip the expand button.
   const hasTraceback =
     outcome.error != null && /traceback/i.test(outcome.error);
+  const lostContactAfterStart = outcome.errorPhase === "poll" && !!outcome.jobId;
 
   return (
     <tr>
@@ -560,11 +566,16 @@ function SpeakerErrorBanner({
         <div className="flex flex-col gap-1">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-xs font-semibold text-amber-900">
-              Speaker-level error:
+              {lostContactAfterStart ? "Lost contact after start:" : "Speaker-level error:"}
             </span>
             <span className="font-mono text-[11px] text-amber-900/90">
               {outcome.error ?? "(no message)"}
             </span>
+            {lostContactAfterStart && outcome.jobId && (
+              <span className="rounded bg-amber-100 px-1.5 py-0.5 font-mono text-[11px] text-amber-900">
+                job {outcome.jobId}
+              </span>
+            )}
             {hasTraceback && (
               <button
                 type="button"
@@ -581,6 +592,11 @@ function SpeakerErrorBanner({
               </button>
             )}
           </div>
+          {lostContactAfterStart && (
+            <div className="text-[11px] text-amber-900/80">
+              The pipeline job was created, but the client lost `/api` connectivity while polling. Reattach or reconcile by backend job id before treating this as a true speaker failure.
+            </div>
+          )}
           {hasTraceback && isOpen && (
             <DetailsBlock
               speaker={outcome.speaker}

--- a/src/components/shared/__tests__/BatchReportModal.test.tsx
+++ b/src/components/shared/__tests__/BatchReportModal.test.tsx
@@ -254,6 +254,7 @@ describe("BatchReportModal", () => {
         speaker: "Gamma03",
         status: "error",
         error: "network down",
+        errorPhase: "start",
         result: null,
       },
     ];
@@ -283,7 +284,33 @@ describe("BatchReportModal", () => {
     expect(onRerunFailed).toHaveBeenCalledWith(["Alpha01", "Gamma03"]);
   });
 
-  it("Test G: Download report produces a Blob with expected JSON", async () => {
+  it("Test G: speaker-level poll disconnect banner distinguishes lost contact after start", () => {
+    const outcomes: BatchSpeakerOutcome[] = [
+      {
+        speaker: "Gamma03",
+        status: "error",
+        error:
+          "Could not reach the PARSE API for POST /api/compute/full_pipeline/status.",
+        errorPhase: "poll",
+        jobId: "job-gamma",
+        result: null,
+      },
+    ];
+
+    render(
+      <BatchReportModal
+        open
+        onClose={() => {}}
+        outcomes={outcomes}
+        stepsRun={["stt"]}
+      />,
+    );
+
+    expect(screen.getByText(/Lost contact after start/i)).toBeTruthy();
+    expect(screen.getByText(/job-gamma/)).toBeTruthy();
+  });
+
+  it("Test H: Download report produces a Blob with expected JSON", async () => {
     const outcomes: BatchSpeakerOutcome[] = [
       {
         speaker: "Alpha01",
@@ -292,6 +319,15 @@ describe("BatchReportModal", () => {
         result: makeResult("Alpha01", {
           stt: { status: "ok", segments: 7 },
         }),
+      },
+      {
+        speaker: "Gamma03",
+        status: "error",
+        error:
+          "Could not reach the PARSE API for POST /api/compute/full_pipeline/status.",
+        errorPhase: "poll",
+        jobId: "job-gamma",
+        result: null,
       },
     ];
 
@@ -357,6 +393,11 @@ describe("BatchReportModal", () => {
     expect(parsed).toHaveProperty("outcomes");
     expect(Array.isArray(parsed.outcomes)).toBe(true);
     expect(parsed.outcomes[0].speaker).toBe("Alpha01");
+    expect(parsed.outcomes[1]).toMatchObject({
+      speaker: "Gamma03",
+      jobId: "job-gamma",
+      errorPhase: "poll",
+    });
 
     createObjectURL.mockRestore();
     revokeObjectURL.mockRestore();

--- a/src/hooks/__tests__/useBatchPipelineJob.test.ts
+++ b/src/hooks/__tests__/useBatchPipelineJob.test.ts
@@ -195,6 +195,31 @@ describe("useBatchPipelineJob", () => {
     expect(result.current.state.status).toBe("complete");
   });
 
+  it("preserves the started job id when polling loses API connectivity", async () => {
+    mockStart.mockResolvedValue({ job_id: "job-A" });
+    mockPoll.mockRejectedValue(
+      new Error(
+        "Could not reach the PARSE API for POST /api/compute/full_pipeline/status.",
+      ),
+    );
+
+    const { result } = renderHook(() => useBatchPipelineJob());
+
+    await act(async () => {
+      await result.current.run(baseRequest(["A"]));
+    });
+
+    expect(result.current.state.status).toBe("complete");
+    expect(result.current.state.outcomes[0]).toMatchObject({
+      speaker: "A",
+      status: "error",
+      error:
+        "Could not reach the PARSE API for POST /api/compute/full_pipeline/status.",
+      jobId: "job-A",
+      errorPhase: "poll",
+    });
+  });
+
   it("final state after all complete", async () => {
     mockStart.mockImplementation(async (_type: string, body: Record<string, unknown>) => ({
       job_id: `job-${String(body.speaker)}`,

--- a/src/hooks/useBatchPipelineJob.ts
+++ b/src/hooks/useBatchPipelineJob.ts
@@ -27,9 +27,16 @@ export interface BatchSpeakerOutcome {
   /** "cancelled" means the user cancelled the batch before this speaker ran.
    *  The speaker's pipeline never started server-side. */
   status: "pending" | "running" | "complete" | "error" | "cancelled";
-  /** Whole-speaker error (e.g. network failure before the pipeline job even started).
-   *  Step-level errors live in `result.results[step].error` instead. */
+  /** Whole-speaker error (e.g. network failure before the pipeline job even started,
+   *  or a transport disconnect after the job had already started). */
   error: string | null;
+  /** Backend job id when the speaker reached startCompute successfully. Preserved
+   *  across later poll failures so the UI/report can distinguish "never started"
+   *  from "lost contact after start". */
+  jobId?: string;
+  /** Which batch phase surfaced the top-level error. "start" = no job was
+   *  queued; "poll" = job was queued but the client lost contact while polling. */
+  errorPhase?: "start" | "poll";
   result: PipelineRunResult | null;
 }
 
@@ -287,6 +294,7 @@ export function useBatchPipelineJob(): UseBatchPipelineJobResult {
                 ...nextOutcomes[i],
                 status: "error",
                 error: message,
+                errorPhase: "start",
               };
               return {
                 ...prev,
@@ -300,7 +308,13 @@ export function useBatchPipelineJob(): UseBatchPipelineJobResult {
             continue;
           }
 
-          setStateIfMounted((prev) => ({ ...prev, currentSubJobId: jobId }));
+          setStateIfMounted((prev) => ({
+            ...prev,
+            currentSubJobId: jobId,
+            outcomes: prev.outcomes.map((outcome, index) => (
+              index === i ? { ...outcome, jobId, errorPhase: undefined } : outcome
+            )),
+          }));
 
           // Poll loop — lives for one speaker.
           let pollErrored = false;
@@ -367,6 +381,8 @@ export function useBatchPipelineJob(): UseBatchPipelineJobResult {
                 ...nextOutcomes[i],
                 status: "error",
                 error: pollErrorMessage,
+                errorPhase: "poll",
+                jobId,
                 // Partial per-step data where present — see the comment in
                 // the poll loop for why we forward this on the error path.
                 result: pollResult,


### PR DESCRIPTION
## Summary
- preserve `jobId` and `errorPhase` on batch speaker outcomes when `startCompute` succeeds but later polling loses `/api` connectivity
- surface a distinct Batch Report banner for "lost contact after start" so started jobs are no longer collapsed into generic speaker-level failures
- include the preserved metadata in the downloaded batch JSON so follow-up audits and reconciliation have the backend handle they need

## Context
The backend IPA interop-thread fix already landed on `main`; this PR implements the next audit follow-up from MC-321 on the frontend/client-state side.

## Test plan
- `npx vitest run src/hooks/__tests__/useBatchPipelineJob.test.ts`
- `npx vitest run src/components/shared/__tests__/BatchReportModal.test.tsx`
- `npx vitest run src/hooks/__tests__/useBatchPipelineJob.test.ts src/components/shared/__tests__/BatchReportModal.test.tsx src/ParseUI.test.tsx`
- `npx tsc --noEmit`
