### PR TITLE
docs: plan separate rebuild path from option 1 to option 3

### DIFF
--- a/docs/plans/option1-parity-inventory.md
+++ b/docs/plans/option1-parity-inventory.md
@@ -1,0 +1,302 @@
+# PARSE Option-1 Rebuild — Parity Inventory and Evidence Matrix
+
+**Status:** Proposed planning doc for the separate rebuild repo  
+**Date:** 2026-04-25  
+**Depends on:**
+- `docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md`
+- `docs/plans/option1-two-agent-parallel-rebuild-plan.md`
+- `docs/desktop_product_architecture.md`
+- current oracle files under `src/`, `python/`, and project data layout
+
+**Primary goal:** define exactly what the separate rebuild repo must match before the Option-1 rebuild can be treated as functionally equivalent to the current PARSE workstation.
+
+---
+
+## 1. Purpose and rules
+
+This document is the **parity scope and evidence contract** for the separate rebuild repo.
+
+It exists to prevent three common failure modes:
+1. silent behavior drift during rebuild work
+2. backend contract drift that the frontend "works around" locally
+3. declaring parity from intuition instead of evidence
+
+### Core rules
+
+- The current PARSE repo remains the **behavior oracle**, **API oracle**, **data-format oracle**, **export oracle**, and **fallback runtime**.
+- Option 1 means **domain-preserving modularization**, not feature redesign.
+- No parity claim is valid without a linked artifact: test output, screenshot, snapshot, export sample, or written checklist evidence.
+- Any non-parity outcome must be logged as a **deviation** with owner, rationale, risk, and closure plan.
+- Coordinator-owned shared contracts remain authoritative; implementation lanes do not redefine them ad hoc.
+
+---
+
+## 2. Oracle definition and freeze
+
+### 2.1 Canonical oracle surfaces
+
+The rebuild must be compared against the current PARSE repo, especially these surfaces:
+
+- `src/api/client.ts` — live frontend HTTP contract and helper surface
+- `package.json` — frontend scripts and baseline validation commands
+- `docs/desktop_product_architecture.md` — desktop launch, loopback, and path rules
+- `src/components/annotate/**` — Annotate workstation behavior
+- `src/components/compare/**` — Compare workstation behavior
+- `src/components/compute/**` and shared modals — compute/config/reporting flows
+- `src/stores/*.ts` — state persistence and UI orchestration invariants
+- `python/server.py` and backend tests — route semantics, jobs, errors, static/runtime safety
+- on-disk project artifacts — annotations, enrichments, project metadata, exports, audio/transcript layout
+
+### 2.2 Oracle baseline record
+
+Before rebuild implementation starts, the coordinator records:
+
+- [ ] oracle repo path
+- [ ] oracle branch
+- [ ] oracle commit SHA
+- [ ] date frozen
+- [ ] frontend gate result on the oracle
+- [ ] backend/API gate result on the oracle
+- [ ] selected fixture dataset/version
+
+Only the coordinator updates the oracle baseline.
+
+---
+
+## 3. Priority tiers
+
+| Tier | Meaning | Examples |
+|---|---|---|
+| **P0** | Must pass before the Option-1 rebuild can be called functionally ready | Annotate, Compare, Tags persistence, annotation/enrichment/config APIs, core jobs, LingPy export, desktop local-runtime rules |
+| **P1** | Must pass before advanced rebuild phases are considered complete | auth flows, AI chat, normalize/onboard, offset tools, CLEF/contact lexeme flows, job logs, comments/tag/concept import |
+| **P2** | Useful parity coverage that can trail the core rebuild if explicitly tracked | extra diagnostics, future-page placeholders, non-critical ergonomics, later package extraction readiness |
+
+No P0 item may be silently downgraded.
+
+---
+
+## 4. Surface inventory summary
+
+| Surface | Primary oracle sources | Primary owner in rebuild | Required parity outcome |
+|---|---|---|---|
+| App shell + navigation | `src/ParseUI.tsx`, `src/components/shared/TopBar.tsx`, `src/stores/uiStore.ts` | Agent A | Same workbench entrypoints, shell state transitions, global feedback surfaces, and no missing thesis-critical controls |
+| Annotate workstation | `src/components/annotate/*.tsx`, `src/stores/annotationStore.ts`, `src/stores/playbackStore.ts` | Agent A + Agent B contract support | Same speaker load/edit/save workflow, waveform review, region/lane actions, STT-assisted review, and playback behavior |
+| Compare workstation | `src/components/compare/*.tsx`, `src/stores/enrichmentStore.ts`, `src/stores/tagStore.ts` | Agent A + Agent B contract support | Same concept × speaker review flow, cognate decisions, borrowing adjudication, enrichments, notes, and tag workflows |
+| Import / management flows | `OnboardingFlow.tsx`, `SpeakerImport.tsx`, `CommentsImport.tsx`, CSV import helpers | Agent A + Agent B contract support | Same upload/import entrypoints, state transitions, and persisted results |
+| HTTP API surface | `src/api/client.ts`, backend route tests | Agent B | Same method/path contracts, payload shapes, error semantics, and async job orchestration |
+| Async jobs + observability | job helpers in `src/api/client.ts`, backend job tests | Agent B | Same start/poll/log/result semantics and same visible progress/failure handling |
+| Export behavior | export helpers in `src/api/client.ts`, backend export tests | Agent B | LingPy parity, preserved NEXUS semantics, deterministic failures |
+| Desktop/runtime constraints | `docs/desktop_product_architecture.md`, static/path/runtime tests | Coordinator + Agent A + Agent B | Same local-first launch model, path safety, loopback-only backend boundary, and no hidden cwd/path assumptions |
+| Data/storage invariants | project artifact layout + stores + backend persistence paths | Coordinator + Agent B | Same files, same compatibility assumptions, same invariants for concept IDs, timestamps, tags, and enrichments |
+
+---
+
+## 5. UI / workbench parity matrix
+
+### 5.1 P0 workbenches and shell surfaces
+
+| Surface | Current oracle files | Critical behaviors that must match | Priority |
+|---|---|---|---|
+| Shell / navigation | `src/ParseUI.tsx`, `src/components/shared/TopBar.tsx`, `src/stores/uiStore.ts` | boot into a usable shell, switch major workbenches/modes, preserve global feedback and blocking/error states, preserve keyboard-accessible top-level actions | P0 |
+| Annotate | `src/components/annotate/AnnotateMode.tsx`, `AnnotationPanel.tsx`, `TranscriptPanel.tsx`, `RegionManager.tsx`, `SuggestionsPanel.tsx`, `TranscriptionLanes.tsx` | load speaker, display waveform/transcript context, manage intervals/lanes, invoke STT/suggestions, preserve save/reload behavior, support fast playback/review loop | P0 |
+| Compare | `src/components/compare/CompareMode.tsx`, `ConceptTable.tsx`, `CognateControls.tsx`, `BorrowingPanel.tsx`, `EnrichmentsPanel.tsx`, `LexemeDetail.tsx` | concept × speaker table rendering, cognate accept/split/merge/cycle, borrowing marking, notes/enrichment persistence, navigation between items | P0 |
+| Tags / enrichments management | `src/components/compare/TagManager.tsx`, `src/stores/tagStore.ts`, `src/stores/enrichmentStore.ts` | create/edit/merge tags, bulk state changes, persistence after mutation, reload survival | P0 |
+
+### 5.2 P1 operational and auxiliary surfaces
+
+| Surface | Current oracle files | Critical behaviors that must match | Priority |
+|---|---|---|---|
+| AI/chat shell | `src/components/annotate/ChatPanel.tsx`, `src/components/shared/ChatMarkdown.tsx` | start session, run/poll chat, show status/result/error cleanly, preserve session semantics expected by UI | P1 |
+| Import / onboarding | `src/components/annotate/OnboardingFlow.tsx`, `src/components/compare/SpeakerImport.tsx`, `src/components/compare/CommentsImport.tsx` | upload/start/poll flows, completion and failure states, no phantom success, persisted outputs appear where current PARSE expects them | P1 |
+| Compute and report modals | `src/components/compute/ClefConfigModal.tsx`, `ClefSourcesReportModal.tsx`, `ClefPopulateSummaryBanner.tsx`, `src/components/shared/BatchReportModal.tsx`, `TranscriptionRunModal.tsx` | same launch affordances, status/progress handling, and report visibility for users reviewing compute outputs | P1 |
+| Contact lexeme / CLEF compare extensions | `ContactLexemePanel.tsx` and CLEF helpers | same coverage/config/fetch flow and same decision-support affordances in Compare mode | P1 |
+| Job diagnostics | shell modals + `getJobLogs()` support | users can inspect job status/logs and distinguish running, failed, and finished states | P1 |
+
+### 5.3 Reserved Phase-3 shell extensibility
+
+Future shell placeholders for `training`, `phonetics`, and broader computational-linguistics workbenches may be scaffolded in Phase 3, but they are **not parity targets** for the current oracle unless and until the coordinator explicitly adds them.
+
+---
+
+## 6. HTTP API parity inventory
+
+The rebuild must preserve the frontend helper surface presently exposed by `src/api/client.ts`.
+
+| Contract group | Current client helpers | Expected parity requirement |
+|---|---|---|
+| Annotation data | `getAnnotation`, `saveAnnotation`, `getSttSegments` | same per-speaker load/save semantics and same response compatibility for annotation review surfaces |
+| Project config and pipeline state | `getConfig`, `updateConfig`, `getPipelineState` | same config mutation semantics, same pipeline-state visibility, same error behavior |
+| Enrichments, tags, notes, imports | `getEnrichments`, `saveEnrichments`, `getTags`, `mergeTags`, `saveLexemeNote`, `importConceptsCsv`, `importTagCsv`, `importCommentsCsv` | same request requirements, same mutation persistence, same success/error semantics for import/admin flows |
+| Auth | `getAuthStatus`, `startAuthFlow`, `pollAuth`, `saveApiKey`, `logoutAuth` | same auth lifecycle and same compatibility quirks expected by current UI/provider flows |
+| STT / normalize / onboard | `startSTT`, `pollSTT`, `startNormalize`, `pollNormalize`, `onboardSpeaker`, `pollOnboardSpeaker` | same start/poll/result semantics, same failure signaling, same artifact side effects |
+| Offset tools | `detectTimestampOffset`, `detectTimestampOffsetFromPair`, `detectTimestampOffsetFromPairs`, `pollOffsetDetectJob`, `applyTimestampOffset` | same request/response semantics, same protected-apply behavior, same job/result handling |
+| Suggestions / lexeme search | `requestSuggestions`, `searchLexeme` | same payload expectations, same result shapes, same user-visible failure handling |
+| Chat and generic compute | `startChatSession`, `getChatSession`, `runChat`, `pollChat`, `startCompute`, `pollCompute` | same session/job lifecycle, same completion statuses, same result envelope expectations |
+| Job observability | `listActiveJobs`, `getJobLogs` | same active-job visibility and same log-fetch semantics |
+| Export and media | `getLingPyExport`, `getNEXUSExport`, `spectrogramUrl` | same export endpoints/content behavior and same spectrogram URL contract |
+| CLEF / contact lexeme | `getContactLexemeCoverage`, `startContactLexemeFetch`, `getClefConfig`, `saveClefConfig`, `getClefCatalog`, `getClefProviders`, `getClefSourcesReport`, `saveClefFormSelections` | same config/catalog/reporting/fetch flows and same compare-mode support contracts |
+
+### 6.1 API-level acceptance criteria
+
+For every contract group above, parity means:
+
+- method + path compatibility are preserved
+- required request fields are preserved
+- response field names and nullable/optional behavior are preserved
+- error status class and structured error behavior are preserved
+- async start/poll patterns remain consistent with the current UI
+- compatibility aliases already expected by the UI remain supported where required
+
+No frontend lane may "solve" a contract mismatch by inventing a new local convention without coordinator approval.
+
+---
+
+## 7. Async job and export parity requirements
+
+### 7.1 Async jobs that require explicit parity evidence
+
+| Job family | Core endpoints/helpers | Minimum parity evidence |
+|---|---|---|
+| STT | `startSTT`, `pollSTT` | start artifact, poll artifact, completion artifact, failure artifact |
+| Normalize | `startNormalize`, `pollNormalize` | same start/poll semantics and same resulting workspace side effects |
+| Generic compute | `startCompute`, `pollCompute` | per-compute-type fixture or snapshot proving status/result parity |
+| Chat | `runChat`, `pollChat` | same session-to-job wiring, same completion semantics, same result rendering compatibility |
+| Onboard speaker | `onboardSpeaker`, `pollOnboardSpeaker` | same long-running import behavior, same completion/failure semantics, same persisted outputs |
+| Offset detection | `detectTimestampOffset*`, `pollOffsetDetectJob`, `applyTimestampOffset` | same detection/apply flow and same safety checks |
+| Active jobs / logs | `listActiveJobs`, `getJobLogs` | at least one running-job snapshot and one completed/failed-job log artifact |
+
+### 7.2 Export parity requirements
+
+| Export surface | Required parity outcome | Priority |
+|---|---|---|
+| LingPy | same endpoint availability, download behavior, and structurally compatible output for downstream use | P0 |
+| NEXUS | preserve the current behavior exactly until the coordinator explicitly changes the product decision | P1 |
+| Failure cases | deterministic and understandable failures for missing/invalid export prerequisites | P0 |
+
+---
+
+## 8. Data and storage invariants
+
+The rebuild may reorganize code, but it must not casually break the project model.
+
+### 8.1 Persisted artifact invariants
+
+The rebuild must preserve compatibility expectations around:
+
+- `annotations/<Speaker>.parse.json` as the active per-speaker annotation format
+- legacy speaker annotation JSON readability where current PARSE still supports it
+- `parse-enrichments.json` as the shared comparative overlay store
+- project metadata files such as `project.json` and `source_index.json`
+- project subdirectories used in desktop planning: `annotations/`, `transcripts/`, `peaks/`, `exports/`, `audio/original/`, `audio/working/`, `sync/`
+
+### 8.2 Semantic invariants
+
+These invariants are not optional without an explicit migration plan:
+
+- concept IDs remain stable identifiers; no silent normalization drift
+- annotation interval `start`/`end` semantics remain compatible with current review/save assumptions
+- tag and enrichment persistence stays durable across reloads
+- per-speaker annotations + shared enrichments remain the core storage model
+- project-relative path behavior remains the default desktop target
+- no rebuild-only hidden fallback data or scaffold content is introduced
+
+---
+
+## 9. Desktop, runtime, and safety parity
+
+The rebuild must preserve the local-first desktop/runtime model already documented for PARSE Desktop.
+
+### Required constraints
+
+- backend boundary remains loopback HTTP, not a remote-first redesign
+- desktop shell starts the backend and waits for readiness before presenting the main workstation
+- backend launch contract remains explicit about host, port, project root, auth token, and user-data root
+- path normalization and traversal prevention remain mandatory
+- no hardcoded machine-specific paths appear in shipped defaults
+- no dependence on current working directory as the implicit project selector
+- cloud AI remains optional and explicitly configured
+
+### Minimum evidence
+
+- one successful desktop/local-runtime launch trace
+- one failure-mode trace showing clear startup or readiness error handling
+- one path-safety or static-serving check linked to the rebuild evidence set
+
+---
+
+## 10. Evidence model and reporting rules
+
+### 10.1 Required evidence fields per parity row
+
+Every parity row or checklist item must record:
+
+- status
+- priority tier
+- oracle reference
+- rebuild reference
+- owner
+- evidence path or artifact link
+- reviewer / approver
+- deviation link, if applicable
+
+### 10.2 Status vocabulary
+
+Use only these status values:
+
+- `not-started`
+- `in-progress`
+- `pass`
+- `blocked`
+- `deviation-approved`
+
+### 10.3 Recommended artifact layout in the rebuild repo
+
+Coordinator-owned shared parity surfaces should remain under `parity/contracts/`, `parity/fixtures/`, and `parity/deviations.md`; lane-owned evidence lives under the UI/API/jobs/export subtrees.
+
+```text
+parity/
+  contracts/
+    oracle-baseline.md
+    route-inventory.md
+  ui/
+    checklists/
+    screenshots/
+  api/
+    snapshots/
+    contract-tests/
+  jobs/
+    traces/
+    logs/
+  export/
+    goldens/
+    comparisons/
+  fixtures/
+  deviations.md
+```
+
+### 10.4 Reporting rule
+
+No agent may report a parity surface as complete without linking the underlying artifact.
+
+"It behaves the same" is not evidence.
+
+---
+
+## 11. Option-1 parity exit criteria
+
+The Option-1 rebuild is ready for sign-off only if:
+
+1. all P0 rows are `pass` or explicitly `deviation-approved`
+2. no hidden contract drift remains between frontend and backend
+3. LingPy export parity is proven on real fixtures
+4. current PARSE can still serve as the fallback runtime until cutover is approved
+5. the coordinator signs off that the rebuild is stable enough to promote toward Option 3 later without another ground-up rewrite
+
+---
+
+## 12. Immediate next use of this document
+
+1. Freeze the oracle SHA and fixture set.
+2. Convert this inventory into actual parity rows inside the rebuild repo.
+3. Use `docs/plans/option1-phase0-shared-contract-checklist.md` to block Agent A / Agent B divergence until shared contracts are frozen.
+4. Require each phase checkpoint in `docs/plans/option1-two-agent-parallel-rebuild-plan.md` to reference this inventory when claiming parity progress.

--- a/docs/plans/option1-phase0-shared-contract-checklist.md
+++ b/docs/plans/option1-phase0-shared-contract-checklist.md
@@ -1,0 +1,382 @@
+# PARSE Option-1 Rebuild — Phase 0 Shared Contract Checklist
+
+**Status:** Proposed coordinator gate for the separate rebuild repo  
+**Date:** 2026-04-25  
+**Depends on:**
+- `docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md`
+- `docs/plans/option1-two-agent-parallel-rebuild-plan.md`
+- `docs/plans/option1-parity-inventory.md`
+- `docs/desktop_product_architecture.md`
+- current oracle files under `src/`, `python/`, and project artifacts
+
+**Primary goal:** freeze the shared contract that both main rebuild agents must obey before any parallel implementation work begins.
+
+---
+
+## 1. Blocking rule
+
+Phase 0 is a **hard blocker**.
+
+Agent A and Agent B do **not** begin divergent implementation until this checklist is complete and explicitly signed off.
+
+### Phase 0 non-goals
+
+- no broad feature implementation
+- no speculative architecture churn beyond the approved rebuild skeleton
+- no agent-specific contract forks
+- no redefining parity targets mid-flight
+
+---
+
+## 2. Canonical inputs and precedence order
+
+The coordinator must freeze a precedence order so agents do not argue from different sources.
+
+### 2.1 Required source set
+
+- [ ] `docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md`
+- [ ] `docs/plans/option1-two-agent-parallel-rebuild-plan.md`
+- [ ] `docs/plans/option1-parity-inventory.md`
+- [ ] `docs/desktop_product_architecture.md`
+- [ ] `AGENTS.md`
+- [ ] `src/api/client.ts`
+- [ ] `package.json`
+- [ ] selected backend route/tests in `python/`
+- [ ] selected oracle project fixtures / exports / sample outputs
+
+### 2.2 Precedence order to record
+
+- [ ] product/architecture docs outrank implementation guesses
+- [ ] current oracle code outranks stale planning assumptions
+- [ ] coordinator decisions outrank lane-local convenience changes
+- [ ] any unresolved contradiction is escalated before implementation starts
+
+---
+
+## 3. Oracle baseline record
+
+The coordinator records the exact current PARSE baseline used for rebuild parity.
+
+| Field | Record before parallel start |
+|---|---|
+| Oracle repo path | |
+| Oracle branch | |
+| Oracle commit SHA | |
+| Freeze date/time | |
+| Frontend validation evidence | |
+| Backend/API validation evidence | |
+| Fixture dataset version | |
+| Known accepted oracle quirks | |
+
+### Required completion items
+
+- [ ] baseline SHA recorded
+- [ ] fixture set recorded
+- [ ] any known contract quirks called out explicitly
+- [ ] both main agents acknowledge the same baseline
+
+---
+
+## 4. Freeze the rebuild-repo skeleton
+
+The top-level rebuild shape must be fixed before work splits.
+
+### 4.1 Required top-level shape
+
+```text
+<rebuild-repo>/
+  README.md
+  desktop/
+  frontend/
+  backend/
+  parity/
+  docs/
+```
+
+### 4.2 Skeleton checklist
+
+- [ ] top-level directories frozen
+- [ ] coordinator-owned directories frozen
+- [ ] Agent A owned directories frozen
+- [ ] Agent B owned directories frozen
+- [ ] naming conventions for new modules/components/hooks/services documented
+- [ ] shared root config files listed explicitly
+- [ ] no ambiguous shared subtree remains
+
+### 4.3 Ownership reminder
+
+Use the ownership model already defined in the two-agent execution plan:
+
+- **Coordinator-only:** root docs/contracts/CI/shared config after Phase 0, plus `parity/contracts/**`, `parity/fixtures/**`, and `parity/deviations.md`
+- **Agent A:** `desktop/**`, `frontend/**`, `parity/ui/**`
+- **Agent B:** `backend/**`, `parity/api/**`, `parity/jobs/**`, `parity/export/**`
+
+Any exception must be recorded before coding starts.
+
+---
+
+## 5. Freeze bootstrap and tooling contract
+
+Both lanes must start from the same executable bootstrap rules.
+
+### 5.1 Runtime/tooling decisions to record
+
+- [ ] Node version / package manager decision
+- [ ] Python version decision
+- [ ] lockfile strategy
+- [ ] repo bootstrap commands
+- [ ] CI baseline jobs
+- [ ] local dev startup commands
+
+### 5.2 Minimum bootstrap gates
+
+| Command | Why it matters | Phase 0 pass condition |
+|---|---|---|
+| `npm install` | frontend bootstrap reproducibility | installs cleanly from a fresh checkout |
+| `npm run test -- --run` | frontend regression gate | green in baseline rebuild scaffold |
+| `./node_modules/.bin/tsc --noEmit` | TypeScript strictness gate | green in baseline rebuild scaffold |
+| `python3 -m pytest -q` | backend bootstrap/test gate | green in baseline rebuild scaffold |
+
+These commands assume the coordinator freezes a **root workspace** topology in Phase 0. If the rebuild uses split manifests instead, the exact equivalent frontend/backend commands must be recorded here before sign-off.
+
+### 5.3 Decisions to make explicitly
+
+- [ ] whether `npm run test:api` is a Phase-0 baseline gate or a Phase-1 follow-up gate
+- [ ] where shared type generation or schema snapshots live, if any
+- [ ] whether the rebuild uses one workspace root or split package manifests from day one
+
+If any of these are left vague, Phase 0 is not done.
+
+---
+
+## 6. Freeze desktop ↔ backend handshake
+
+The desktop runtime boundary must be explicit before Agent A and Agent B diverge.
+
+### 6.1 Baseline contract to record
+
+From the desktop architecture plan, the shell/backend handshake must define:
+
+- [ ] backend host policy (`127.0.0.1`)
+- [ ] port policy (`--port 0` / ephemeral port)
+- [ ] project-root handoff
+- [ ] auth-token handoff
+- [ ] user-data-root handoff
+- [ ] readiness/health handshake
+- [ ] renderer load timing after backend readiness
+- [ ] failure UI / restart / fail-fast policy
+
+### 6.2 Coordinator questions that must be answered
+
+- [ ] which readiness endpoint or payload counts as backend-ready
+- [ ] what timeout/retry policy the shell uses before showing an error
+- [ ] which failures are recoverable warnings vs hard launch blockers
+- [ ] where desktop logs live during rebuild development
+
+No lane should invent its own startup semantics.
+
+---
+
+## 7. Freeze workbench and route inventory
+
+The coordinator must freeze what the rebuild shell contains before parallel implementation begins.
+
+### 7.1 In-scope current workbenches / surfaces
+
+- [ ] shell / navigation
+- [ ] Annotate
+- [ ] Compare
+- [ ] Tags / management surfaces
+- [ ] AI/chat shell surfaces currently exposed to users
+- [ ] import / onboarding / comments / tags / concepts flows
+- [ ] compute/report/config surfaces required by current workflows
+
+### 7.2 Phase-3 reserved placeholders
+
+These may be reserved in the shell plan but are **not** initial parity targets unless explicitly approved:
+
+- [ ] `training`
+- [ ] `phonetics`
+- [ ] `linguistics`
+
+### 7.3 Route inventory questions to settle
+
+- [ ] whether the rebuild uses multiple explicit routes or a shell with internal workbench switching
+- [ ] reserved route/path names
+- [ ] entrypoint for project-open / create-project flow
+- [ ] location of auth/config/settings surfaces
+
+The route inventory must be frozen before Agent A builds navigation and before Agent B relies on frontend entry assumptions.
+
+---
+
+## 8. Freeze HTTP API contract inventory
+
+The current frontend helper surface in `src/api/client.ts` is the baseline API inventory.
+
+### 8.1 Contract groups that must be frozen
+
+- [ ] annotations + STT segments
+- [ ] enrichments + config + pipeline state
+- [ ] tags + lexeme notes + CSV imports
+- [ ] auth
+- [ ] STT / normalize / onboard
+- [ ] offset detection / apply
+- [ ] suggestions + lexeme search
+- [ ] chat + generic compute
+- [ ] active jobs + job logs
+- [ ] export + spectrogram
+- [ ] contact lexeme + CLEF config/catalog/reporting
+
+### 8.2 Contract details to record per group
+
+- [ ] method/path
+- [ ] request shape
+- [ ] response shape
+- [ ] error semantics
+- [ ] job start/poll semantics, when applicable
+- [ ] compatibility aliases already expected by current UI
+
+### 8.3 Known compatibility quirks to preserve or deliberately retire
+
+Record them explicitly before implementation starts, for example:
+
+- [ ] field aliases such as `job_id` / `jobId` where the current UI expects compatibility
+- [ ] session identifier compatibility such as `session_id` / `sessionId`, where applicable
+- [ ] accepted terminal status values already consumed by the current UI
+- [ ] provider-specific auth or parameter behavior that must remain compatible during rebuild
+
+---
+
+## 9. Freeze parity artifact layout and fixture set
+
+Parity evidence must have a stable home before teams start producing it.
+
+### 9.1 Required `parity/` layout
+
+```text
+parity/
+  contracts/
+  ui/
+  api/
+  jobs/
+  export/
+  fixtures/
+  deviations.md
+```
+
+### 9.2 Artifact rules
+
+- [ ] naming convention recorded
+- [ ] metadata fields recorded: date, oracle SHA, rebuild SHA, owner, scenario
+- [ ] location for screenshots recorded
+- [ ] location for API snapshots recorded
+- [ ] location for export goldens recorded
+- [ ] location for deviation log recorded
+
+### 9.3 Fixture checklist
+
+- [ ] selected speaker fixture set
+- [ ] selected compare/enrichment fixture set
+- [ ] selected export fixture set
+- [ ] one failure-path fixture where relevant
+- [ ] deterministic reset/reload instructions
+- [ ] no hidden scaffold/fallback data policy recorded
+
+---
+
+## 10. Freeze test gates and review cadence
+
+### 10.1 Per-track expectations
+
+- [ ] Agent A local gates defined
+- [ ] Agent B local gates defined
+- [ ] coordinator reintegration gates defined
+- [ ] parity review cadence defined at the end of each major phase
+
+### 10.2 Minimum cadence rules
+
+- [ ] every major phase ends with parity evidence, not just code completion
+- [ ] deviations are logged instead of silently normalized away
+- [ ] integration review happens on the coordinator lane, not by direct A ↔ B merges
+- [ ] failures block forward claims until classified as bug, accepted gap, or deliberate redesign
+
+---
+
+## 11. Freeze branch, worktree, and merge strategy
+
+### 11.1 Branches to create and record
+
+- [ ] `feat/rebuild-track-a-frontend-desktop`
+- [ ] `feat/rebuild-track-b-backend-parity`
+- [ ] `feat/rebuild-integration`
+
+### 11.2 Worktrees to create and record
+
+- [ ] `frontend-desktop/`
+- [ ] `backend-parity/`
+- [ ] `integration/`
+
+### 11.3 Merge policy to freeze
+
+- [ ] Agent A never merges directly into Agent B
+- [ ] Agent B never merges directly into Agent A
+- [ ] both lanes merge only through the integration lane
+- [ ] only the coordinator resolves cross-track conflicts
+- [ ] one write subagent per owned subtree at a time
+
+---
+
+## 12. Ready-to-parallelize definition
+
+Parallel rebuild work may start only when every item below is true.
+
+- [ ] oracle SHA is frozen
+- [ ] parity inventory is approved
+- [ ] rebuild skeleton is frozen
+- [ ] bootstrap/tooling gates are frozen
+- [ ] desktop/backend handshake is frozen
+- [ ] route/workbench inventory is frozen
+- [ ] API contract inventory is frozen
+- [ ] parity artifact layout and fixtures are frozen
+- [ ] branch/worktree strategy is frozen
+- [ ] ownership boundaries are acknowledged by both main agents
+- [ ] coordinator signs off that Phase 0 is complete
+
+### Sign-off record
+
+| Role | Name | Date | Notes |
+|---|---|---|---|
+| Coordinator | | | |
+| Agent A owner | | | |
+| Agent B owner | | | |
+
+---
+
+## 13. Change control after Phase 0
+
+Once Phase 0 is signed off:
+
+- contract changes require coordinator approval
+- shared contract docs are updated before implementation claims continue
+- both main agents must acknowledge reopened shared contracts
+- accidental drift is treated as a defect, not as a local convenience edit
+
+### Reopen checklist
+
+If a shared contract must change mid-rebuild, record:
+
+- [ ] reason for reopening
+- [ ] affected files/surfaces
+- [ ] owner
+- [ ] rollback or migration path
+- [ ] new parity evidence required
+
+---
+
+## 14. Immediate next actions after this checklist lands
+
+1. Fill the oracle baseline record.
+2. Convert the parity inventory into concrete rows/artifacts in the rebuild repo.
+3. Bootstrap the separate rebuild repo using the frozen skeleton and gate commands.
+4. Start Agent A and Agent B only after the coordinator signs the Ready-to-Parallelize section.

--- a/docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md
+++ b/docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md
@@ -171,8 +171,15 @@ Even though the immediate strategy is Option 1, the rebuild repo can still be la
 ├── parity/
 │   ├── fixtures/
 │   ├── contracts/
-│   ├── browser-checklists/
-│   └── comparison-scripts/
+│   ├── ui/
+│   │   ├── checklists/
+│   │   └── screenshots/
+│   ├── api/
+│   │   ├── snapshots/
+│   │   └── contract-tests/
+│   ├── jobs/
+│   ├── export/
+│   └── deviations.md
 └── docs/
 ```
 
@@ -258,10 +265,11 @@ For thesis-critical workflows:
 ### 7.3 Parity artifacts to maintain
 
 The rebuild repo should keep a dedicated `parity/` directory for:
-- golden fixtures
-- route snapshots
-- UI checklists
-- export comparisons
+- shared fixtures and oracle baseline snapshots
+- UI checklists and screenshots
+- API contract snapshots/tests
+- job traces/logs
+- export comparisons/goldens
 - known deviations with justification
 
 ---
@@ -275,6 +283,8 @@ The rebuild repo should keep a dedicated `parity/` directory for:
 Deliverables:
 - plan-only PR in current PARSE repo
 - rebuild repo scaffold
+- `docs/plans/option1-parity-inventory.md` as the parity scope + evidence contract
+- `docs/plans/option1-phase0-shared-contract-checklist.md` as the coordinator gate before parallel work
 - initial parity checklist
 - explicit contract inventory from current PARSE
 
@@ -370,9 +380,15 @@ By the end of Phase 3, the separate rebuild repo should still be recognizably **
 ├── parity/
 │   ├── fixtures/
 │   ├── contracts/
-│   ├── browser-checklists/
-│   ├── export-goldens/
-│   └── comparison-scripts/
+│   ├── ui/
+│   │   ├── checklists/
+│   │   └── screenshots/
+│   ├── api/
+│   │   ├── snapshots/
+│   │   └── contract-tests/
+│   ├── jobs/
+│   ├── export/
+│   └── deviations.md
 └── docs/
 ```
 
@@ -420,14 +436,15 @@ This plan succeeds if:
 
 1. Approve the architecture decision: **separate rebuild repo now, Option 1 initially, Option 3 later**.
 2. Create the rebuild repo.
-3. Write a concrete parity inventory from the current PARSE repo:
-   - pages
+3. Use `docs/plans/option1-parity-inventory.md` to freeze the parity scope for:
+   - pages / workbenches
    - APIs
    - jobs
    - exports
    - desktop-critical constraints
-4. Use `docs/plans/option1-two-agent-parallel-rebuild-plan.md` as the execution split for two main agents + subagents.
-5. Start the rebuild with shell/bootstrap + parity harness first.
+4. Use `docs/plans/option1-phase0-shared-contract-checklist.md` to block Agent A / Agent B divergence until the shared contract is frozen.
+5. Use `docs/plans/option1-two-agent-parallel-rebuild-plan.md` as the execution split for two main agents + subagents.
+6. Start the rebuild with shell/bootstrap + parity harness first.
 
 ---
 

--- a/docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md
+++ b/docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md
@@ -1,0 +1,373 @@
+# PARSE Separate-Rebuild Plan: Option 1 Now, Option 3 Later
+
+**Status:** Proposed plan-only PR  
+**Date:** 2026-04-25  
+**Applies to:** current `origin/main` as the behavior oracle; implementation happens in a separate rebuild repo  
+**Decision type:** architecture + delivery strategy
+
+---
+
+## 1. Executive summary
+
+PARSE should **not** attempt a full in-place rewrite inside the current repo.
+
+Instead, the immediate plan is:
+
+1. **Document the current repo as the canonical behavior/specification source**.
+2. **Rebuild the app in a separate repo**.
+3. Use **Option 1 (domain-preserving modularization)** as the initial architecture in that rebuild effort.
+4. **Test for behavior parity continuously as the rebuild progresses**.
+5. Once the rebuilt app reaches functional parity and desktop viability, **promote the rebuilt codebase toward Option 3** — the desktop-product / platform-oriented architecture.
+
+So the strategy is:
+
+> **Build now with Option 1 discipline, in a separate repo, while deliberately aiming for Option 3 as the long-term destination.**
+
+---
+
+## 2. Why this plan exists
+
+The current PARSE codebase has multiple monoliths large enough that a safe in-place rewrite is likely to stall feature work and blur regression ownership.
+
+### Verified monolith pressure points
+
+- `python/server.py` — ~8962 lines
+- `python/ai/chat_tools.py` — ~6408 lines
+- `src/ParseUI.tsx` — ~5327 lines
+- `python/adapters/mcp_adapter.py` — ~2050 lines
+- `python/ai/provider.py` — ~1907 lines
+
+### Verified current domain structure worth preserving
+
+Frontend already has meaningful domains:
+- `src/components/annotate/`
+- `src/components/compare/`
+- `src/components/compute/`
+- `src/components/shared/`
+- `src/hooks/`, `src/stores/`, `src/api/`
+
+Backend already has meaningful domains:
+- `python/ai/`
+- `python/compare/`
+- `python/external_api/`
+- `python/adapters/`
+- `python/workers/`
+- `python/shared/`
+- `python/packages/parse_mcp/`
+
+The repo also already signals a desktop/platform future:
+- `desktop/README.md` scaffold
+- `docs/desktop_product_architecture.md` as canonical desktop plan
+- `python/packages/parse_mcp/` publishable wrapper package
+- `python/external_api/` OpenAPI + HTTP MCP bridge + streaming
+
+---
+
+## 3. Core architectural decision
+
+## 3.1 Immediate implementation strategy: **Option 1**
+
+The rebuilt app should begin with **domain-preserving modularization**.
+
+That means:
+- preserve the strong domain concepts already present in the current PARSE repo
+- split the monoliths into smaller modules inside those domains
+- avoid a massive package/repo reset while parity is still being established
+
+## 3.2 Long-term destination: **Option 3**
+
+Once the rebuilt app is stable and parity-tested, the codebase should move toward a desktop-product / platform split:
+- desktop shell
+- frontend UI app
+- backend engine/services
+- shared packages/contracts
+- agent-facing and external-client packages
+
+This is the architecture that best supports:
+- a standalone desktop app
+- non-specialist usability
+- multiple future pages/workbenches
+- agent interoperability
+- typed contracts and reusable linguistics tooling
+
+---
+
+## 4. Delivery decision: rebuild in a separate repo
+
+## 4.1 Why separate repo instead of in-place rewrite
+
+A separate rebuild repo is preferred because it:
+- protects the current PARSE runtime from architectural churn
+- lets current PARSE continue serving as the working reference implementation
+- enables clean parity testing against the current app
+- avoids half-migrated states landing on `origin/main`
+- keeps thesis-critical usage unblocked while the rebuild advances
+
+## 4.2 Role of the current PARSE repo during the rebuild
+
+The current repo remains:
+- the **behavior oracle**
+- the **API contract oracle**
+- the **data-format oracle**
+- the **export correctness oracle**
+- the **fallback runtime**
+
+The rebuild repo is where the new implementation is assembled and tested.
+
+## 4.3 Repo naming
+
+Final rebuild repo name is still a decision.
+
+Working placeholder names:
+- `parse-next`
+- `parse-desktop-rebuild`
+- `parse-platform`
+
+This plan intentionally does not hard-code a final repo name.
+
+---
+
+## 5. Recommended rebuild-repo shape for Phase 1
+
+Even though the immediate strategy is Option 1, the rebuild repo can still be laid out to make the later Option 3 migration easier.
+
+### Recommended Phase-1 rebuild tree
+
+```text
+<rebuild-repo>/
+├── desktop/
+│   ├── electron-main/
+│   ├── preload/
+│   └── packaging/
+├── frontend/
+│   ├── src/
+│   │   ├── app/
+│   │   ├── api/
+│   │   ├── components/
+│   │   │   ├── annotate/
+│   │   │   ├── compare/
+│   │   │   ├── compute/
+│   │   │   ├── shell/
+│   │   │   └── shared/
+│   │   ├── hooks/
+│   │   ├── stores/
+│   │   ├── lib/
+│   │   └── workers/
+│   └── package.json
+├── backend/
+│   ├── app/
+│   │   ├── routes/
+│   │   ├── jobs/
+│   │   ├── http/
+│   │   ├── services/
+│   │   └── bootstrap.py
+│   ├── ai/
+│   ├── compare/
+│   ├── external_api/
+│   ├── adapters/
+│   ├── workers/
+│   ├── shared/
+│   └── tests/
+├── parity/
+│   ├── fixtures/
+│   ├── contracts/
+│   ├── browser-checklists/
+│   └── comparison-scripts/
+└── docs/
+```
+
+### Why this is still “Option 1” in practice
+
+Because the structure preserves the current domains:
+- annotate
+- compare
+- compute
+- shared
+- ai
+- compare backend
+- external API
+- adapters
+- workers
+
+It does **not** yet force a full package/platform split inside the code itself.
+
+---
+
+## 6. What “move to Option 3” means later
+
+After parity and desktop viability are established, the rebuild repo should evolve toward:
+
+```text
+<future-parse-platform>/
+├── desktop/
+├── frontend/
+├── backend/
+└── packages/
+    ├── parse_contracts/
+    ├── parse_mcp/
+    ├── parse_client_types/
+    ├── parse_shared_utils/
+    └── parse_linguistics_core/
+```
+
+### Expected Option-3 upgrades
+
+1. Extract shared contracts/types from app code into packages.
+2. Separate backend engine concerns into clearer service packages/modules.
+3. Separate reusable linguistics/compute logic from transport/UI code.
+4. Make agent-facing surfaces first-class packages rather than incidental wrappers.
+5. Treat desktop shell as a stable app boundary, not just a convenience launcher.
+
+---
+
+## 7. Build-and-test-as-we-go rule
+
+This plan explicitly requires **continuous parity testing during the rebuild**.
+
+### 7.1 Principle
+
+Do not “finish the rebuild and test later.”
+
+Every major slice must be tested against the current PARSE behavior as it lands.
+
+### 7.2 Required parity tracks
+
+#### A. Frontend parity
+For each rebuilt page or flow:
+- compare current PARSE UI behavior vs rebuilt behavior
+- check keyboard shortcuts
+- verify mode/page transitions
+- verify visible affordances and data loading
+
+#### B. API/contract parity
+For each rebuilt backend route:
+- compare request/response shapes
+- compare error semantics
+- compare job lifecycle payloads
+- compare export behavior
+
+#### C. Workflow parity
+For thesis-critical workflows:
+- annotate load/edit/save
+- compare load/decision flows
+- tags and enrichments persistence
+- export
+- onboarding/import
+- job status / progress / failure handling
+
+### 7.3 Parity artifacts to maintain
+
+The rebuild repo should keep a dedicated `parity/` directory for:
+- golden fixtures
+- route snapshots
+- UI checklists
+- export comparisons
+- known deviations with justification
+
+---
+
+## 8. Suggested phased roadmap
+
+## Phase 0 — Planning + contracts
+
+**Location:** current PARSE repo + rebuild repo bootstrap
+
+Deliverables:
+- plan-only PR in current PARSE repo
+- rebuild repo scaffold
+- initial parity checklist
+- explicit contract inventory from current PARSE
+
+## Phase 1 — Rebuild shell + core routes (Option 1 style)
+
+Deliverables:
+- rebuilt app shell in separate repo
+- thin frontend shell structure
+- thin backend route/service structure
+- first parity tests against current PARSE
+
+Targets:
+- frontend shell/navigation
+- basic project/config loading
+- baseline route contracts
+- desktop bootstrap handshake
+
+## Phase 2 — Rebuild Annotate + Compare core workflows
+
+Deliverables:
+- rebuilt Annotate page
+- rebuilt Compare page
+- core backend support for both
+- parity tests for save/load/compute/export-critical flows
+
+Targets:
+- replace dependence on giant `ParseUI.tsx`
+- replace dependence on giant `server.py` route pile-up
+
+## Phase 3 — Rebuild advanced compute / AI / agent surfaces
+
+Deliverables:
+- rebuilt job orchestration
+- AI/chat/tool surfaces
+- MCP/OpenAPI/streaming parity
+- desktop hardening for local runtime
+
+Targets:
+- `chat_tools.py` decomposition
+- route/service separation for advanced compute paths
+
+## Phase 4 — Promote toward Option 3
+
+Deliverables:
+- shared package extraction
+- contract/type packages
+- stronger separation between desktop/frontend/backend/packages
+- deprecation strategy for the old repo/runtime
+
+Targets:
+- evolve rebuild repo from Option 1 implementation shape to Option 3 platform shape
+
+---
+
+## 9. Success criteria
+
+This plan succeeds if:
+
+1. The rebuilt app reaches usable parity with current PARSE while still in the separate repo.
+2. Testing happens continuously during the rebuild, not only at the end.
+3. The rebuilt app is clearly structured enough that Option 3 promotion is evolutionary rather than a second rewrite.
+4. Current PARSE remains usable as the stable behavior oracle until the rebuild is genuinely ready.
+
+---
+
+## 10. Explicit non-goals for the first rebuild wave
+
+- Do **not** try to convert the current PARSE repo directly into the final platform structure.
+- Do **not** perform a one-shot repo-wide move to `frontend/`, `backend/`, and `packages/` in the current repo.
+- Do **not** delay testing until the rebuild is “mostly complete.”
+- Do **not** assume the final platform package boundaries before parity has been earned.
+
+---
+
+## 11. Recommended next actions after this plan PR
+
+1. Approve the architecture decision: **separate rebuild repo now, Option 1 initially, Option 3 later**.
+2. Create the rebuild repo.
+3. Write a concrete parity inventory from the current PARSE repo:
+   - pages
+   - APIs
+   - jobs
+   - exports
+   - desktop-critical constraints
+4. Start the rebuild with shell/bootstrap + parity harness first.
+
+---
+
+## 12. Bottom line
+
+This plan intentionally separates:
+- **where we build next** → a separate rebuild repo
+- **how we build first** → Option 1
+- **where we are going** → Option 3
+
+That is the least risky path that still aligns with PARSE’s likely future as a desktop product and agent-accessible computational linguistics platform.

--- a/docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md
+++ b/docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md
@@ -316,6 +316,73 @@ Targets:
 - `chat_tools.py` decomposition
 - route/service separation for advanced compute paths
 
+### Phase 3 target structure (expected rebuild-repo shape by end of phase)
+
+By the end of Phase 3, the separate rebuild repo should still be recognizably **Option 1**, but mature enough that the later Option-3 promotion is mostly packaging/boundary work rather than another rewrite.
+
+```text
+<rebuild-repo>/
+├── desktop/
+│   ├── electron-main/
+│   ├── preload/
+│   └── packaging/
+├── frontend/
+│   ├── src/
+│   │   ├── app/
+│   │   │   ├── router.tsx
+│   │   │   ├── layouts/
+│   │   │   └── providers/
+│   │   ├── api/
+│   │   ├── components/
+│   │   │   ├── annotate/
+│   │   │   ├── compare/
+│   │   │   ├── compute/
+│   │   │   ├── shell/
+│   │   │   └── shared/
+│   │   ├── hooks/
+│   │   ├── stores/
+│   │   ├── lib/
+│   │   └── workers/
+│   └── tests/
+├── backend/
+│   ├── app/
+│   │   ├── routes/
+│   │   ├── jobs/
+│   │   ├── http/
+│   │   ├── services/
+│   │   └── bootstrap.py
+│   ├── ai/
+│   │   ├── chat/
+│   │   ├── providers/
+│   │   ├── stt/
+│   │   ├── ipa/
+│   │   └── workflow/
+│   ├── compare/
+│   │   ├── providers/
+│   │   ├── cognates/
+│   │   ├── offsets/
+│   │   └── contact_lexemes/
+│   ├── external_api/
+│   ├── adapters/
+│   ├── workers/
+│   ├── shared/
+│   └── tests/
+├── parity/
+│   ├── fixtures/
+│   ├── contracts/
+│   ├── browser-checklists/
+│   ├── export-goldens/
+│   └── comparison-scripts/
+└── docs/
+```
+
+### Why this Phase 3 structure matters
+- the **desktop shell is already first-class**
+- the **frontend shell and pages are separated from shared primitives**
+- the **backend transport layer is already thinner than today's `server.py`**
+- AI/compare domains are already decomposed enough to extract later into real packages
+- parity assets remain explicit and continuously maintained during the rebuild
+
 ## Phase 4 — Promote toward Option 3
 
 Deliverables:

--- a/docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md
+++ b/docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md
@@ -426,7 +426,8 @@ This plan succeeds if:
    - jobs
    - exports
    - desktop-critical constraints
-4. Start the rebuild with shell/bootstrap + parity harness first.
+4. Use `docs/plans/option1-two-agent-parallel-rebuild-plan.md` as the execution split for two main agents + subagents.
+5. Start the rebuild with shell/bootstrap + parity harness first.
 
 ---
 

--- a/docs/plans/option1-two-agent-parallel-rebuild-plan.md
+++ b/docs/plans/option1-two-agent-parallel-rebuild-plan.md
@@ -2,7 +2,11 @@
 
 **Status:** Proposed execution-planning doc for the separate rebuild repo  
 **Date:** 2026-04-25  
-**Depends on:** `docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md`  
+**Depends on:**
+- `docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md`
+- `docs/plans/option1-parity-inventory.md`
+- `docs/plans/option1-phase0-shared-contract-checklist.md`
+
 **Primary goal:** execute the separate rebuild repo efficiently with **two main agents in parallel**, each allowed to use **subagents within owned boundaries**, without colliding on the same files.
 
 ---
@@ -71,6 +75,8 @@ These must be written once and then treated as frozen/shared unless the coordina
   docs/contracts/
   docs/architecture/
   parity/contracts/
+  parity/fixtures/
+  parity/deviations.md
   .github/workflows/
   root toolchain/bootstrap config
 ```
@@ -79,6 +85,7 @@ Examples:
 - root README
 - architecture docs
 - parity contract snapshots / schemas
+- shared fixtures and deviation log
 - CI workflow files
 - top-level workspace metadata
 
@@ -129,8 +136,9 @@ No implementation starts until Phase 0 is complete.
 The coordinator must define and freeze:
 
 1. **Behavior oracle set**
-   - which current PARSE pages/workflows are in parity scope first
-   - annotate / compare / tags / export / jobs / auth / desktop bootstrap
+   - which current PARSE pages/workflows are in rebuild parity scope
+   - recorded in `docs/plans/option1-parity-inventory.md`, including which rows are P0 vs P1
+   - initial scope includes annotate / compare / tags / export / jobs / auth / desktop bootstrap
 
 2. **Rebuild-repo skeleton**
    - repo layout
@@ -150,15 +158,20 @@ The coordinator must define and freeze:
    - error semantics
 
 5. **Parity artifact layout**
-   - what lives under `parity/ui`, `parity/api`, `parity/jobs`, `parity/export`, `parity/contracts`
+   - what lives under `parity/ui`, `parity/api`, `parity/jobs`, `parity/export`, `parity/contracts`, `parity/fixtures`, and `parity/deviations.md`
 
 6. **Page/workbench inventory**
    - current: Annotate, Compare, Tags, chat/compute shell
    - future placeholders allowed later: training, phonetics, computational-linguistics tools
 
+7. **Coordinator gate checklist**
+   - completion tracked in `docs/plans/option1-phase0-shared-contract-checklist.md`
+
 ## 4.2 Gate commands
 
-Before tracks diverge, both agents must be able to run the same baseline commands successfully in the rebuild repo:
+Before tracks diverge, both agents must be able to run the same baseline commands successfully in the rebuild repo.
+
+These commands assume the coordinator froze a **root workspace** shape in Phase 0. If the rebuild instead uses split manifests, the coordinator must record the exact equivalent frontend/backend commands in `docs/plans/option1-phase0-shared-contract-checklist.md` before parallel work starts:
 
 ```bash
 # frontend shell available
@@ -271,7 +284,7 @@ Objectives:
 Suggested subagent split:
 1. **A1** — desktop shell bootstrap (`desktop/**`)
 2. **A2** — frontend app shell/router/layout (`frontend/src/app/**`)
-3. **A3** — UI primitives + shell page containers (`frontend/src/components/shell/**`, `frontend/src/shared/**`)
+3. **A3** — UI primitives + shell page containers (`frontend/src/components/shell/**`, `frontend/src/components/shared/**`)
 4. **A4** — UI parity checklist scaffold (`parity/ui/**`)
 
 ### Agent B (backend + parity)
@@ -455,6 +468,8 @@ This execution plan succeeds if:
 ## 11. Immediate next actions if this plan is accepted
 
 1. Create the separate rebuild repo.
-2. Let the coordinator land the Phase 0 bootstrap + contract inventory.
-3. Start Agent A and Agent B from their dedicated worktrees/branches.
+2. Let the coordinator land the Phase 0 bootstrap + contract inventory using:
+   - `docs/plans/option1-parity-inventory.md`
+   - `docs/plans/option1-phase0-shared-contract-checklist.md`
+3. Start Agent A and Agent B from their dedicated worktrees/branches only after the Phase-0 checklist is signed off.
 4. Require parity evidence at the end of every phase, not just at the end of the rebuild.

--- a/docs/plans/option1-two-agent-parallel-rebuild-plan.md
+++ b/docs/plans/option1-two-agent-parallel-rebuild-plan.md
@@ -1,0 +1,460 @@
+# PARSE Option-1 Rebuild: Two-Agent Parallel Execution Plan
+
+**Status:** Proposed execution-planning doc for the separate rebuild repo  
+**Date:** 2026-04-25  
+**Depends on:** `docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md`  
+**Primary goal:** execute the separate rebuild repo efficiently with **two main agents in parallel**, each allowed to use **subagents within owned boundaries**, without colliding on the same files.
+
+---
+
+## 1. Executive summary
+
+This plan assumes PARSE will be rebuilt in a **separate repo** using **Option 1 / domain-preserving modularization** first, while keeping the current PARSE repo as the behavior oracle.
+
+Execution will use:
+- **one coordinator** (human + planning agent role)
+- **two main implementation agents** running in parallel
+- **multiple subagents** inside each main agent's lane, but only within file-ownership boundaries
+
+The key principle is:
+
+> **Parallelize by stable file ownership, not by abstract responsibility.**
+
+That means we do **not** split by “UI vs logic” or “frontend vs state” in overlapping files. We split by **owned subtrees** plus a **shared contract gate** before implementation starts.
+
+---
+
+## 2. Roles
+
+## 2.1 Coordinator
+
+The coordinator owns:
+- the current PARSE repo planning/docs PRs
+- rebuild-repo bootstrap decisions
+- shared contracts
+- merge/integration leadership
+- parity acceptance criteria
+- conflict arbitration
+
+The coordinator does **not** implement broad feature slices directly once the two main lanes start.
+
+## 2.2 Agent A — Frontend + desktop shell lane
+
+Agent A owns:
+- desktop shell scaffolding inside the rebuild repo
+- frontend shell/navigation/layout
+- page/workbench UI composition
+- frontend state wiring
+- UI parity artifacts
+
+## 2.3 Agent B — Backend + parity/contracts lane
+
+Agent B owns:
+- backend app/bootstrap/routes/services
+- AI/compare decomposition in the rebuild repo
+- API/job/export parity artifacts
+- contract conformance checks
+- backend observability surfaces needed by the rebuilt app
+
+---
+
+## 3. Rebuild-repo ownership table (hard boundary)
+
+## 3.1 Coordinator-only files/directories
+
+These must be written once and then treated as frozen/shared unless the coordinator explicitly reopens them:
+
+```text
+<rebuild-repo>/
+  README.md
+  docs/
+  docs/contracts/
+  docs/architecture/
+  parity/contracts/
+  .github/workflows/
+  root toolchain/bootstrap config
+```
+
+Examples:
+- root README
+- architecture docs
+- parity contract snapshots / schemas
+- CI workflow files
+- top-level workspace metadata
+
+## 3.2 Agent A owned subtree
+
+```text
+<rebuild-repo>/
+  desktop/
+  frontend/
+  parity/ui/
+```
+
+Agent A may also create read-only notes under:
+- `docs/track-a/`
+
+but does not edit coordinator-owned docs after Phase 0 without approval.
+
+## 3.3 Agent B owned subtree
+
+```text
+<rebuild-repo>/
+  backend/
+  parity/api/
+  parity/jobs/
+  parity/export/
+```
+
+Agent B may also create read-only notes under:
+- `docs/track-b/`
+
+but does not edit coordinator-owned docs after Phase 0 without approval.
+
+## 3.4 Explicit no-touch rule
+
+- Agent A never writes `backend/**`
+- Agent B never writes `frontend/**` or `desktop/**`
+- Neither agent rewrites root bootstrap/config after Phase 0
+- Shared contract files are coordinator-owned and treated as **immutable unless reopened**
+
+---
+
+## 4. Shared contract gate (Phase 0 — blocker)
+
+No implementation starts until Phase 0 is complete.
+
+## 4.1 Shared contract deliverables
+
+The coordinator must define and freeze:
+
+1. **Behavior oracle set**
+   - which current PARSE pages/workflows are in parity scope first
+   - annotate / compare / tags / export / jobs / auth / desktop bootstrap
+
+2. **Rebuild-repo skeleton**
+   - repo layout
+   - root toolchain
+   - CI scaffold
+   - dev bootstrap commands
+
+3. **Desktop bootstrap contract**
+   - how desktop shell launches backend
+   - port/auth token behavior
+   - readiness/health handshake
+
+4. **API contract inventory**
+   - page-critical endpoints
+   - request/response shapes
+   - job state payloads
+   - error semantics
+
+5. **Parity artifact layout**
+   - what lives under `parity/ui`, `parity/api`, `parity/jobs`, `parity/export`, `parity/contracts`
+
+6. **Page/workbench inventory**
+   - current: Annotate, Compare, Tags, chat/compute shell
+   - future placeholders allowed later: training, phonetics, computational-linguistics tools
+
+## 4.2 Gate commands
+
+Before tracks diverge, both agents must be able to run the same baseline commands successfully in the rebuild repo:
+
+```bash
+# frontend shell available
+npm install
+npm run test -- --run
+./node_modules/.bin/tsc --noEmit
+
+# backend test bootstrap available
+python3 -m pytest -q
+```
+
+If Phase 0 is not green, parallel work does not start.
+
+---
+
+## 5. Branch and worktree strategy
+
+## 5.1 Branches
+
+Inside the rebuild repo, use three long-lived branches:
+
+- `feat/rebuild-track-a-frontend-desktop`
+- `feat/rebuild-track-b-backend-parity`
+- `feat/rebuild-integration`
+
+## 5.2 Worktrees
+
+Use three worktrees:
+
+```text
+<rebuild-worktrees>/
+  frontend-desktop/
+  backend-parity/
+  integration/
+```
+
+## 5.3 Merge rule
+
+- Agent A and Agent B never merge directly into each other
+- both merge into `feat/rebuild-integration`
+- only the coordinator resolves integration conflicts
+
+---
+
+## 6. How subagents are allowed to work
+
+## 6.1 Subagent rule
+
+Each main agent may use subagents, but only inside its owned subtree.
+
+## 6.2 Allowed subagent patterns
+
+### Agent A subagents
+- `desktop bootstrap shell`
+- `frontend shell/router/layout`
+- `Annotate page slice`
+- `Compare page slice`
+- `shared UI primitives within frontend-owned tree`
+- `UI parity test cases`
+
+### Agent B subagents
+- `route module extraction`
+- `service layer extraction`
+- `job registry/progress/streaming surfaces`
+- `chat/AI tool decomposition`
+- `compare backend decomposition`
+- `API/export/job parity harness`
+
+## 6.3 Forbidden subagent patterns
+
+- No subagent may edit both frontend and backend in one task
+- No two write subagents may target the same subtree simultaneously
+- No subagent touches coordinator-owned contract files unless explicitly delegated
+
+---
+
+## 7. Parallel execution phases
+
+## Phase 0 — Bootstrap + contract freeze (Coordinator)
+
+Deliverables:
+- rebuild repo created
+- root skeleton exists
+- contracts frozen
+- parity directories created
+- CI/dev baseline green
+
+At the end of Phase 0:
+- Agent A starts from a stable frontend/desktop shell
+- Agent B starts from a stable backend/app shell
+
+---
+
+## Phase 1 — Parallel foundation lanes
+
+### Agent A (frontend + desktop)
+
+Owns:
+- `desktop/**`
+- `frontend/**`
+- `parity/ui/**`
+
+Objectives:
+- desktop shell bootstrap
+- frontend app shell
+- navigation and page placeholders
+- base stores/hooks organization
+- initial UI parity checklist
+
+Suggested subagent split:
+1. **A1** — desktop shell bootstrap (`desktop/**`)
+2. **A2** — frontend app shell/router/layout (`frontend/src/app/**`)
+3. **A3** — UI primitives + shell page containers (`frontend/src/components/shell/**`, `frontend/src/shared/**`)
+4. **A4** — UI parity checklist scaffold (`parity/ui/**`)
+
+### Agent B (backend + parity)
+
+Owns:
+- `backend/**`
+- `parity/api/**`
+- `parity/jobs/**`
+- `parity/export/**`
+
+Objectives:
+- backend bootstrap shell
+- route modules
+- service boundaries
+- job/streaming skeleton
+- API/job/export parity harness
+
+Suggested subagent split:
+1. **B1** — backend bootstrap + route registry (`backend/app/**`)
+2. **B2** — route/service split for annotations/config/enrichments/export
+3. **B3** — job registry / job status / streaming scaffolding
+4. **B4** — parity harness for API/job/export comparison
+
+### Phase-1 conflict prevention
+
+- Agent A never edits route/service/backend files
+- Agent B never edits UI/shell/desktop files
+- Shared page names and route names are fixed by Phase 0 contract, not renegotiated in implementation threads
+
+---
+
+## Phase 2 — Core workflow rebuild in parallel
+
+### Agent A track
+
+Objectives:
+- rebuilt Annotate page
+- rebuilt Compare page
+- rebuilt Tags/management flow
+- maintained shell navigation between them
+
+Suggested subagent split:
+1. **A5** — Annotate page skeleton and interactions
+2. **A6** — Compare page skeleton and interactions
+3. **A7** — Tags/manage flow
+4. **A8** — shell-level shared controls (mode switcher, drawers, chat dock placeholders)
+
+### Agent B track
+
+Objectives:
+- annotation backend behavior parity
+- compare backend behavior parity
+- export parity
+- auth/job parity for the rebuilt frontend to consume
+
+Suggested subagent split:
+1. **B5** — annotation routes/services
+2. **B6** — compare routes/services
+3. **B7** — export/auth/job behavior
+4. **B8** — parity snapshots + fixtures for these flows
+
+### Phase-2 conflict prevention
+
+- Agent A consumes backend contracts; does not redefine them
+- Agent B preserves response semantics; does not redesign UI assumptions without coordinator approval
+- parity failures are logged in `parity/**`, not “fixed silently” by changing the oracle
+
+---
+
+## Phase 3 — Advanced compute / AI / agent surfaces
+
+### Agent A track
+
+Objectives:
+- polished desktop UX
+- non-specialist usability improvements in the rebuilt shell
+- future-page scaffolding for later workbenches
+
+Suggested subagent split:
+1. **A9** — desktop UX polish, onboarding, project-open flow
+2. **A10** — shell extensibility for future pages (`training`, `phonetics`, `linguistics` placeholders)
+3. **A11** — UI parity and usability checklist expansion
+
+### Agent B track
+
+Objectives:
+- decompose `chat_tools.py`
+- rebuild AI/chat/tool surfaces
+- MCP/OpenAPI/streaming parity
+- harden backend for local desktop runtime
+
+Suggested subagent split:
+1. **B9** — AI/chat route + service split
+2. **B10** — MCP/OpenAPI surfaces
+3. **B11** — streaming/job/event parity
+4. **B12** — desktop-local runtime hardening
+
+### Why Phase 3 is still safe in parallel
+
+Because by this point:
+- Agent A owns the outer shell and usability/page expansion
+- Agent B owns the internal engine and agent surfaces
+- their file systems remain largely disjoint
+
+---
+
+## Phase 4 — Integration and promotion toward Option 3
+
+This phase is **not parallel-owned**.
+
+The coordinator leads integration in `feat/rebuild-integration`.
+
+Deliverables:
+- merged frontend + backend rebuild
+- parity review against current PARSE
+- package extraction candidates identified
+- first Option-3 promotion plan prepared
+
+Only after this phase should the rebuild begin promoting toward:
+- `desktop/`
+- `frontend/`
+- `backend/`
+- `packages/`
+
+as a more formal platform split.
+
+---
+
+## 8. Testing and parity rules
+
+## 8.1 Continuous testing rule
+
+Every track must test as it goes.
+
+### Agent A must keep green
+- UI tests for frontend-owned code
+- typecheck for frontend-owned code
+- browser parity checklist updates
+
+### Agent B must keep green
+- backend unit/integration tests
+- route parity snapshots
+- job/export parity checks
+
+## 8.2 Shared parity review cadence
+
+At the end of each major phase:
+1. compare rebuilt behavior against current PARSE
+2. record deviations explicitly
+3. decide whether deviation is:
+   - bug
+   - accepted temporary gap
+   - deliberate redesign
+
+No hidden drift.
+
+---
+
+## 9. Concrete anti-collision rules
+
+1. **Single-writer ownership per subtree**
+2. **Coordinator owns contracts/docs/CI/root config after Phase 0**
+3. **No direct Agent A ↔ Agent B merges**
+4. **Subagents inherit ownership limits from their parent agent**
+5. **One write subagent per owned subtree at a time**
+6. **Cross-track changes require coordinator approval first**
+7. **No redefining parity oracle behavior inside the rebuild repo**
+
+---
+
+## 10. Success criteria
+
+This execution plan succeeds if:
+1. Two main agents can work for long stretches without merge collisions.
+2. Subagents accelerate implementation instead of creating duplicate edits.
+3. The rebuild repo reaches parity faster than an in-place rewrite would.
+4. The codebase remains clean enough to promote from Option 1 to Option 3 later.
+
+---
+
+## 11. Immediate next actions if this plan is accepted
+
+1. Create the separate rebuild repo.
+2. Let the coordinator land the Phase 0 bootstrap + contract inventory.
+3. Start Agent A and Agent B from their dedicated worktrees/branches.
+4. Require parity evidence at the end of every phase, not just at the end of the rebuild.


### PR DESCRIPTION
## Summary
- add a plan-only PARSE architecture doc for rebuilding in a separate repo
- define the immediate delivery strategy as Option 1 (domain-preserving modularization)
- define the long-term target as Option 3 (desktop/platform split)
- require parity testing throughout the rebuild instead of testing only at the end

## Why
PARSE is likely heading toward a standalone desktop product with agent-facing surfaces and more non-specialist users. The current repo has multiple monoliths (`python/server.py`, `python/ai/chat_tools.py`, `src/ParseUI.tsx`) large enough that an in-place rewrite is too risky. This plan documents a safer path:
- current repo stays the behavior/API/export oracle
- rebuild happens in a separate repo
- architecture starts with Option 1 discipline
- once stable, the rebuilt app evolves toward Option 3

## Plan artifact
- `docs/plans/option1-separate-rebuild-to-option3-desktop-platform.md`

## Testing
- docs-only change
- verified with `git diff --check`

## Notes
This PR is intentionally plan-only. It does not start the rebuild inside the current PARSE repo.
