### PR TITLE
docs: refresh PARSE docs for PRs 214-219

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ It combines:
 
 - **WaveSurfer 7** waveform review for long recordings
 - **Four annotation tiers**: IPA, orthography, concept, and speaker
-- **Stacked transcription lanes** for STT, IPA, and ORTH with synchronized horizontal scrolling and inline edit / split / merge / delete controls
+- **Stacked transcription lanes** for STT, IPA, ORTH, and an optional **Boundaries** diagnostic lane with synchronized horizontal scrolling and inline edit / split / merge / delete controls
 - **Audio normalization**, **speaker-level STT**, **ORTH transcription**, and **acoustic IPA fill** jobs
-- **Tier 2 forced alignment** with wav2vec2 for tighter word-level boundaries
+- **Tier 2 forced alignment** with wav2vec2 for tighter word-level boundaries plus a read-only boundary-delta overlay for spotting Tier 1 drift
 - **Per-speaker undo/redo** for annotation edits, including merge recovery and STT-tier migration
 - **Draggable timestamp correction** and clip-bounded playback for manual review
-- **Batch transcription** with preflight checks, per-step **Keep / Overwrite** scope controls, and rerun-failed support
+- **Batch transcription** with preflight checks, per-step **Keep / Overwrite** scope controls, rerun-failed support, and report rows that preserve backend job ids when the UI loses `/api` connectivity mid-run
 - **Timestamp-offset detection/apply workflows** for constant CSV↔audio misalignment, now with async progress, crash-log surfacing, and protection for manually adjusted / anchored lexemes
 - **Search & anchor lexeme** tooling built on the Lexical Anchor Alignment System
 - **Shared tags** and the in-session **AI chat dock**
@@ -181,7 +181,7 @@ PARSE is designed around a real fieldwork sequence rather than a toy demo sequen
 4. **Correct timestamps and confirm segments** in Annotate mode
 5. **Search and anchor difficult lexemes** across long recordings
 6. **Compare the concept set across speakers** in the matrix view
-7. **Use CLEF evidence** when a borrowing analysis needs external lexical context — the first time you run **Borrowing detection (CLEF)** from the Compute panel, PARSE opens a guided setup modal where you pick 1–2 primary contact languages (English + Spanish by default) and optionally auto-populate lexeme forms from the provider stack. The config lives in `config/sil_contact_languages.json`; extend the language picker with `config/sil_catalog_extra.json`. Each language now also carries an ISO 15924 `script` hint so bare Reference Forms route deterministically between IPA-like Latin text and non-Latin script text.
+7. **Use CLEF evidence** when a borrowing analysis needs external lexical context — the first time you run **Borrowing detection (CLEF)** from the Compute panel, PARSE opens a guided setup modal where you pick 1–2 primary contact languages (English + Spanish by default) and optionally auto-populate lexeme forms from the provider stack. The config lives in `config/sil_contact_languages.json`; extend the language picker with `config/sil_catalog_extra.json`. Each language now also carries an ISO 15924 `script` hint so bare Reference Forms route deterministically between IPA-like Latin text and non-Latin script text. If your workspace was populated before the 2026-04-25 exact-match fix for `lingpy_wordlist`, rerun CLEF populate with overwrite so any previously misbucketed doculect forms are replaced.
 8. **Export LingPy TSV or NEXUS** for downstream comparative and phylogenetic analysis
 
 The guiding principle is simple: timestamps are central, human review stays explicit, and automation should make linguistic judgment faster rather than opaque.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ It combines:
 
 - **WaveSurfer 7** waveform review for long recordings
 - **Four annotation tiers**: IPA, orthography, concept, and speaker
-- **Stacked transcription lanes** for STT, IPA, ORTH, and an optional **Boundaries** diagnostic lane with synchronized horizontal scrolling and inline edit / split / merge / delete controls
+- **Stacked transcription lanes** for STT, IPA, ORTH, plus optional **Words (Tier 1)** and **Boundaries (Tier 2)** diagnostic lanes with synchronized horizontal scrolling and inline edit / split / merge / delete controls
 - **Audio normalization**, **speaker-level STT**, **ORTH transcription**, and **acoustic IPA fill** jobs
-- **Tier 2 forced alignment** with wav2vec2 for tighter word-level boundaries plus a read-only boundary-delta overlay for spotting Tier 1 drift
+- **Tier 2 forced alignment** with wav2vec2 for tighter word-level boundaries plus paired Tier 1/Tier 2 read-only overlays for spotting boundary drift
 - **Per-speaker undo/redo** for annotation edits, including merge recovery and STT-tier migration
 - **Draggable timestamp correction** and clip-bounded playback for manual review
 - **Batch transcription** with preflight checks, per-step **Keep / Overwrite** scope controls, rerun-failed support, and report rows that preserve backend job ids when the UI loses `/api` connectivity mid-run
@@ -72,7 +72,7 @@ It provides:
 - Per-row editing, speaker flags, and secondary actions for review work
 - **Borrowing adjudication** aided by contact-language similarity evidence, dynamic primary-language similarity columns, and selectable reference forms
 - **Enrichment overlays** for computed comparative metadata
-- The **CLEF** panel for multi-source contact-language lookup, provenance-aware **Sources Report**, and retryable populate workflows
+- The **CLEF** panel for multi-source contact-language lookup, provenance-aware **Sources Report**, academic citation cards, and retryable populate workflows
 - The same shared **tag system** used in Annotate mode
 - Export to **LingPy-compatible TSV** and **NEXUS** for downstream phylogenetic analysis
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -297,6 +297,8 @@ On the first CLEF run, PARSE opens a guided **Configure CLEF** modal that lets y
 
 Catalog entries now include an ISO 15924 `script` hint, and PARSE persists that hint into the CLEF config so bare Reference Forms can be routed deterministically even when providers return unlabeled raw strings.
 
+The local `lingpy_wordlist` provider also now matches doculect identifiers by exact equality instead of substring containment. If a workspace was populated before that 2026-04-25 fix, rerun CLEF populate with overwrite so any previously misbucketed forms are replaced.
+
 The resulting config is written to:
 
 - `config/sil_contact_languages.json`
@@ -412,6 +414,16 @@ When reviewing pipeline state, prefer the coverage-aware fields:
 - `full_coverage`
 
 This matters when old runs only covered a stale timestamp window rather than the entire recording.
+
+### A batch report says "Lost contact after start"
+
+This message means the backend job was created successfully, but the browser lost `/api` connectivity while polling — commonly because the Vite dev server or proxy died while the Python backend kept running.
+
+Use the preserved backend `jobId` shown in the batch report to reconcile before rerunning blindly:
+
+1. restore the frontend / proxy if needed
+2. poll the backend job directly or reopen PARSE and let the UI reattach
+3. only rerun the speaker if the backend job truly failed or never produced the expected result
 
 ### Need logs during a launch failure
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 # User Guide
 
-> Last updated: 2026-04-24
+> Last updated: 2026-04-25
 >
 > This guide focuses on the current PARSE workstation as described in the latest repository README: the unified React shell, Annotate route `/`, Compare route `/compare`, CLEF, the AI chat dock, and processed-speaker workspace hydration.
 
@@ -45,6 +45,7 @@ The current Annotate surface includes:
   - STT
   - IPA
   - ORTH
+  - optional **Boundaries** diagnostics (off by default)
 - **Inline lane editing** across STT, IPA, and ORTH via double-click or right-click context actions
 - **Synchronized horizontal scrolling** between waveform and lanes
 - **Clip-bounded playback** for the selected region
@@ -92,6 +93,14 @@ Tier 2 forced alignment uses `torchaudio.functional.forced_align` against wav2ve
 
 This is the step that turns coarse word timing into more reviewable alignment.
 
+Annotate mode now also includes an optional **Boundaries** lane (hidden by default) that overlays the Tier 2 word windows beneath the waveform. Each interval is color-coded from the delta between the Tier 1 STT word and its paired Tier 2 boundary:
+
+- green — worst edge shift under 50 ms
+- amber — 50–100 ms
+- red — over 100 ms, or a Tier 2 `short_clip_fallback`
+
+When no Tier 1 partner exists, PARSE falls back to Tier 2 `confidence` coloring instead. The lane is read-only in the current build: it is meant to expose suspicious Tier 1 windows before you decide whether to correct timestamps or rerun a step, not to replace the existing interval-editing workflow.
+
 #### Acoustic IPA fill
 
 The current IPA path is **acoustic wav2vec2-only**.
@@ -113,7 +122,9 @@ The current batch flow includes:
 - a walk-away batch report with expandable tracebacks
 - explicit **empty-step detection** for runs that technically completed but wrote no intervals
 - skip-breakdown counters and exception samples for steps that ran but still produced no usable output
+- preserved backend `jobId` + `errorPhase` metadata when a speaker started successfully but the UI later lost `/api` connectivity while polling
 
+If a batch report row says **Lost contact after start**, PARSE is telling you that the backend job was created and the browser lost transport later. Use the preserved backend job id to reattach or reconcile before treating that row as a true speaker-level pipeline failure.
 A key detail is that preflight distinguishes **"has intervals"** from **"full WAV coverage"** via fields such as:
 
 - `duration_sec`
@@ -136,6 +147,9 @@ Annotate mode supports:
 - manual boundary correction
 - constant timestamp-offset detect/apply workflows for CSV↔audio misalignment
 - manual fallback from a trusted single pair when automated offset detection is weak
+- optional boundary diagnostics through the **Boundaries** lane and the read-only corpus script `scripts/benchmark_tier1_boundaries.py`
+
+The benchmark script is useful when you want a workspace-level read on how far Tier 2 windows are shifting away from Tier 1 STT words without rerunning the pipeline. It reports confidence distributions, onset/offset/max-edge shift percentiles, the fraction of words whose worst edge exceeds the configured padding, and `alignment.methodCounts` from existing `.stt.json` + `.aligned.json` artifacts.
 
 This is one of the main places where PARSE differs from purely transcription-first tools: timestamps are not treated as disposable by-products.
 
@@ -248,6 +262,8 @@ Populate jobs now follow the same global-job pattern as other heavy PARSE workfl
 
 The Compare table and detail views also follow the configured CLEF primaries dynamically: similarity columns are no longer hard-coded to Arabic/Persian, and the **Reference Forms** panel can render multiple forms per language.
 
+The local `lingpy_wordlist` provider now matches doculect identifiers by exact case-insensitive equality (with whitespace / dash / underscore folding), not substring containment. That prevents contact-language buckets such as Arabic from accidentally absorbing unrelated doculects like Avar, Karelian, or Hungarian simply because their identifiers contain `ar`.
+
 Each reference form row has a checkbox. Those selections persist to `sil_contact_languages.json._meta.form_selections`, and only the selected forms contribute to the similarity score.
 
 Bare-string reference forms are no longer routed by Unicode guessing alone. Each configured contact language now carries an ISO 15924 `script` hint, so PARSE can decide deterministically whether a raw form should land in the IPA-like slot or the script-text slot. Explicit provider labels (`ipa` / `script`) still win over the hint, and the Unicode-block regex remains only as a fallback for legacy or hint-less entries.
@@ -260,6 +276,8 @@ On a fresh workspace, the first run of **Borrowing detection (CLEF)** now opens 
 - save the language setup only, or **Save & populate** immediately
 
 The saved config lives at `config/sil_contact_languages.json`; optional extra catalog entries can be provided through `config/sil_catalog_extra.json`.
+
+If a workspace was populated before the 2026-04-25 exact-match fix in `lingpy_wordlist`, rerun CLEF populate with overwrite so any forms previously misbucketed by substring-matched doculect ids are replaced with the corrected provider output.
 
 ### Current provider set (10)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -45,7 +45,8 @@ The current Annotate surface includes:
   - STT
   - IPA
   - ORTH
-  - optional **Boundaries** diagnostics (off by default)
+  - optional **Words (Tier 1)** diagnostics (off by default)
+  - optional **Boundaries (Tier 2)** diagnostics (off by default)
 - **Inline lane editing** across STT, IPA, and ORTH via double-click or right-click context actions
 - **Synchronized horizontal scrolling** between waveform and lanes
 - **Clip-bounded playback** for the selected region
@@ -93,13 +94,18 @@ Tier 2 forced alignment uses `torchaudio.functional.forced_align` against wav2ve
 
 This is the step that turns coarse word timing into more reviewable alignment.
 
-Annotate mode now also includes an optional **Boundaries** lane (hidden by default) that overlays the Tier 2 word windows beneath the waveform. Each interval is color-coded from the delta between the Tier 1 STT word and its paired Tier 2 boundary:
+Annotate mode now also includes two optional diagnostic lanes (both hidden by default) beneath the waveform:
+
+- **Words (Tier 1)** — cyan boxes from `sttBySpeaker[speaker].segments[].words[]`
+- **Boundaries (Tier 2)** — the forced-aligned word windows
+
+Each Tier 2 interval is color-coded from the delta between the Tier 1 STT word and its paired Tier 2 boundary:
 
 - green — worst edge shift under 50 ms
 - amber — 50–100 ms
 - red — over 100 ms, or a Tier 2 `short_clip_fallback`
 
-When no Tier 1 partner exists, PARSE falls back to Tier 2 `confidence` coloring instead. The lane is read-only in the current build: it is meant to expose suspicious Tier 1 windows before you decide whether to correct timestamps or rerun a step, not to replace the existing interval-editing workflow.
+When no Tier 1 partner exists, PARSE falls back to Tier 2 `confidence` coloring instead. Stacking **Words (Tier 1)** directly above **Boundaries (Tier 2)** lets you eyeball the same lexical item in both tiers without relying on color alone. Both lanes are read-only in the current build: they are meant to expose suspicious Tier 1 windows before you decide whether to correct timestamps or rerun a step, not to replace the existing interval-editing workflow.
 
 #### Acoustic IPA fill
 
@@ -147,7 +153,7 @@ Annotate mode supports:
 - manual boundary correction
 - constant timestamp-offset detect/apply workflows for CSV↔audio misalignment
 - manual fallback from a trusted single pair when automated offset detection is weak
-- optional boundary diagnostics through the **Boundaries** lane and the read-only corpus script `scripts/benchmark_tier1_boundaries.py`
+- optional boundary diagnostics through the **Words (Tier 1)** + **Boundaries (Tier 2)** lanes and the read-only corpus script `scripts/benchmark_tier1_boundaries.py`
 
 The benchmark script is useful when you want a workspace-level read on how far Tier 2 windows are shifting away from Tier 1 STT words without rerunning the pipeline. It reports confidence distributions, onset/offset/max-edge shift percentiles, the fraction of words whose worst edge exceeds the configured padding, and `alignment.methodCounts` from existing `.stt.json` + `.aligned.json` artifacts.
 
@@ -304,11 +310,21 @@ If a workspace was populated before the 2026-04-25 exact-match fix in `lingpy_wo
 - `POST /api/compute/contact-lexemes` — start a contact-lexeme fetch job
 - `GET /api/contact-lexemes/coverage` — inspect current provider coverage
 
-### Sources Report and provenance
+### Sources Report, provenance, and citations
 
 The **Sources Report** modal summarizes which providers contributed the currently populated reference forms.
 
 This matters for academic use because CLEF no longer treats the populated form list as an opaque blob. New entries can carry per-form provenance such as `wikidata`, `wiktionary`, `asjp`, or other provider sources, while older bare-string entries remain readable as legacy `unknown` provenance until you explicitly repopulate them.
+
+The report now also includes an **Academic citations** section for the providers that actually contributed forms in the current corpus. For each contributing provider, PARSE can surface:
+
+- a full dataset/tool citation paragraph
+- DOI and URL links where available
+- provider caveat notes (for example, warnings around AI-generated or legacy unattributed data)
+- **Copy citation** and, where applicable, **Copy BibTeX** actions
+- an **Export BibTeX** action when at least one contributing provider has a bibliographic entry
+
+This gives thesis workflows a direct path from populated reference forms to footnotes and reference-manager imports, instead of treating provider chips as informal provenance only.
 
 ## AI Workflow Assistant in daily use
 


### PR DESCRIPTION
## Summary
- refresh README, Getting Started, and User Guide for the user-facing changes that landed in today's PARSE PRs
- document the new Annotate Boundaries diagnostics lane and the `scripts/benchmark_tier1_boundaries.py` workflow from PR #218
- document the batch-report `lost contact after start` semantics from PR #219 and the CLEF exact-match / repopulate guidance from PR #216

## PRs audited
- #214 `fix: tolerate late IPA interop thread config`
- #216 `fix(clef): exact-match doculect IDs in lingpy_wordlist provider`
- #217 `fix(clef): show contact-lexemes job in header chip, not drawer`
- #218 `feat(annotate): Boundaries lane + Tier 1 diagnostic script`
- #219 `fix(batch): preserve job ids across poll disconnects`

## Notes
- PR #217 did not require a new user-doc section because the current CLEF docs already describe populate progress living in the shared header status chip.
- PR #214 already shipped its dedicated debugging write-up under `docs/debugging/ipa-threading-error-findings.md`; no additional top-level troubleshooting prose was needed beyond today's user-facing updates.

## Test plan
- `git diff --check`
- manual code-grounded verification against current `origin/main` for:
  - `src/components/annotate/TranscriptionLanes.tsx`
  - `scripts/benchmark_tier1_boundaries.py`
  - `src/hooks/useBatchPipelineJob.ts`
  - `src/components/shared/BatchReportModal.tsx`
  - `python/compare/providers/lingpy_wordlist.py`
