### PR TITLE
feat(clef): academic citations in Sources Report

### DIFF
--- a/python/compare/providers/citations.py
+++ b/python/compare/providers/citations.py
@@ -1,0 +1,345 @@
+"""Academic citations for the CLEF Sources Report.
+
+Each provider in ``PROVIDER_PRIORITY`` carries a canonical bibliographic
+reference that the Sources Report modal renders alongside the per-form
+provider chip. The citations are dataset-level, not per-form: an ASJP
+entry currently can't be deep-linked to a specific row, only attributed
+to "the ASJP database (version 20)". A follow-up change can extend the
+``FetchResult`` shape to attach per-form metadata (URL, dataset version,
+retrieval date, lexeme id) for true per-form citations.
+
+Schema -- one entry per provider id::
+
+    {
+      "label":   "Wikidata",
+      "type":    "dataset" | "tool" | "ai" | "manual" | "sentinel",
+      "authors": "Vrandečić, D. & Krötzsch, M.",
+      "year":    2014,
+      "title":   "Wikidata: a free collaborative knowledgebase",
+      "venue":   "Communications of the ACM 57(10): 78-85",
+      "doi":     "10.1145/2629489",
+      "url":     "https://www.wikidata.org",
+      "license": "CC0-1.0",
+      "note":    "(optional caveat -- e.g. 'LLM-generated, must be verified')",
+      "citation": "Vrandečić, D. & Krötzsch, M. 2014. Wikidata: a free collaborative knowledgebase. Communications of the ACM 57(10): 78-85. doi:10.1145/2629489",
+      "bibtex":   "@article{wikidata2014, ...}"
+    }
+
+The free-text ``citation`` is what most readers paste into a footnote.
+``bibtex`` lets the user export a single .bib for the whole report.
+``type`` lets the modal flag the LLM and sentinel entries differently.
+
+The keys here MUST match the provider ids registered in
+``compare/providers/registry.PROVIDER_PRIORITY`` plus the
+``compare/providers/provenance.UNKNOWN_SOURCE`` sentinel. A test in
+``test_citations.py`` enforces that contract so a new provider can't
+ship without a citation entry.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+# Stable order so the modal can render a consistent provider list across
+# refreshes. Not enforced -- the registry's PROVIDER_PRIORITY drives the
+# real fetch order; this list just controls display when iterating the
+# citations map.
+CITATION_DISPLAY_ORDER = (
+    "csv_override",
+    "lingpy_wordlist",
+    "pycldf",
+    "pylexibank",
+    "asjp",
+    "cldf",
+    "wikidata",
+    "wiktionary",
+    "grokipedia",
+    "literature",
+    "unknown",
+)
+
+
+PROVIDER_CITATIONS: Dict[str, Dict[str, Any]] = {
+    "asjp": {
+        "label": "ASJP",
+        "type": "dataset",
+        "authors": "Wichmann, S., Holman, E. W., & Brown, C. H. (eds.)",
+        "year": 2022,
+        "title": "The ASJP Database (version 20)",
+        "venue": "Max Planck Institute for Evolutionary Anthropology",
+        "url": "https://asjp.clld.org",
+        "license": "CC-BY-4.0",
+        "citation": (
+            "Wichmann, S., Holman, E. W., & Brown, C. H. (eds.). 2022. "
+            "The ASJP Database (version 20). "
+            "Max Planck Institute for Evolutionary Anthropology. "
+            "https://asjp.clld.org"
+        ),
+        "bibtex": (
+            "@misc{asjp2022,\n"
+            "  author = {Wichmann, Søren and Holman, Eric W. and Brown, Cecil H.},\n"
+            "  title = {{The ASJP Database (version 20)}},\n"
+            "  year = {2022},\n"
+            "  publisher = {Max Planck Institute for Evolutionary Anthropology},\n"
+            "  url = {https://asjp.clld.org}\n"
+            "}"
+        ),
+    },
+    "wikidata": {
+        "label": "Wikidata",
+        "type": "dataset",
+        "authors": "Vrandečić, D. & Krötzsch, M.",
+        "year": 2014,
+        "title": "Wikidata: a free collaborative knowledgebase",
+        "venue": "Communications of the ACM 57(10): 78-85",
+        "doi": "10.1145/2629489",
+        "url": "https://www.wikidata.org",
+        "license": "CC0-1.0",
+        "citation": (
+            "Vrandečić, D. & Krötzsch, M. 2014. Wikidata: a free collaborative "
+            "knowledgebase. Communications of the ACM 57(10): 78-85. "
+            "doi:10.1145/2629489"
+        ),
+        "bibtex": (
+            "@article{wikidata2014,\n"
+            "  author = {Vrandečić, Denny and Krötzsch, Markus},\n"
+            "  title = {{Wikidata: A Free Collaborative Knowledgebase}},\n"
+            "  journal = {Communications of the ACM},\n"
+            "  volume = {57},\n"
+            "  number = {10},\n"
+            "  pages = {78--85},\n"
+            "  year = {2014},\n"
+            "  doi = {10.1145/2629489}\n"
+            "}"
+        ),
+    },
+    "wiktionary": {
+        "label": "Wiktionary",
+        "type": "dataset",
+        "authors": "Wiktionary contributors",
+        "year": None,  # rolling -- citation includes "accessed YYYY-MM-DD"
+        "title": "Wiktionary, the free dictionary",
+        "url": "https://www.wiktionary.org",
+        "license": "CC-BY-SA-4.0",
+        "note": "Per-page revision history available via the wiki history view.",
+        "citation": (
+            "Wiktionary contributors. Wiktionary, the free dictionary. "
+            "Wikimedia Foundation. https://www.wiktionary.org "
+            "(accessed via the PARSE CLEF populate run; check entry history "
+            "for the revision used)."
+        ),
+        "bibtex": (
+            "@misc{wiktionary,\n"
+            "  author = {{Wiktionary contributors}},\n"
+            "  title = {{Wiktionary, the free dictionary}},\n"
+            "  publisher = {Wikimedia Foundation},\n"
+            "  url = {https://www.wiktionary.org},\n"
+            "  note = {Accessed via PARSE CLEF; entry-level revisions in page history}\n"
+            "}"
+        ),
+    },
+    "cldf": {
+        "label": "CLDF",
+        "type": "dataset",
+        "authors": "Forkel, R., List, J.-M., Greenhill, S. J., Rzymski, C., Bank, S., Cysouw, M., Hammarström, H., Haspelmath, M., Kaiping, G. A., & Gray, R. D.",
+        "year": 2018,
+        "title": "Cross-Linguistic Data Formats, advancing data sharing and re-use in comparative linguistics",
+        "venue": "Scientific Data 5: 180205",
+        "doi": "10.1038/sdata.2018.205",
+        "url": "https://cldf.clld.org",
+        "license": "CC-BY-4.0",
+        "citation": (
+            "Forkel, R. et al. 2018. Cross-Linguistic Data Formats, advancing "
+            "data sharing and re-use in comparative linguistics. "
+            "Scientific Data 5: 180205. doi:10.1038/sdata.2018.205"
+        ),
+        "bibtex": (
+            "@article{cldf2018,\n"
+            "  author = {Forkel, Robert and List, Johann-Mattis and Greenhill, "
+            "Simon J. and Rzymski, Christoph and Bank, Sebastian and Cysouw, "
+            "Michael and Hammarström, Harald and Haspelmath, Martin and Kaiping, "
+            "Gereon A. and Gray, Russell D.},\n"
+            "  title = {{Cross-Linguistic Data Formats, advancing data sharing "
+            "and re-use in comparative linguistics}},\n"
+            "  journal = {Scientific Data},\n"
+            "  volume = {5},\n"
+            "  pages = {180205},\n"
+            "  year = {2018},\n"
+            "  doi = {10.1038/sdata.2018.205}\n"
+            "}"
+        ),
+    },
+    "pycldf": {
+        "label": "pycldf",
+        "type": "tool",
+        "authors": "Forkel, R.",
+        "year": 2024,
+        "title": "pycldf: A Python library to read and write CLDF datasets",
+        "url": "https://github.com/cldf/pycldf",
+        "license": "Apache-2.0",
+        "note": "Cite the underlying CLDF dataset(s) too; pycldf is the loader.",
+        "citation": (
+            "Forkel, R. 2024. pycldf: A Python library to read and write "
+            "CLDF datasets. https://github.com/cldf/pycldf"
+        ),
+        "bibtex": (
+            "@misc{pycldf,\n"
+            "  author = {Forkel, Robert},\n"
+            "  title = {{pycldf: A Python library to read and write CLDF datasets}},\n"
+            "  year = {2024},\n"
+            "  url = {https://github.com/cldf/pycldf}\n"
+            "}"
+        ),
+    },
+    "pylexibank": {
+        "label": "Lexibank / pylexibank",
+        "type": "dataset",
+        "authors": "List, J.-M., Forkel, R., Greenhill, S. J., Rzymski, C., Englisch, J., & Gray, R. D.",
+        "year": 2022,
+        "title": "Lexibank, a public repository of standardized wordlists with computed phonological and lexical features",
+        "venue": "Scientific Data 9: 316",
+        "doi": "10.1038/s41597-022-01432-0",
+        "url": "https://lexibank.clld.org",
+        "license": "CC-BY-4.0",
+        "note": "Cite the specific Lexibank wordlist used in addition to this umbrella reference.",
+        "citation": (
+            "List, J.-M., Forkel, R., Greenhill, S. J., Rzymski, C., Englisch, J., "
+            "& Gray, R. D. 2022. Lexibank, a public repository of standardized "
+            "wordlists with computed phonological and lexical features. "
+            "Scientific Data 9: 316. doi:10.1038/s41597-022-01432-0"
+        ),
+        "bibtex": (
+            "@article{lexibank2022,\n"
+            "  author = {List, Johann-Mattis and Forkel, Robert and Greenhill, "
+            "Simon J. and Rzymski, Christoph and Englisch, Johannes and Gray, "
+            "Russell D.},\n"
+            "  title = {{Lexibank, a public repository of standardized wordlists "
+            "with computed phonological and lexical features}},\n"
+            "  journal = {Scientific Data},\n"
+            "  volume = {9},\n"
+            "  pages = {316},\n"
+            "  year = {2022},\n"
+            "  doi = {10.1038/s41597-022-01432-0}\n"
+            "}"
+        ),
+    },
+    "lingpy_wordlist": {
+        "label": "LingPy",
+        "type": "tool",
+        "authors": "List, J.-M., Greenhill, S. J., Tresoldi, T., & Forkel, R.",
+        "year": 2023,
+        "title": "LingPy. A Python library for quantitative tasks in historical linguistics",
+        "doi": "10.5281/zenodo.10093521",
+        "url": "https://lingpy.org",
+        "license": "GPL-3.0",
+        "note": "Cite the underlying CLDF/Lexibank wordlist too; LingPy is the loader.",
+        "citation": (
+            "List, J.-M., Greenhill, S. J., Tresoldi, T., & Forkel, R. 2023. "
+            "LingPy. A Python library for quantitative tasks in historical "
+            "linguistics. doi:10.5281/zenodo.10093521"
+        ),
+        "bibtex": (
+            "@software{lingpy2023,\n"
+            "  author = {List, Johann-Mattis and Greenhill, Simon J. and Tresoldi, "
+            "Tiago and Forkel, Robert},\n"
+            "  title = {{LingPy. A Python library for quantitative tasks in "
+            "historical linguistics}},\n"
+            "  year = {2023},\n"
+            "  doi = {10.5281/zenodo.10093521},\n"
+            "  url = {https://lingpy.org}\n"
+            "}"
+        ),
+    },
+    "csv_override": {
+        "label": "CSV override (workspace-local)",
+        "type": "manual",
+        "authors": "Workspace maintainer",
+        "year": None,
+        "title": "Per-workspace CSV override",
+        "note": (
+            "User-curated forms loaded from config/clef_overrides.csv. "
+            "Provenance is whatever the maintainer recorded in their own notes."
+        ),
+        "citation": (
+            "Per-workspace CSV override (config/clef_overrides.csv). "
+            "Cite the maintainer's source notes for each entry."
+        ),
+        "bibtex": "",  # not bibliographically citable -- workspace-local
+    },
+    "literature": {
+        "label": "Literature (workspace-local)",
+        "type": "manual",
+        "authors": "Workspace maintainer",
+        "year": None,
+        "title": "Manually curated literature references",
+        "note": (
+            "Forms loaded from the literature provider's per-workspace config. "
+            "Each entry should carry its own bibliographic source -- see the "
+            "provider's config file for per-form citations."
+        ),
+        "citation": (
+            "Workspace-local literature references. "
+            "See the literature provider's config for per-form bibliographic sources."
+        ),
+        "bibtex": "",
+    },
+    "grokipedia": {
+        "label": "Grokipedia (LLM-generated)",
+        "type": "ai",
+        "authors": None,
+        "year": None,
+        "title": "LLM-generated reference forms (xAI Grok / OpenAI GPT)",
+        "note": (
+            "NOT CITABLE AS A PRIMARY SOURCE. LLM output -- model name + "
+            "version + prompt are recorded in the populate job log, but the "
+            "underlying training data is not auditable. Verify each form "
+            "against an authoritative source before using in published work."
+        ),
+        "citation": (
+            "Grokipedia provider: LLM-generated reference forms (xAI Grok or "
+            "OpenAI GPT, depending on auth_tokens.json). Not citable as a "
+            "primary source -- verify each form before publication."
+        ),
+        "bibtex": "",  # intentionally empty -- LLM output is not bibliographic
+    },
+    "unknown": {
+        "label": "Unattributed (legacy)",
+        "type": "sentinel",
+        "authors": None,
+        "year": None,
+        "title": "Pre-provenance bare-string entry",
+        "note": (
+            "These forms were populated before PR #209 introduced provenance "
+            "tracking, so the provider that contributed each form is not "
+            "recorded on disk. Re-run CLEF populate with overwrite=true to "
+            "re-attribute the entries."
+        ),
+        "citation": (
+            "Unattributed legacy entry: provider not recorded. "
+            "Re-run CLEF populate with overwrite=true to attribute."
+        ),
+        "bibtex": "",
+    },
+}
+
+
+def get_citations() -> Dict[str, Dict[str, Any]]:
+    """Return a deep-copy-safe view of the provider citation map.
+
+    The Sources Report endpoint surfaces this as part of its JSON payload
+    so the modal renders citations without a second round-trip.
+    """
+    return {k: dict(v) for k, v in PROVIDER_CITATIONS.items()}
+
+
+def get_citation(provider_id: str) -> Dict[str, Any]:
+    """Look up the citation block for ``provider_id``.
+
+    Falls back to the ``unknown`` sentinel for unrecognised providers so
+    the modal can still render a row instead of crashing.
+    """
+    entry = PROVIDER_CITATIONS.get(provider_id)
+    if entry is None:
+        return dict(PROVIDER_CITATIONS["unknown"])
+    return dict(entry)

--- a/python/compare/providers/test_citations.py
+++ b/python/compare/providers/test_citations.py
@@ -1,0 +1,179 @@
+"""Tests for the per-provider academic citation map.
+
+Locks in two contracts the Sources Report modal depends on:
+
+1. Every provider id registered in ``PROVIDER_PRIORITY`` (plus the
+   ``UNKNOWN_SOURCE`` sentinel) has a citation entry. A new provider
+   can't ship without an entry -- otherwise the modal would render a
+   bare provider id instead of a citation.
+
+2. Each entry has the required fields the modal renders. ``citation``
+   (free text) is mandatory; ``bibtex`` may be empty for non-bibliographic
+   providers (LLM, manual, sentinel) but the *key must exist* so the
+   modal's ``Export BibTeX`` filter can run without per-row null checks.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+try:
+    from .citations import (
+        CITATION_DISPLAY_ORDER,
+        PROVIDER_CITATIONS,
+        get_citation,
+        get_citations,
+    )
+    from .registry import PROVIDER_PRIORITY
+    from .provenance import UNKNOWN_SOURCE
+except ImportError:  # pragma: no cover -- direct-invoke fallback
+    from citations import (  # type: ignore
+        CITATION_DISPLAY_ORDER,
+        PROVIDER_CITATIONS,
+        get_citation,
+        get_citations,
+    )
+    from registry import PROVIDER_PRIORITY  # type: ignore
+    from provenance import UNKNOWN_SOURCE  # type: ignore
+
+
+REQUIRED_KEYS = {"label", "type", "authors", "year", "title", "citation", "bibtex"}
+VALID_TYPES = {"dataset", "tool", "ai", "manual", "sentinel"}
+TYPES_THAT_MAY_OMIT_BIBTEX = {"ai", "manual", "sentinel"}
+DOI_RE = re.compile(r"^10\.\d{4,9}/[^\s]+$")
+
+
+# ---------------------------------------------------------------------------
+# Coverage / completeness
+# ---------------------------------------------------------------------------
+
+def test_every_registry_provider_has_a_citation():
+    missing = [p for p in PROVIDER_PRIORITY if p not in PROVIDER_CITATIONS]
+    assert not missing, (
+        "Providers in PROVIDER_PRIORITY without a citation entry: "
+        f"{missing}. Add an entry to PROVIDER_CITATIONS in citations.py."
+    )
+
+
+def test_unknown_sentinel_has_a_citation():
+    # The Sources Report modal renders ``unknown`` rows for legacy
+    # bare-string entries; the citation must be present so the modal
+    # can show a "re-populate to attribute" caveat.
+    assert UNKNOWN_SOURCE in PROVIDER_CITATIONS
+
+
+def test_no_orphan_citation_entries():
+    # Reverse coverage: every citation entry corresponds to a real
+    # provider id (or the sentinel). Catches typos that would render
+    # never-used citation blocks.
+    valid = set(PROVIDER_PRIORITY) | {UNKNOWN_SOURCE}
+    orphans = [k for k in PROVIDER_CITATIONS if k not in valid]
+    assert not orphans, (
+        f"Citation entries with no matching provider id: {orphans}"
+    )
+
+
+def test_display_order_matches_citation_keys():
+    # CITATION_DISPLAY_ORDER drives the modal's section ordering; every
+    # provider with a citation must appear in it exactly once.
+    expected = set(PROVIDER_CITATIONS.keys())
+    actual = set(CITATION_DISPLAY_ORDER)
+    assert expected == actual
+    assert len(CITATION_DISPLAY_ORDER) == len(set(CITATION_DISPLAY_ORDER)), (
+        "CITATION_DISPLAY_ORDER has duplicates"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-entry shape
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("provider_id", sorted(PROVIDER_CITATIONS.keys()))
+def test_citation_entry_has_required_keys(provider_id):
+    entry = PROVIDER_CITATIONS[provider_id]
+    missing = REQUIRED_KEYS - entry.keys()
+    assert not missing, (
+        f"{provider_id}: missing required keys {missing}"
+    )
+
+
+@pytest.mark.parametrize("provider_id", sorted(PROVIDER_CITATIONS.keys()))
+def test_citation_type_is_valid(provider_id):
+    t = PROVIDER_CITATIONS[provider_id]["type"]
+    assert t in VALID_TYPES, f"{provider_id}: type {t!r} not in {VALID_TYPES}"
+
+
+@pytest.mark.parametrize("provider_id", sorted(PROVIDER_CITATIONS.keys()))
+def test_citation_text_is_non_empty(provider_id):
+    citation = PROVIDER_CITATIONS[provider_id]["citation"]
+    assert isinstance(citation, str) and citation.strip(), (
+        f"{provider_id}: citation must be a non-empty string"
+    )
+
+
+@pytest.mark.parametrize("provider_id", sorted(PROVIDER_CITATIONS.keys()))
+def test_bibtex_present_for_bibliographic_providers(provider_id):
+    entry = PROVIDER_CITATIONS[provider_id]
+    bibtex = entry["bibtex"]
+    assert isinstance(bibtex, str), f"{provider_id}: bibtex must be a string"
+    if entry["type"] in TYPES_THAT_MAY_OMIT_BIBTEX:
+        # LLM, manual, sentinel: bibtex may be empty (these aren't
+        # bibliographically citable) but the field must exist.
+        return
+    assert bibtex.strip().startswith("@"), (
+        f"{provider_id}: dataset/tool entries must have a BibTeX block "
+        f"starting with @, got {bibtex!r}"
+    )
+
+
+@pytest.mark.parametrize("provider_id", sorted(PROVIDER_CITATIONS.keys()))
+def test_doi_is_well_formed_when_present(provider_id):
+    entry = PROVIDER_CITATIONS[provider_id]
+    doi = entry.get("doi")
+    if doi is None:
+        return
+    assert DOI_RE.match(doi), f"{provider_id}: DOI {doi!r} doesn't match 10.XXXX/... pattern"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_get_citations_returns_a_copy():
+    a = get_citations()
+    a["asjp"]["label"] = "MUTATED"
+    b = get_citations()
+    assert b["asjp"]["label"] != "MUTATED", (
+        "get_citations() must return a defensive copy so modal-side "
+        "mutation can't poison the module-level dict"
+    )
+
+
+def test_get_citation_falls_back_to_unknown_for_unrecognised_id():
+    # A provider id the citations map doesn't know about -- say a
+    # workspace-local override or a brand-new provider that landed
+    # before its citation was added -- should still get a renderable
+    # row (the sentinel) rather than blowing up the modal.
+    entry = get_citation("definitely-not-a-real-provider")
+    assert entry["type"] == "sentinel"
+    assert entry["label"] == PROVIDER_CITATIONS[UNKNOWN_SOURCE]["label"]
+
+
+def test_grokipedia_is_flagged_as_ai():
+    # The modal renders ``ai`` rows with a red caveat banner. If
+    # grokipedia ever drops to "tool" or "dataset" the warning vanishes,
+    # which would let users cite LLM output as a primary source.
+    assert PROVIDER_CITATIONS["grokipedia"]["type"] == "ai"
+    note = PROVIDER_CITATIONS["grokipedia"].get("note", "")
+    assert "verify" in note.lower() or "primary source" in note.lower()
+
+
+def test_unknown_sentinel_is_marked_sentinel_with_remediation_note():
+    entry = PROVIDER_CITATIONS[UNKNOWN_SOURCE]
+    assert entry["type"] == "sentinel"
+    assert "overwrite" in entry["note"].lower(), (
+        "The unknown sentinel's note should tell users how to fix legacy "
+        "data (re-run populate with overwrite=true)"
+    )

--- a/python/server.py
+++ b/python/server.py
@@ -8372,11 +8372,21 @@ class RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
             key=lambda x: (-x["total_forms"], x["id"]),
         )
 
+        # Attach the per-provider academic citations so the Sources Report
+        # modal can render full bibliographic references next to each
+        # provider chip without a second round-trip. Citations are
+        # dataset-level, not per-form -- a follow-up change can extend
+        # the FetchResult shape to thread per-form metadata (URL, dataset
+        # version, retrieval date, lexeme id) for true per-form citations.
+        from compare.providers.citations import get_citations, CITATION_DISPLAY_ORDER
+
         self._send_json(HTTPStatus.OK, {
             "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
             "providers": providers_sorted,
             "languages": languages_out,
             "concepts_total": all_concepts_total,
+            "citations": get_citations(),
+            "citation_order": list(CITATION_DISPLAY_ORDER),
         })
 
     def _api_update_config(self) -> None:

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -268,9 +268,44 @@ export interface ClefSourcesReportLanguage {
   forms: ClefSourcesReportForm[];
 }
 
+/** Academic citation block for one provider id, surfaced by the Sources
+ *  Report endpoint so the modal can render full bibliographic references
+ *  alongside each provider chip. Citations are *dataset-level* -- per-form
+ *  metadata (URL, dataset version, retrieval date) is a follow-up change
+ *  that requires extending the FetchResult shape across all providers.
+ *
+ *  ``type`` lets the modal flag entries differently:
+ *    - "dataset" / "tool" -> standard provider, render normally
+ *    - "ai"               -> LLM, show a "must be verified" warning
+ *    - "manual"           -> user-curated, point at the workspace config
+ *    - "sentinel"         -> "unknown" legacy entry, render as caveat */
+export interface ClefSourceCitation {
+  label: string;
+  type: "dataset" | "tool" | "ai" | "manual" | "sentinel";
+  authors: string | null;
+  year: number | null;
+  title: string;
+  venue?: string;
+  doi?: string;
+  url?: string;
+  license?: string;
+  note?: string;
+  /** Free-text citation suitable for pasting into a footnote. */
+  citation: string;
+  /** BibTeX entry suitable for an ``Export BibTeX`` action. Empty
+   *  string for non-bibliographic providers (LLM, manual overrides). */
+  bibtex: string;
+}
+
 export interface ClefSourcesReport {
   generated_at: string;
   providers: Array<{ id: string; total_forms: number }>;
   languages: ClefSourcesReportLanguage[];
   concepts_total: number;
+  /** Per-provider citation blocks keyed by provider id. Includes the
+   *  ``unknown`` sentinel for legacy entries. */
+  citations: Record<string, ClefSourceCitation>;
+  /** Stable display order for the citations section -- matches
+   *  ``CITATION_DISPLAY_ORDER`` in the backend. */
+  citation_order: string[];
 }

--- a/src/components/compute/ClefSourcesReportModal.tsx
+++ b/src/components/compute/ClefSourcesReportModal.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { X, AlertCircle, Loader2, BookOpen, RefreshCw } from "lucide-react";
+import { X, AlertCircle, Loader2, BookOpen, RefreshCw, Copy, Download, ExternalLink } from "lucide-react";
 import { getClefSourcesReport } from "../../api/client";
-import type { ClefSourcesReport, ClefSourcesReportLanguage } from "../../api/types";
+import type { ClefSourceCitation, ClefSourcesReport, ClefSourcesReportLanguage } from "../../api/types";
 
-/** Human-friendly labels for the provider ids the backend emits. Keep
- *  in sync with ``compare/providers/registry.PROVIDER_PRIORITY`` plus
- *  the ``unknown`` sentinel used for legacy (pre-provenance) entries. */
-const PROVIDER_LABELS: Record<string, string> = {
+/** Fallback label map for provider ids when the backend hasn't surfaced
+ *  a citation block (e.g. an older server, or a brand-new provider that
+ *  shipped without a citation entry). The authoritative labels live in
+ *  ``compare/providers/citations.PROVIDER_CITATIONS`` and ride on the
+ *  Sources Report payload. */
+const FALLBACK_PROVIDER_LABELS: Record<string, string> = {
   csv_override: "CSV override",
   lingpy_wordlist: "LingPy wordlist",
   pycldf: "pycldf",
@@ -20,8 +22,71 @@ const PROVIDER_LABELS: Record<string, string> = {
   unknown: "Unattributed (legacy)",
 };
 
-function providerLabel(id: string): string {
-  return PROVIDER_LABELS[id] ?? id;
+function providerLabel(id: string, citations?: Record<string, ClefSourceCitation>): string {
+  return citations?.[id]?.label ?? FALLBACK_PROVIDER_LABELS[id] ?? id;
+}
+
+/** Best-effort copy-to-clipboard. Falls back to a temporary textarea
+ *  for browsers/contexts where ``navigator.clipboard`` isn't available
+ *  (file://, sandboxed iframes, very old browsers). Returns true on
+ *  success so callers can flash a "Copied!" indicator. */
+async function copyText(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to legacy path
+    }
+  }
+  if (typeof document !== "undefined") {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand("copy");
+      document.body.removeChild(ta);
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/** Build a single .bib file containing every provider's BibTeX entry
+ *  that actually contributed forms in this corpus. Skips providers
+ *  with empty ``bibtex`` (LLM, manual overrides, sentinel) so the
+ *  generated file only contains real bibliographic records. */
+function buildBibtex(
+  providersUsed: ReadonlyArray<{ id: string }>,
+  citations: Record<string, ClefSourceCitation>,
+): string {
+  const blocks: string[] = [];
+  for (const { id } of providersUsed) {
+    const c = citations[id];
+    if (c && c.bibtex && c.bibtex.trim()) {
+      blocks.push(c.bibtex.trim());
+    }
+  }
+  return blocks.join("\n\n") + (blocks.length > 0 ? "\n" : "");
+}
+
+function downloadBibtex(text: string, filename = "clef-sources.bib"): void {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([text], { type: "application/x-bibtex;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 interface ClefSourcesReportModalProps {
@@ -150,7 +215,9 @@ export function ClefSourcesReportModal({ open, onClose }: ClefSourcesReportModal
                         className="flex items-center justify-between rounded border border-slate-100 bg-slate-50 px-2 py-1"
                         data-testid={`sources-report-provider-${p.id}`}
                       >
-                        <span className="truncate text-slate-700">{providerLabel(p.id)}</span>
+                        <span className="truncate text-slate-700">
+                          {providerLabel(p.id, report.citations)}
+                        </span>
                         <span className="ml-2 shrink-0 font-mono text-[11px] text-slate-500">
                           {p.total_forms} form{p.total_forms === 1 ? "" : "s"}
                         </span>
@@ -159,6 +226,14 @@ export function ClefSourcesReportModal({ open, onClose }: ClefSourcesReportModal
                   </ul>
                 )}
               </section>
+
+              {/* Academic citations -- one block per provider that
+                  actually contributed forms in this corpus. Each block
+                  shows the dataset-level citation, license, optional
+                  caveat note, and Copy / DOI / URL actions. The Export
+                  BibTeX action at the section header bundles every
+                  provider's @-entry into a single .bib download. */}
+              <CitationsSection report={report} />
 
               {/* Language tabs */}
               <section>
@@ -192,7 +267,9 @@ export function ClefSourcesReportModal({ open, onClose }: ClefSourcesReportModal
                   })}
                 </div>
 
-                {activeLangEntry && <LanguageDetail entry={activeLangEntry} />}
+                {activeLangEntry && (
+                  <LanguageDetail entry={activeLangEntry} citations={report.citations} />
+                )}
               </section>
             </div>
           )}
@@ -212,7 +289,182 @@ export function ClefSourcesReportModal({ open, onClose }: ClefSourcesReportModal
   );
 }
 
-function LanguageDetail({ entry }: { entry: ClefSourcesReportLanguage }) {
+/** Stable order: prefer the backend-provided ``citation_order``, then
+ *  fall back to the corpus's actual contribution-sorted provider list.
+ *  Filters to providers that *actually contributed* (so a fresh corpus
+ *  with only ``unknown`` legacy entries doesn't render a wall of every
+ *  provider's citation). */
+function orderedUsedProviders(report: ClefSourcesReport): Array<{ id: string; total_forms: number }> {
+  const used = new Map(report.providers.map((p) => [p.id, p]));
+  const out: Array<{ id: string; total_forms: number }> = [];
+  for (const id of report.citation_order ?? []) {
+    const entry = used.get(id);
+    if (entry) {
+      out.push(entry);
+      used.delete(id);
+    }
+  }
+  // Anything left didn't appear in citation_order -- append in
+  // contribution-desc order (the order the backend already sorted them).
+  for (const entry of report.providers) {
+    if (used.has(entry.id)) {
+      out.push(entry);
+      used.delete(entry.id);
+    }
+  }
+  return out;
+}
+
+function CitationsSection({ report }: { report: ClefSourcesReport }) {
+  const used = useMemo(() => orderedUsedProviders(report), [report]);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const flashCopied = useCallback((key: string) => {
+    setCopiedKey(key);
+    setTimeout(() => {
+      setCopiedKey((prev) => (prev === key ? null : prev));
+    }, 1500);
+  }, []);
+
+  const onCopyCitation = useCallback(
+    async (id: string, citation: string) => {
+      const ok = await copyText(citation);
+      if (ok) flashCopied(`cite:${id}`);
+    },
+    [flashCopied],
+  );
+
+  const onCopyBibtex = useCallback(
+    async (id: string, bibtex: string) => {
+      if (!bibtex) return;
+      const ok = await copyText(bibtex);
+      if (ok) flashCopied(`bib:${id}`);
+    },
+    [flashCopied],
+  );
+
+  const onExportBibtex = useCallback(() => {
+    downloadBibtex(buildBibtex(used, report.citations));
+  }, [used, report.citations]);
+
+  const exportable = used.some((p) => report.citations[p.id]?.bibtex);
+
+  if (used.length === 0) return null;
+
+  return (
+    <section data-testid="sources-report-citations">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+          Academic citations
+        </div>
+        {exportable && (
+          <button
+            onClick={onExportBibtex}
+            data-testid="sources-report-export-bibtex"
+            className="inline-flex items-center gap-1 rounded border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-medium text-slate-600 hover:bg-slate-50"
+            title="Download a .bib file with every provider's BibTeX entry"
+          >
+            <Download className="h-3 w-3" /> Export BibTeX
+          </button>
+        )}
+      </div>
+      <ul className="space-y-2">
+        {used.map(({ id }) => {
+          const c = report.citations[id];
+          if (!c) return null;
+          const isAi = c.type === "ai";
+          const isSentinel = c.type === "sentinel";
+          const isManual = c.type === "manual";
+          const accent = isAi
+            ? "border-rose-200 bg-rose-50"
+            : isSentinel
+              ? "border-amber-200 bg-amber-50"
+              : isManual
+                ? "border-slate-200 bg-slate-50"
+                : "border-slate-200 bg-white";
+          return (
+            <li
+              key={id}
+              data-testid={`sources-report-citation-${id}`}
+              className={`rounded-md border ${accent} px-3 py-2 text-[12px]`}
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <div className="font-semibold text-slate-800">{c.label}</div>
+                <div className="flex shrink-0 items-center gap-1 text-[10px] text-slate-500">
+                  {c.license && (
+                    <span className="rounded bg-white/70 px-1.5 py-0.5 font-mono">
+                      {c.license}
+                    </span>
+                  )}
+                  {c.url && (
+                    <a
+                      href={c.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="inline-flex items-center gap-0.5 text-slate-500 hover:text-slate-800"
+                      title={c.url}
+                    >
+                      <ExternalLink className="h-3 w-3" /> URL
+                    </a>
+                  )}
+                  {c.doi && (
+                    <a
+                      href={`https://doi.org/${c.doi}`}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="inline-flex items-center gap-0.5 text-slate-500 hover:text-slate-800"
+                      title={`DOI: ${c.doi}`}
+                    >
+                      <ExternalLink className="h-3 w-3" /> DOI
+                    </a>
+                  )}
+                </div>
+              </div>
+              <p className="mt-1 text-slate-700">{c.citation}</p>
+              {c.note && (
+                <p
+                  className={`mt-1 text-[11px] ${
+                    isAi ? "text-rose-700" : isSentinel ? "text-amber-700" : "text-slate-500"
+                  }`}
+                >
+                  {c.note}
+                </p>
+              )}
+              <div className="mt-1.5 flex items-center gap-1.5 text-[11px]">
+                <button
+                  onClick={() => void onCopyCitation(id, c.citation)}
+                  data-testid={`sources-report-copy-cite-${id}`}
+                  className="inline-flex items-center gap-1 rounded border border-slate-200 bg-white px-1.5 py-0.5 text-slate-600 hover:bg-slate-50"
+                >
+                  <Copy className="h-3 w-3" />
+                  {copiedKey === `cite:${id}` ? "Copied!" : "Copy citation"}
+                </button>
+                {c.bibtex && (
+                  <button
+                    onClick={() => void onCopyBibtex(id, c.bibtex)}
+                    data-testid={`sources-report-copy-bibtex-${id}`}
+                    className="inline-flex items-center gap-1 rounded border border-slate-200 bg-white px-1.5 py-0.5 text-slate-600 hover:bg-slate-50"
+                  >
+                    <Copy className="h-3 w-3" />
+                    {copiedKey === `bib:${id}` ? "Copied!" : "Copy BibTeX"}
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function LanguageDetail({
+  entry,
+  citations,
+}: {
+  entry: ClefSourcesReportLanguage;
+  citations: Record<string, ClefSourceCitation>;
+}) {
   const coveragePct =
     entry.concepts_total > 0
       ? Math.round((entry.concepts_covered / entry.concepts_total) * 100)
@@ -248,8 +500,10 @@ function LanguageDetail({ entry }: { entry: ClefSourcesReportLanguage }) {
             <span
               key={id}
               className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] text-slate-600"
+              title={citations[id]?.citation ?? undefined}
             >
-              {providerLabel(id)} <span className="font-mono text-slate-400">· {n}</span>
+              {providerLabel(id, citations)}{" "}
+              <span className="font-mono text-slate-400">· {n}</span>
             </span>
           ))}
         </div>
@@ -287,10 +541,13 @@ function LanguageDetail({ entry }: { entry: ClefSourcesReportLanguage }) {
                           className={`rounded px-1.5 py-0.5 text-[10px] ${
                             s === "unknown"
                               ? "bg-amber-50 text-amber-700"
-                              : "bg-slate-100 text-slate-700"
+                              : citations[s]?.type === "ai"
+                                ? "bg-rose-50 text-rose-700"
+                                : "bg-slate-100 text-slate-700"
                           }`}
+                          title={citations[s]?.citation ?? undefined}
                         >
-                          {providerLabel(s)}
+                          {providerLabel(s, citations)}
                         </span>
                       ))}
                     </div>

--- a/src/components/compute/__tests__/ClefSourcesReportModal.test.tsx
+++ b/src/components/compute/__tests__/ClefSourcesReportModal.test.tsx
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetReport = vi.fn();
+
+vi.mock("../../../api/client", () => ({
+  getClefSourcesReport: () => mockGetReport(),
+}));
+
+import { ClefSourcesReportModal } from "../ClefSourcesReportModal";
+import type { ClefSourcesReport } from "../../../api/types";
+
+const baseCitations = {
+  asjp: {
+    label: "ASJP",
+    type: "dataset" as const,
+    authors: "Wichmann, S., Holman, E. W., & Brown, C. H. (eds.)",
+    year: 2022,
+    title: "The ASJP Database (version 20)",
+    url: "https://asjp.clld.org",
+    license: "CC-BY-4.0",
+    citation:
+      "Wichmann, S., Holman, E. W., & Brown, C. H. (eds.). 2022. The ASJP Database (version 20).",
+    bibtex:
+      "@misc{asjp2022,\n  title = {{The ASJP Database (version 20)}},\n  year = {2022}\n}",
+  },
+  wikidata: {
+    label: "Wikidata",
+    type: "dataset" as const,
+    authors: "Vrandečić, D. & Krötzsch, M.",
+    year: 2014,
+    title: "Wikidata: a free collaborative knowledgebase",
+    doi: "10.1145/2629489",
+    url: "https://www.wikidata.org",
+    license: "CC0-1.0",
+    citation:
+      "Vrandečić, D. & Krötzsch, M. 2014. Wikidata: a free collaborative knowledgebase.",
+    bibtex: "@article{wikidata2014, title={Wikidata}, year={2014}}",
+  },
+  grokipedia: {
+    label: "Grokipedia (LLM-generated)",
+    type: "ai" as const,
+    authors: null,
+    year: null,
+    title: "LLM-generated reference forms",
+    note: "NOT CITABLE AS A PRIMARY SOURCE. Verify each form before using.",
+    citation: "Grokipedia provider: LLM-generated. Not citable as primary.",
+    bibtex: "",
+  },
+  unknown: {
+    label: "Unattributed (legacy)",
+    type: "sentinel" as const,
+    authors: null,
+    year: null,
+    title: "Pre-provenance bare-string entry",
+    note: "Re-run CLEF populate with overwrite=true to re-attribute.",
+    citation: "Unattributed legacy entry: provider not recorded.",
+    bibtex: "",
+  },
+};
+
+function makeReport(overrides: Partial<ClefSourcesReport> = {}): ClefSourcesReport {
+  return {
+    generated_at: "2026-04-25T16:00:00Z",
+    providers: [
+      { id: "asjp", total_forms: 12 },
+      { id: "wikidata", total_forms: 3 },
+      { id: "grokipedia", total_forms: 1 },
+    ],
+    languages: [
+      {
+        code: "ar",
+        name: "Arabic",
+        family: "Semitic",
+        script: "Arab",
+        total_forms: 16,
+        concepts_covered: 16,
+        concepts_total: 20,
+        per_provider: { asjp: 12, wikidata: 3, grokipedia: 1 },
+        forms: [
+          { concept_en: "water", form: "ماء", sources: ["wikidata"] },
+          { concept_en: "fire", form: "naːr", sources: ["asjp"] },
+        ],
+      },
+    ],
+    concepts_total: 20,
+    citations: baseCitations,
+    citation_order: ["asjp", "wikidata", "grokipedia", "unknown"],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  mockGetReport.mockReset();
+});
+
+describe("ClefSourcesReportModal — academic citations section", () => {
+  it("renders one citation block per provider that contributed forms", async () => {
+    mockGetReport.mockResolvedValueOnce(makeReport());
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId("sources-report-citations"));
+
+    expect(screen.getByTestId("sources-report-citation-asjp")).toBeTruthy();
+    expect(screen.getByTestId("sources-report-citation-wikidata")).toBeTruthy();
+    expect(screen.getByTestId("sources-report-citation-grokipedia")).toBeTruthy();
+    // ``unknown`` is in citation_order but not in providers -- shouldn't render
+    expect(screen.queryByTestId("sources-report-citation-unknown")).toBeNull();
+  });
+
+  it("shows full citation text + license + DOI/URL links for bibliographic providers", async () => {
+    mockGetReport.mockResolvedValueOnce(makeReport());
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId("sources-report-citation-wikidata"));
+    const block = screen.getByTestId("sources-report-citation-wikidata");
+
+    expect(block.textContent).toContain("Vrandečić");
+    expect(block.textContent).toContain("Wikidata");
+    expect(block.textContent).toContain("CC0-1.0");
+
+    const doiLink = block.querySelector('a[href="https://doi.org/10.1145/2629489"]');
+    expect(doiLink).toBeTruthy();
+    const urlLink = block.querySelector('a[href="https://www.wikidata.org"]');
+    expect(urlLink).toBeTruthy();
+  });
+
+  it("flags AI-typed entries with their non-citable warning note", async () => {
+    mockGetReport.mockResolvedValueOnce(makeReport());
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId("sources-report-citation-grokipedia"));
+    const block = screen.getByTestId("sources-report-citation-grokipedia");
+
+    expect(block.textContent).toContain("NOT CITABLE AS A PRIMARY SOURCE");
+    // No BibTeX button for AI rows -- their bibtex is intentionally empty.
+    expect(screen.queryByTestId("sources-report-copy-bibtex-grokipedia")).toBeNull();
+  });
+
+  it("hides the citations section entirely when no providers contributed", async () => {
+    mockGetReport.mockResolvedValueOnce(
+      makeReport({
+        providers: [],
+        languages: [
+          {
+            code: "ar",
+            name: "Arabic",
+            family: null,
+            total_forms: 0,
+            concepts_covered: 0,
+            concepts_total: 20,
+            per_provider: {},
+            forms: [],
+          },
+        ],
+      }),
+    );
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    // Wait for the modal body to settle on a non-empty state.
+    await waitFor(() => screen.getByText(/No reference forms populated yet|No providers recorded/i));
+    expect(screen.queryByTestId("sources-report-citations")).toBeNull();
+  });
+});
+
+describe("ClefSourcesReportModal — copy + export actions", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("Copy citation writes the citation text to the clipboard", async () => {
+    mockGetReport.mockResolvedValueOnce(makeReport());
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId("sources-report-copy-cite-asjp"));
+    fireEvent.click(screen.getByTestId("sources-report-copy-cite-asjp"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText).toHaveBeenCalledWith(baseCitations.asjp.citation);
+  });
+
+  it("Copy BibTeX writes the BibTeX block to the clipboard", async () => {
+    mockGetReport.mockResolvedValueOnce(makeReport());
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId("sources-report-copy-bibtex-wikidata"));
+    fireEvent.click(screen.getByTestId("sources-report-copy-bibtex-wikidata"));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const arg = writeText.mock.calls[0][0] as string;
+    expect(arg).toContain("@article{wikidata2014");
+  });
+
+  it("Export BibTeX is shown only when at least one provider has a non-empty bibtex", async () => {
+    mockGetReport.mockResolvedValueOnce(makeReport());
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId("sources-report-export-bibtex"));
+    expect(screen.getByTestId("sources-report-export-bibtex")).toBeTruthy();
+  });
+
+  it("Export BibTeX is hidden when only non-bibliographic providers contributed", async () => {
+    mockGetReport.mockResolvedValueOnce(
+      makeReport({
+        providers: [{ id: "grokipedia", total_forms: 1 }],
+        languages: [
+          {
+            code: "ar",
+            name: "Arabic",
+            family: null,
+            total_forms: 1,
+            concepts_covered: 1,
+            concepts_total: 20,
+            per_provider: { grokipedia: 1 },
+            forms: [{ concept_en: "fire", form: "naːr", sources: ["grokipedia"] }],
+          },
+        ],
+      }),
+    );
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId("sources-report-citations"));
+    expect(screen.queryByTestId("sources-report-export-bibtex")).toBeNull();
+  });
+});
+
+describe("ClefSourcesReportModal — provider chip styling reflects citation type", () => {
+  it("AI provider chips in the per-form table render in the rose accent", async () => {
+    mockGetReport.mockResolvedValueOnce(
+      makeReport({
+        languages: [
+          {
+            code: "ar",
+            name: "Arabic",
+            family: null,
+            total_forms: 1,
+            concepts_covered: 1,
+            concepts_total: 20,
+            per_provider: { grokipedia: 1 },
+            forms: [{ concept_en: "fire", form: "naːr", sources: ["grokipedia"] }],
+          },
+        ],
+        providers: [{ id: "grokipedia", total_forms: 1 }],
+      }),
+    );
+    render(<ClefSourcesReportModal open onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId("sources-report-form-row-ar-0"));
+    const row = screen.getByTestId("sources-report-form-row-ar-0");
+    const chip = Array.from(row.querySelectorAll("span")).find((el) =>
+      el.className.includes("rose"),
+    );
+    expect(chip, "expected an AI-tinted chip in the form row").toBeTruthy();
+    expect(chip!.textContent).toContain("Grokipedia");
+  });
+});


### PR DESCRIPTION
## Summary

Sources Report rendered every form's provenance as a plain provider chip ("Wikidata", "ASJP"). For thesis use, users need the *full bibliographic reference* per provider, copy-to-clipboard for footnotes, and a `.bib` export. This PR adds those.

Follow-up to the earlier diagnosis where every form was rendering as "Unattributed (legacy)" — that case stays handled (sentinel row with a clear "re-populate to attribute" note); this PR is about what users see *after* re-populating with overwrite=true and the new `{form, sources}` shape carries provider IDs.

## Backend

- New `python/compare/providers/citations.py` carries one citation block per provider id in `PROVIDER_PRIORITY` plus the `unknown` sentinel. Each block has:
  - `label`, `type` (`dataset` / `tool` / `ai` / `manual` / `sentinel`)
  - `authors`, `year`, `title`, `venue`, `doi`, `url`, `license`, `note`
  - free-text `citation` for footnotes
  - `bibtex` for the references manager (intentionally empty for `ai` / `manual` / `sentinel` so they're filtered out of `.bib` export)
- `_api_get_clef_sources_report` surfaces the citation map and a stable `citation_order` so the modal renders without a second round-trip.

## Frontend

- `ClefSourceCitation` TS interface mirrors the backend block.
- `ClefSourcesReportModal` gains an **Academic citations** section rendered between the providers summary and the language tabs. Renders one card per provider that *actually contributed* forms in this corpus (so a corpus with only `unknown` legacy entries doesn't flood with every provider's citation):
  - Full citation paragraph
  - License chip + URL + DOI links (DOI links to `doi.org`)
  - Optional caveat note — `ai` rows render in red, `sentinel` amber, `manual` muted, `dataset`/`tool` neutral
  - **Copy citation** + **Copy BibTeX** buttons (BibTeX hidden when empty, e.g. Grokipedia / manual overrides)
  - "Copied!" flash on success
- **Export BibTeX** header action concatenates every contributing provider's `bibtex` block into a single `.bib` download. Hidden when no contributing provider has bibtex (e.g. only Grokipedia populated this corpus).
- Per-form chips and per-language summary chips now use the citation-aware label (`citations[id].label`) and carry the citation paragraph as a `title` tooltip. AI provider chips in per-form rows render in the rose accent so users can spot LLM contributions at a glance.
- Clipboard fallback path uses a temporary textarea so copy works in sandboxed contexts without `navigator.clipboard`.

## Citations included

| provider | type | citation core | DOI |
|---|---|---|---|
| asjp | dataset | Wichmann et al. 2022, *The ASJP Database (v.20)* | — |
| wikidata | dataset | Vrandečić & Krötzsch 2014, *Communications of the ACM* 57(10) | 10.1145/2629489 |
| wiktionary | dataset | Wiktionary contributors, accessed via PARSE | — |
| cldf | dataset | Forkel et al. 2018, *Scientific Data* 5: 180205 | 10.1038/sdata.2018.205 |
| pycldf | tool | Forkel 2024, GitHub | — |
| pylexibank | dataset | List et al. 2022, *Scientific Data* 9: 316 | 10.1038/s41597-022-01432-0 |
| lingpy_wordlist | tool | List et al. 2023, LingPy | 10.5281/zenodo.10093521 |
| csv_override | manual | Workspace-local | — |
| literature | manual | Workspace-local | — |
| grokipedia | **ai** | **Not citable as primary source — verify before publication.** | — |
| unknown | sentinel | Pre-provenance legacy entry; re-populate with `overwrite=true` to attribute. | — |

## Out of scope (separate follow-up)

Per-form metadata: specific Wikidata lexeme ID, Wiktionary URL + revision timestamp, ASJP version, retrieval date. Requires extending the `FetchResult` shape across all providers and the persisted `{form, sources}` schema. Today's citations are dataset-level, which is the academic minimum for footnotes and what most journals accept for aggregated linguistic resources.

## Tests

- `test_citations.py` — 63 parametrised cases:
  - Coverage: every `PROVIDER_PRIORITY` entry has a citation; no orphans; `CITATION_DISPLAY_ORDER` matches keys.
  - Per-entry shape: required keys, valid type, non-empty citation, BibTeX starts with `@` for bibliographic providers, well-formed DOIs.
  - Helpers: `get_citations()` returns a defensive copy; `get_citation()` falls back to sentinel for unknown ids.
  - Invariants: Grokipedia stays flagged as `ai` with a "verify" note; `unknown` sentinel has a "re-run with overwrite=true" remediation note.
- `ClefSourcesReportModal.test.tsx` — 9 cases covering citations section rendering, license / DOI / URL surfacing, AI caveat, hide-when-empty, Copy citation, Copy BibTeX, Export BibTeX visibility based on contributing-providers, AI chip styling in per-form rows.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `vitest run` — 283/283 (was 272 before this PR's 9 new modal tests + 2 fixed counts).
- [x] `pytest python/compare/` — 135/135 (was 72 pre-citations + 63 new).
- [ ] Manual UI verification (preview infra rooted at the stale `/Users/lucasardelean/PARSE/` mockup per memory; can't exercise from this session). Manual checks: open Sources Report on a corpus that has populated forms in the new `{form, sources}` shape; confirm: (1) Academic citations section appears with one card per contributing provider, (2) DOI links open `doi.org`, (3) Copy citation / Copy BibTeX flash "Copied!", (4) Export BibTeX downloads a `clef-sources.bib`, (5) Grokipedia-only corpus hides the Export button, (6) legacy `unknown`-only corpus shows the sentinel card with the remediation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)