### PR TITLE
feat(annotate): split BND into Words + Boundaries lanes

### DIFF
--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -5202,13 +5202,14 @@ function JobLogsModal({ jobId, onClose }: { jobId: string | null; onClose: () =>
 }
 
 // Visual order mirrors TranscriptionLanes.tsx: phone IPA → word IPA → STT → ORTH.
-const LANE_ORDER: LaneKind[] = ['ipa_phone', 'ipa', 'stt', 'ortho', 'boundaries'];
+const LANE_ORDER: LaneKind[] = ['ipa_phone', 'ipa', 'stt', 'ortho', 'stt_words', 'boundaries'];
 const LANE_DISPLAY: Record<LaneKind, { label: string; hint: string }> = {
   ipa_phone: { label: 'Phones tier', hint: 'Phone-level IPA' },
   ipa: { label: 'IPA tier', hint: 'Word/lexeme IPA' },
   stt: { label: 'STT segments', hint: 'Coarse transcript' },
   ortho: { label: 'Ortho tier', hint: 'Orthographic' },
-  boundaries: { label: 'Boundaries', hint: 'Tier 2 word edges, colored by Tier 1 ↔ Tier 2 shift' },
+  stt_words: { label: 'Words (Tier 1)', hint: 'Raw faster-whisper word boundaries' },
+  boundaries: { label: 'Boundaries (Tier 2)', hint: 'Forced-aligned edges; colored by Tier 1 ↔ Tier 2 shift' },
 };
 
 function LexemeSearchBlock({ speaker, conceptId }: { speaker: string; conceptId: string | number }) {

--- a/src/components/annotate/TranscriptionLanes.tsx
+++ b/src/components/annotate/TranscriptionLanes.tsx
@@ -42,8 +42,11 @@ interface LaneStrip {
 
 // Lane order is hard-coded top-to-bottom and intentionally independent of
 // each tier's numeric display_order (which only governs Praat export sort).
-// Phone IPA → word IPA → STT → ORTH → Boundaries (diagnostic overlay).
-const LANE_ORDER: LaneKind[] = ["ipa_phone", "ipa", "stt", "ortho", "boundaries"];
+// Phone IPA → word IPA → STT → ORTH → Words (Tier 1) → Boundaries (Tier 2).
+// Words sits directly above Boundaries so a researcher reading the strips
+// top-down sees the same word at both Tier 1 and Tier 2 positions and can
+// eyeball the shift without color-coding alone.
+const LANE_ORDER: LaneKind[] = ["ipa_phone", "ipa", "stt", "ortho", "stt_words", "boundaries"];
 
 /** Tier 2 forced-align ±pad window; matches forced_align.py:_slice_window
  * default. A Tier 1 word boundary off by more than this frequently means the
@@ -151,6 +154,7 @@ export function TranscriptionLanes({
     ipa: null,
     stt: null,
     ortho: null,
+    stt_words: null,
     boundaries: null,
   });
 
@@ -282,6 +286,40 @@ export function TranscriptionLanes({
     const out: LaneStrip[] = [];
     for (const kind of LANE_ORDER) {
       if (!lanes[kind].visible) continue;
+
+      if (kind === "stt_words") {
+        const segs: SttSegment[] = sttBySpeaker[speaker] ?? [];
+        const intervals: Array<{ start: number; end: number; text: string }> = [];
+        for (const seg of segs) {
+          for (const w of seg.words ?? []) {
+            const text = (w.word ?? "").trim();
+            if (!text) continue;
+            // Skip degenerate boundaries (Whisper's word_timestamps occasionally
+            // emits start==end==0 for the first word of a segment). They'd
+            // render as an invisible 1px box anyway and just clutter the lane.
+            if (w.start === 0 && w.end === 0) continue;
+            intervals.push({ start: w.start, end: w.end, text });
+          }
+        }
+        const status = sttStatus[speaker] ?? "idle";
+        const emptyHint =
+          intervals.length > 0
+            ? undefined
+            : status === "loading"
+              ? "Loading STT…"
+              : status === "error"
+                ? "Failed to load STT"
+                : `No word-level STT yet — run word-level STT for ${speaker}`;
+        out.push({
+          kind: "stt_words",
+          label: LANE_LABELS.stt_words,
+          intervals,
+          emptyHint,
+          status,
+          // No sourceIndices → strip is read-only (clicks seek, no editor).
+        });
+        continue;
+      }
 
       if (kind === "boundaries") {
         const segs: SttSegment[] = sttBySpeaker[speaker] ?? [];

--- a/src/stores/transcriptionLanesStore.ts
+++ b/src/stores/transcriptionLanesStore.ts
@@ -6,7 +6,7 @@ import { getSttSegments } from "../api/client";
 // Lane identities visible in the transcription viewer. The visual top-to-bottom
 // order is hard-coded in TranscriptionLanes.tsx (LANE_ORDER), independent of
 // the canonical numeric display_order used for Praat export.
-export type LaneKind = "ipa_phone" | "ipa" | "stt" | "ortho" | "boundaries";
+export type LaneKind = "ipa_phone" | "ipa" | "stt" | "ortho" | "stt_words" | "boundaries";
 
 export interface LaneConfig {
   visible: boolean;
@@ -43,15 +43,17 @@ export const LANE_LABELS: Record<LaneKind, string> = {
   ipa: "IPA",
   stt: "STT",
   ortho: "ORTH",
+  stt_words: "Words",
   boundaries: "BND",
 };
 
 const DEFAULT_LANES: Record<LaneKind, LaneConfig> = {
-  ipa_phone: { visible: true, color: "#8b5cf6" }, // violet — phone-level IPA
-  ipa: { visible: true, color: "#059669" },       // emerald — word/lexeme IPA
-  stt: { visible: true, color: "#6366f1" },       // indigo
-  ortho: { visible: true, color: "#d97706" },     // amber
-  boundaries: { visible: false, color: "#dc2626" }, // off by default; lane fill is per-interval
+  ipa_phone: { visible: true, color: "#8b5cf6" },  // violet — phone-level IPA
+  ipa: { visible: true, color: "#059669" },        // emerald — word/lexeme IPA
+  stt: { visible: true, color: "#6366f1" },        // indigo — sentence-level STT
+  ortho: { visible: true, color: "#d97706" },      // amber
+  stt_words: { visible: false, color: "#0891b2" }, // cyan — Tier 1 word boxes (paired companion to BND)
+  boundaries: { visible: false, color: "#dc2626" }, // BND fill is per-interval (color by shift)
   // To surface the sentence tier as a lane later: add "sentence" to LaneKind,
   // LANE_LABELS above, LANE_ORDER in TranscriptionLanes.tsx, and uncomment:
   // sentence: { visible: false, color: "#0ea5e9" }, // sky — sentence grouping
@@ -118,13 +120,13 @@ export const useTranscriptionLanesStore = create<TranscriptionLanesStore>()(
     }),
     {
       name: "parse.transcription-lanes",
-      // Bumped to v3 when boundaries was added (v2 added ipa_phone). Old
-      // persisted lane configs lack newer keys; migrate fills them with the
+      // v4 added stt_words; v3 added boundaries; v2 added ipa_phone. Old
+      // persisted configs lack newer keys; migrate fills them with the
       // default rather than letting the lookup return undefined and crash
       // the renderer.
       storage: createJSONStorage(() => localStorage),
       partialize: (state): PersistedState => ({ lanes: state.lanes }),
-      version: 3,
+      version: 4,
       migrate: (persisted: unknown, fromVersion: number): PersistedState => {
         const fallback: PersistedState = { lanes: DEFAULT_LANES };
         if (!persisted || typeof persisted !== "object") return fallback;
@@ -136,6 +138,7 @@ export const useTranscriptionLanesStore = create<TranscriptionLanesStore>()(
               ipa: raw.ipa ?? DEFAULT_LANES.ipa,
               stt: raw.stt ?? DEFAULT_LANES.stt,
               ortho: raw.ortho ?? DEFAULT_LANES.ortho,
+              stt_words: DEFAULT_LANES.stt_words,
               boundaries: DEFAULT_LANES.boundaries,
             },
           };


### PR DESCRIPTION
## Summary

Per [user feedback on #218](https://github.com/ArdeleanLucas/PARSE/pull/218): combining Tier 1 and Tier 2 into a single BND strip with shift color-coding made the two layers hard to distinguish, especially when boundaries overlap. Tier 1 information was only inferable from BND's color — the actual Tier 1 boundary was never visible as its own boundary.

This adds a separate **Words (Tier 1)** lane (cyan, off by default) sourced from `sttBySpeaker[speaker].segments[].words[]`, sitting directly above the existing **Boundaries (Tier 2)** strip. Stacking them lets a researcher eyeball Tier 1 onset vs Tier 2 onset at the same time index without relying on color alone.

## What changed

- `src/stores/transcriptionLanesStore.ts` — `LaneKind` adds `"stt_words"`; store schema bumps to v4 with a migration that fills the new key with the default (`visible: false`) on existing localStorage.
- `src/components/annotate/TranscriptionLanes.tsx` — new strip-builder branch for `stt_words`. Skips degenerate Whisper boundaries (`start === 0 && end === 0` — common on first word of a segment) so they don't render as 1px-wide invisible boxes.
- `src/ParseUI.tsx` — adds `stt_words` to the right-drawer `LANE_ORDER` + `LANE_DISPLAY`. Relabels boundaries to "Boundaries (Tier 2)" so the pairing reads naturally next to the new "Words (Tier 1)" entry.

Both new lanes off by default. Existing users keep their current view on first load.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] Live preview confirms store migrates to v4 with both `stt_words` and `boundaries` entries
- [ ] Visual verification with real Tier 1 word data on Fail02 — pending the in-flight forced_align job (the same data blocker as #218; `.aligned.json` is finally being produced now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)