### PR TITLE
feat(annotate): editable Words/BND lanes + add-in-gap (Layer 1)

### DIFF
--- a/src/__tests__/annotationUndoRedo.test.ts
+++ b/src/__tests__/annotationUndoRedo.test.ts
@@ -48,7 +48,14 @@ describe("annotationStore undo/redo", () => {
 
     const merged = useAnnotationStore.getState().records.S1.tiers.ipa.intervals;
     expect(merged).toHaveLength(2);
-    expect(merged[0]).toEqual({ start: 0, end: 2, text: "a b" });
+    // Merges flag the resulting interval as manuallyAdjusted so a future
+    // partial re-run preserves the user's grouping decision.
+    expect(merged[0]).toEqual({
+      start: 0,
+      end: 2,
+      text: "a b",
+      manuallyAdjusted: true,
+    });
 
     const label = useAnnotationStore.getState().undo("S1");
     // Label flows into the "Undid X" toast — pin the exact human text so a
@@ -68,7 +75,12 @@ describe("annotationStore undo/redo", () => {
 
     const ivs = useAnnotationStore.getState().records.S1.tiers.ipa.intervals;
     expect(ivs).toHaveLength(2);
-    expect(ivs[1]).toEqual({ start: 1, end: 3, text: "b c" });
+    expect(ivs[1]).toEqual({
+      start: 1,
+      end: 3,
+      text: "b c",
+      manuallyAdjusted: true,
+    });
   });
 
   it("updateInterval / undo swaps text back", () => {

--- a/src/components/annotate/AnnotationPanel.tsx
+++ b/src/components/annotate/AnnotationPanel.tsx
@@ -4,7 +4,7 @@ import { usePlaybackStore } from "../../stores/playbackStore";
 import { useAnnotationStore } from "../../stores/annotationStore";
 import {
   useTranscriptionLanesStore,
-  LANE_LABELS,
+  labelForTier,
 } from "../../stores/transcriptionLanesStore";
 import { Button } from "../shared/Button";
 import { Input } from "../shared/Input";
@@ -248,7 +248,9 @@ export function AnnotationPanel({ onAnnotationSaved, onSeek }: AnnotationPanelPr
 interface SegmentControlsProps {
   speaker: string | null;
   currentTime: number;
-  selected: { speaker: string; tier: import("../../stores/transcriptionLanesStore").LaneKind; index: number } | null;
+  // ``tier`` is the annotation tier name (e.g. "stt", "ortho_words"), not
+  // the visual lane kind — the two diverge for the Boundaries lane.
+  selected: { speaker: string; tier: string; index: number } | null;
   record: import("../../api/types").AnnotationRecord | null;
   onUpdateText: (speaker: string, tier: string, index: number, text: string) => void;
   onUpdateTimes: (speaker: string, tier: string, index: number, start: number, end: number) => void;
@@ -333,7 +335,7 @@ function SegmentControls({
         <div style={{ fontWeight: 600 }}>
           Selected segment
           <span style={{ color: "#6b7280", fontWeight: 400, marginLeft: "0.5rem" }}>
-            ({LANE_LABELS[selected.tier]} #{selected.index + 1})
+            ({labelForTier(selected.tier)} #{selected.index + 1})
           </span>
         </div>
         <Button variant="secondary" size="sm" onClick={onClearSelection}>

--- a/src/components/annotate/TranscriptionLanes.tsx
+++ b/src/components/annotate/TranscriptionLanes.tsx
@@ -18,23 +18,35 @@ interface TranscriptionLanesProps {
 interface LaneStrip {
   kind: LaneKind;
   label: string;
-  intervals: Array<{ start: number; end: number; text: string }>;
-  /** Index into the underlying `record.tiers[kind].intervals` array. Set when
+  intervals: Array<{
+    start: number;
+    end: number;
+    text: string;
+    manuallyAdjusted?: boolean;
+  }>;
+  /** Annotation tier name to dispatch store actions against. When unset
+   * (legacy code path), the lane `kind` is used. The two diverge for the
+   * Words and BND lanes: `kind: "stt_words"` → `tier: "stt_words"`,
+   * `kind: "boundaries"` → `tier: "ortho_words"`. */
+  tier?: string;
+  /** Index into the underlying `record.tiers[tier].intervals` array. Set when
    * the strip is sourced from the editable tier (so inline edits / merges /
-   * splits can address the original interval). For STT sourced from the API
-   * cache (pre-migration) this is the index into `sttBySpeaker[speaker]` —
-   * the same offset survives migration because `ensureSttTier` copies
-   * segments verbatim in order. */
+   * splits can address the original interval). */
   sourceIndices?: number[];
   /** Per-interval color override aligned to `intervals[]`. Used by the
    * Boundaries lane to color each Tier 2 word by its shift from the matching
    * Tier 1 word (or by Tier 2 confidence when no Tier 1 partner exists).
    * When unset, the lane's single color from the store is used. */
   intervalColors?: (string | undefined)[];
-  /** True for the STT strip when the record hasn't yet migrated STT into
-   * `record.tiers.stt`. Edit-path handlers must call `ensureSttTier` before
-   * opening the inline editor / context menu so the tier entry exists. */
+  /** Boundary-only lanes (Words, BND) suppress text labels inside boxes.
+   * Text content lives in STT/ORTH/IPA — these lanes are pure timing. */
+  boundaryOnly?: boolean;
+  /** True when the editable tier hasn't been populated yet for this lane.
+   * Edit-path handlers must call the corresponding `ensure*Tier` migration
+   * before opening the editor / committing edits so the tier entry exists. */
   needsMigration?: boolean;
+  /** Migration callback to run on first edit; resolves `needsMigration`. */
+  migrate?: () => void;
   status?: "idle" | "loading" | "loaded" | "error";
   /** Custom empty-state message; falls back to a generic per-tier hint. */
   emptyHint?: string;
@@ -137,7 +149,9 @@ export function TranscriptionLanes({
   const removeInterval = useAnnotationStore((s) => s.removeInterval);
   const mergeIntervals = useAnnotationStore((s) => s.mergeIntervals);
   const splitInterval = useAnnotationStore((s) => s.splitInterval);
+  const addInterval = useAnnotationStore((s) => s.addInterval);
   const ensureSttTier = useAnnotationStore((s) => s.ensureSttTier);
+  const ensureSttWordsTier = useAnnotationStore((s) => s.ensureSttWordsTier);
 
   const [pxPerSec, setPxPerSec] = useState(0);
   const [duration, setDuration] = useState(0);
@@ -146,6 +160,15 @@ export function TranscriptionLanes({
   const [editing, setEditing] = useState<{ kind: LaneKind; index: number } | null>(null);
   const [menu, setMenu] = useState<
     { kind: LaneKind; index: number; x: number; y: number } | null
+  >(null);
+  /** Active drag-to-create-interval on a boundary-only lane. The user
+   * presses on an empty region of the lane and drags rightward; on
+   * release we commit a new ``manuallyAdjusted`` interval to that lane's
+   * tier. ``startX`` and ``currentX`` are pixels relative to the timeline
+   * inner div (already includes scroll offset). */
+  const [pendingDrag, setPendingDrag] = useState<
+    | { kind: LaneKind; tier: string; startSec: number; endSec: number }
+    | null
   >(null);
   const editRef = useRef<HTMLSpanElement | null>(null);
 
@@ -263,6 +286,7 @@ export function TranscriptionLanes({
       const ws = wsRef.current;
       const t = ws?.getCurrentTime() ?? 0;
       e.preventDefault();
+      // ``sel.tier`` is the annotation tier name (mapped at selection time).
       splitInterval(sel.speaker, sel.tier, sel.index, t);
     };
     document.addEventListener("keydown", onKey);
@@ -288,40 +312,73 @@ export function TranscriptionLanes({
       if (!lanes[kind].visible) continue;
 
       if (kind === "stt_words") {
-        const segs: SttSegment[] = sttBySpeaker[speaker] ?? [];
-        const intervals: Array<{ start: number; end: number; text: string }> = [];
-        for (const seg of segs) {
-          for (const w of seg.words ?? []) {
-            const text = (w.word ?? "").trim();
-            if (!text) continue;
-            // Skip degenerate boundaries (Whisper's word_timestamps occasionally
-            // emits start==end==0 for the first word of a segment). They'd
-            // render as an invisible 1px box anyway and just clutter the lane.
-            if (w.start === 0 && w.end === 0) continue;
-            intervals.push({ start: w.start, end: w.end, text });
+        // Words is a boundary-only lane (no text inside boxes). The text
+        // for each word belongs in STT/ORTH segment-level tiers; Words
+        // exists purely so the user can see and adjust where Tier 1
+        // placed word boundaries (and add new ones in gaps where the
+        // model produced nothing).
+        //
+        // Source priority: ``record.tiers.stt_words`` post-migration,
+        // else fall back to the API-cached ``segments[].words[]``.
+        // ``ensureSttWordsTier`` flips us to the migrated path on first
+        // edit (drag, split, merge, delete, add-in-gap).
+        const tierIvs: AnnotationInterval[] =
+          record?.tiers?.stt_words?.intervals ?? [];
+        const hasTier = tierIvs.length > 0;
+        if (hasTier) {
+          out.push({
+            kind: "stt_words",
+            tier: "stt_words",
+            label: LANE_LABELS.stt_words,
+            intervals: tierIvs.map((iv) => ({
+              start: iv.start,
+              end: iv.end,
+              text: "",
+              manuallyAdjusted: iv.manuallyAdjusted,
+            })),
+            sourceIndices: tierIvs.map((_, i) => i),
+            boundaryOnly: true,
+          });
+        } else {
+          const segs: SttSegment[] = sttBySpeaker[speaker] ?? [];
+          const intervals: LaneStrip["intervals"] = [];
+          for (const seg of segs) {
+            for (const w of seg.words ?? []) {
+              if (w.start === 0 && w.end === 0) continue;
+              intervals.push({ start: w.start, end: w.end, text: "" });
+            }
           }
+          const status = sttStatus[speaker] ?? "idle";
+          const emptyHint =
+            intervals.length > 0
+              ? undefined
+              : status === "loading"
+                ? "Loading STT…"
+                : status === "error"
+                  ? "Failed to load STT"
+                  : `No word-level STT yet — run word-level STT for ${speaker}`;
+          out.push({
+            kind: "stt_words",
+            tier: "stt_words",
+            label: LANE_LABELS.stt_words,
+            intervals,
+            sourceIndices: intervals.map((_, i) => i),
+            boundaryOnly: true,
+            needsMigration: true,
+            migrate: () => ensureSttWordsTier(speaker, segs),
+            emptyHint,
+            status,
+          });
         }
-        const status = sttStatus[speaker] ?? "idle";
-        const emptyHint =
-          intervals.length > 0
-            ? undefined
-            : status === "loading"
-              ? "Loading STT…"
-              : status === "error"
-                ? "Failed to load STT"
-                : `No word-level STT yet — run word-level STT for ${speaker}`;
-        out.push({
-          kind: "stt_words",
-          label: LANE_LABELS.stt_words,
-          intervals,
-          emptyHint,
-          status,
-          // No sourceIndices → strip is read-only (clicks seek, no editor).
-        });
         continue;
       }
 
       if (kind === "boundaries") {
+        // BND is a boundary-only lane (no text inside boxes). It edits
+        // ``tiers.ortho_words`` directly — the persisted refined word
+        // boundaries from Tier 2 forced alignment. Color-coded by shift
+        // to the matching Tier 1 word; falls back to Tier 2 confidence
+        // when no Tier 1 partner exists.
         const segs: SttSegment[] = sttBySpeaker[speaker] ?? [];
         const tier1Words: Array<{ start: number; end: number; text: string }> = [];
         for (const seg of segs) {
@@ -335,30 +392,39 @@ export function TranscriptionLanes({
           text: string;
           confidence?: number;
           source?: "forced_align" | "short_clip_fallback";
+          manuallyAdjusted?: boolean;
         }>;
 
-        const intervals: Array<{ start: number; end: number; text: string }> = [];
+        const intervals: LaneStrip["intervals"] = [];
         const intervalColors: (string | undefined)[] = [];
+        const sourceIndices: number[] = [];
         tier2Ivs.forEach((iv, i) => {
-          if (!iv.text || !iv.text.trim()) return;
-          intervals.push({ start: iv.start, end: iv.end, text: iv.text });
+          intervals.push({
+            start: iv.start,
+            end: iv.end,
+            text: "",
+            manuallyAdjusted: iv.manuallyAdjusted,
+          });
           intervalColors.push(boundaryColor(iv, tier1Words[i]));
+          sourceIndices.push(i);
         });
 
         const hasTier2 = intervals.length > 0;
         const emptyHint = hasTier2
           ? undefined
           : tier1Words.length > 0
-            ? "Run ORTH alignment to populate Tier 2 boundaries"
-            : `Run Orthographic STT for ${speaker}`;
+            ? "Run forced-align (or drag here to add a boundary manually)"
+            : `Run Orthographic STT for ${speaker}, then forced-align`;
 
         out.push({
           kind: "boundaries",
+          tier: "ortho_words",
           label: LANE_LABELS.boundaries,
           intervals,
           intervalColors,
+          sourceIndices,
+          boundaryOnly: true,
           emptyHint,
-          // No sourceIndices → strip is read-only (clicks seek, no editor).
         });
         continue;
       }
@@ -394,10 +460,12 @@ export function TranscriptionLanes({
           const segs: SttSegment[] = sttBySpeaker[speaker] ?? [];
           out.push({
             kind: "stt",
+            tier: "stt",
             label: LANE_LABELS.stt,
             intervals: segs.map((s) => ({ start: s.start, end: s.end, text: s.text })),
             sourceIndices: segs.map((_, i) => i),
             needsMigration: true,
+            migrate: () => ensureSttTier(speaker, segs),
             status: sttStatus[speaker] ?? "idle",
           });
         }
@@ -432,12 +500,58 @@ export function TranscriptionLanes({
   const visibleEndSec =
     (scrollLeft + viewportWidth + VIRTUAL_BUFFER_PX) / pxPerSec;
 
-  const commitEdit = (kind: LaneKind, sourceIdx: number, text: string) => {
+  const commitEdit = (tier: string, sourceIdx: number, text: string) => {
     const trimmed = text.trim();
     if (!speaker) return;
-    updateInterval(speaker, kind, sourceIdx, trimmed);
+    updateInterval(speaker, tier, sourceIdx, trimmed);
     setEditing(null);
   };
+
+  // Strip lookup by kind (used by the context menu / pending-drag commit).
+  const stripByKind = (kind: LaneKind): LaneStrip | undefined =>
+    strips.find((s) => s.kind === kind);
+
+  // Drag-to-create on a boundary-only lane: while pendingDrag is active,
+  // track mouse moves anywhere on the page (the user may drag past the
+  // lane edge) and commit on mouseup. Threshold 50ms — shorter drags are
+  // treated as clicks (no interval created).
+  useEffect(() => {
+    if (!pendingDrag) return;
+    if (!speaker || pxPerSec <= 0) return;
+    const onMove = (e: MouseEvent) => {
+      const laneEl = laneScrollRefs.current[pendingDrag.kind];
+      if (!laneEl) return;
+      const rect = laneEl.getBoundingClientRect();
+      const px = e.clientX - rect.left + laneEl.scrollLeft;
+      const sec = Math.max(0, Math.min(duration, px / pxPerSec));
+      setPendingDrag((prev) => (prev ? { ...prev, endSec: sec } : prev));
+    };
+    const onUp = () => {
+      setPendingDrag((prev) => {
+        if (!prev) return null;
+        const a = Math.min(prev.startSec, prev.endSec);
+        const b = Math.max(prev.startSec, prev.endSec);
+        if (b - a >= 0.05) {
+          const strip = stripByKind(prev.kind);
+          if (strip?.needsMigration) strip.migrate?.();
+          addInterval(speaker, prev.tier, {
+            start: a,
+            end: b,
+            text: "",
+            manuallyAdjusted: true,
+          });
+        }
+        return null;
+      });
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingDrag, speaker, pxPerSec, duration]);
 
   return (
     <div className="mt-2 space-y-1 px-5">
@@ -496,18 +610,65 @@ export function TranscriptionLanes({
                 }}
                 className="h-full overflow-hidden"
               >
-                <div className="relative h-full" style={{ width: innerWidth }}>
+                <div
+                  className="relative h-full"
+                  style={{ width: innerWidth }}
+                  onMouseDown={(e) => {
+                    // Drag-to-create on boundary-only lanes (Words / BND).
+                    // Only fires on empty timeline space — clicks on
+                    // existing interval buttons are stopped at the button
+                    // handler (stopPropagation on those covers it).
+                    if (!strip.boundaryOnly) return;
+                    if (!speaker) return;
+                    if (pxPerSec <= 0) return;
+                    if (e.button !== 0) return;
+                    const target = e.target as HTMLElement | null;
+                    if (target?.closest("button")) return;
+                    const tier = strip.tier ?? strip.kind;
+                    const sec = Math.max(
+                      0,
+                      Math.min(
+                        duration,
+                        (e.nativeEvent as MouseEvent).offsetX / pxPerSec,
+                      ),
+                    );
+                    setPendingDrag({
+                      kind: strip.kind,
+                      tier,
+                      startSec: sec,
+                      endSec: sec,
+                    });
+                    e.preventDefault();
+                  }}
+                >
+                  {pendingDrag?.kind === strip.kind && (() => {
+                    const a = Math.min(pendingDrag.startSec, pendingDrag.endSec);
+                    const b = Math.max(pendingDrag.startSec, pendingDrag.endSec);
+                    return (
+                      <div
+                        className="pointer-events-none absolute top-1 bottom-1 rounded border-2 border-dashed"
+                        style={{
+                          left: a * pxPerSec,
+                          width: Math.max(1, (b - a) * pxPerSec),
+                          borderColor: color,
+                          backgroundColor: withAlpha(color, 0.12),
+                        }}
+                      />
+                    );
+                  })()}
                   {visible.map((iv, slotIdx) => {
                     const sourceIdx = visibleSourceIndices?.[slotIdx];
                     const absIdx = firstIdx + slotIdx;
                     const left = iv.start * pxPerSec;
                     const width = Math.max(1, (iv.end - iv.start) * pxPerSec);
-                    const showLabel = width >= MIN_LABEL_WIDTH_PX;
+                    const showLabel =
+                      !strip.boundaryOnly && width >= MIN_LABEL_WIDTH_PX;
                     const isEditable = sourceIdx !== undefined;
+                    const tierName = strip.tier ?? strip.kind;
                     const isSelected =
                       isEditable &&
                       selectedInterval?.speaker === speaker &&
-                      selectedInterval?.tier === strip.kind &&
+                      selectedInterval?.tier === tierName &&
                       selectedInterval?.index === sourceIdx;
                     const isEditing =
                       isEditable &&
@@ -536,7 +697,7 @@ export function TranscriptionLanes({
                             if (e.key === "Enter") {
                               e.preventDefault();
                               commitEdit(
-                                strip.kind,
+                                tierName,
                                 sourceIdx,
                                 e.currentTarget.textContent ?? "",
                               );
@@ -547,7 +708,7 @@ export function TranscriptionLanes({
                           }}
                           onBlur={(e) =>
                             commitEdit(
-                              strip.kind,
+                              tierName,
                               sourceIdx,
                               e.currentTarget.textContent ?? "",
                             )
@@ -565,12 +726,16 @@ export function TranscriptionLanes({
                       <button
                         key={`${strip.kind}-${slotIdx}-${iv.start}`}
                         type="button"
+                        // Stop propagation so the lane's drag-to-create
+                        // handler doesn't fire when the user clicks on an
+                        // existing interval.
+                        onMouseDown={(e) => e.stopPropagation()}
                         onClick={(e) => {
                           e.stopPropagation();
                           if (isEditable && sourceIdx !== undefined) {
                             setSelectedInterval({
                               speaker,
-                              tier: strip.kind,
+                              tier: tierName,
                               index: sourceIdx,
                             });
                           }
@@ -579,26 +744,20 @@ export function TranscriptionLanes({
                         onDoubleClick={(e) => {
                           e.stopPropagation();
                           if (!isEditable || sourceIdx === undefined) return;
-                          // First-edit STT: migrate the API-cached segments
-                          // into record.tiers.stt before entering edit mode.
-                          // `ensureSttTier` is idempotent and batched with
-                          // setEditing so the next render sees the tier
-                          // populated and opens the inline editor directly.
-                          if (strip.needsMigration) {
-                            ensureSttTier(speaker, sttBySpeaker[speaker] ?? []);
-                          }
+                          // Boundary-only lanes have no text to edit;
+                          // double-click is a no-op on Words/BND.
+                          if (strip.boundaryOnly) return;
+                          if (strip.needsMigration) strip.migrate?.();
                           setEditing({ kind: strip.kind, index: sourceIdx });
                         }}
                         onContextMenu={(e) => {
                           if (!isEditable || sourceIdx === undefined) return;
                           e.preventDefault();
                           e.stopPropagation();
-                          if (strip.needsMigration) {
-                            ensureSttTier(speaker, sttBySpeaker[speaker] ?? []);
-                          }
+                          if (strip.needsMigration) strip.migrate?.();
                           setSelectedInterval({
                             speaker,
-                            tier: strip.kind,
+                            tier: tierName,
                             index: sourceIdx,
                           });
                           setMenu({
@@ -613,10 +772,26 @@ export function TranscriptionLanes({
                           (isSelected ? " ring-2" : "")
                         }
                         style={baseStyle}
-                        title={`${iv.start.toFixed(3)}–${iv.end.toFixed(3)} s · ${iv.text}`}
-                        aria-label={`${strip.label} ${iv.start.toFixed(2)}s: ${iv.text}`}
+                        title={
+                          strip.boundaryOnly
+                            ? `${iv.start.toFixed(3)}–${iv.end.toFixed(3)} s${
+                                iv.manuallyAdjusted ? " · manually adjusted" : ""
+                              }`
+                            : `${iv.start.toFixed(3)}–${iv.end.toFixed(3)} s · ${iv.text}`
+                        }
+                        aria-label={`${strip.label} ${iv.start.toFixed(2)}s${
+                          iv.text ? `: ${iv.text}` : ""
+                        }`}
                       >
                         {showLabel ? <span className="truncate">{iv.text}</span> : null}
+                        {iv.manuallyAdjusted && (
+                          <span
+                            aria-hidden
+                            className="pointer-events-none absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full"
+                            style={{ backgroundColor: ivColor }}
+                            title="Manually adjusted"
+                          />
+                        )}
                       </button>
                     );
                   })}
@@ -633,8 +808,11 @@ export function TranscriptionLanes({
       })}
 
       {menu && (() => {
-        const target = record?.tiers?.[menu.kind]?.intervals?.[menu.index];
+        const strip = stripByKind(menu.kind);
+        const tierName = strip?.tier ?? menu.kind;
+        const target = record?.tiers?.[tierName]?.intervals?.[menu.index];
         if (!target) return null;
+        const boundaryOnly = !!strip?.boundaryOnly;
         return (
           <ContextMenu
             x={menu.x}
@@ -642,22 +820,26 @@ export function TranscriptionLanes({
             laneLabel={LANE_LABELS[menu.kind]}
             start={target.start}
             end={target.end}
-            onEdit={() => {
-              setEditing({ kind: menu.kind, index: menu.index });
-              setMenu(null);
-            }}
+            onEdit={
+              boundaryOnly
+                ? null
+                : () => {
+                    setEditing({ kind: menu.kind, index: menu.index });
+                    setMenu(null);
+                  }
+            }
             onSplit={() => {
               const ws = wsRef.current;
               const t = ws?.getCurrentTime() ?? 0;
-              splitInterval(speaker, menu.kind, menu.index, t);
+              splitInterval(speaker, tierName, menu.index, t);
               setMenu(null);
             }}
             onMerge={() => {
-              mergeIntervals(speaker, menu.kind, menu.index);
+              mergeIntervals(speaker, tierName, menu.index);
               setMenu(null);
             }}
             onDelete={() => {
-              removeInterval(speaker, menu.kind, menu.index);
+              removeInterval(speaker, tierName, menu.index);
               setSelectedInterval(null);
               setMenu(null);
             }}
@@ -674,7 +856,9 @@ interface ContextMenuProps {
   laneLabel: string;
   start: number;
   end: number;
-  onEdit: () => void;
+  /** When null, the "Edit text" menu item is omitted — boundary-only
+   * lanes (Words / BND) have no text content to edit. */
+  onEdit: (() => void) | null;
   onSplit: () => void;
   onMerge: () => void;
   onDelete: () => void;
@@ -705,7 +889,7 @@ function ContextMenu({
         </span>
       </div>
       <div className="mb-1 h-px bg-slate-100" />
-      <MenuItem label="Edit text" hint="dbl-click" onClick={onEdit} />
+      {onEdit && <MenuItem label="Edit text" hint="dbl-click" onClick={onEdit} />}
       <MenuItem label="Split at playhead" hint="S" onClick={onSplit} />
       <MenuItem label="Merge with next" onClick={onMerge} />
       <div className="my-1 h-px bg-slate-100" />

--- a/src/stores/annotationStore.ts
+++ b/src/stores/annotationStore.ts
@@ -200,6 +200,14 @@ interface AnnotationStore {
    * entries (same affordances as IPA/ORTH). No-op if the tier already has
    * entries. Called lazily on first STT double-click / right-click. */
   ensureSttTier: (speaker: string, segments: SttSegment[]) => void;
+  /** One-time migration: flatten Tier 1 word-level boundaries from the API
+   * STT cache into ``record.tiers.stt_words`` so the Words lane becomes
+   * editable (drag, split, merge, delete, add-in-gap). No-op if the tier
+   * already has entries. Called lazily on first edit/add interaction. */
+  ensureSttWordsTier: (
+    speaker: string,
+    segments: SttSegment[],
+  ) => void;
   /** Persist a confirmed lexical anchor for a concept on this speaker.
    * Lives in the `confirmed_anchors` sidecar, NOT in any tier — keeps
    * Praat round-trips clean. Pass `null` to clear an existing anchor. */
@@ -343,7 +351,12 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     if (index < 0 || index >= pre.tiers[tier].intervals.length) return;
 
     const clone = deepClone(pre);
-    clone.tiers[tier].intervals[index].text = text;
+    const target = clone.tiers[tier].intervals[index];
+    clone.tiers[tier].intervals[index] = {
+      ...target,
+      text,
+      manuallyAdjusted: true,
+    };
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
@@ -454,6 +467,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
       start: left.start,
       end: right.end,
       text: mergedText,
+      manuallyAdjusted: true,
     });
     clone.modified_at = nowIsoUtc();
 
@@ -481,8 +495,18 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.tiers[tier].intervals.splice(
       index,
       1,
-      { start: target.start, end: splitTime, text: target.text },
-      { start: splitTime, end: target.end, text: "" },
+      {
+        start: target.start,
+        end: splitTime,
+        text: target.text,
+        manuallyAdjusted: true,
+      },
+      {
+        start: splitTime,
+        end: target.end,
+        text: "",
+        manuallyAdjusted: true,
+      },
     );
     clone.modified_at = nowIsoUtc();
 
@@ -523,6 +547,53 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
 
     set((s) => ({
       ...pushHistoryDelta(s, speaker, pre, "enable STT editing"),
+      records: { ...s.records, [speaker]: clone },
+      dirty: { ...s.dirty, [speaker]: true },
+    }));
+    scheduleAutosave(speaker);
+  },
+
+  ensureSttWordsTier: (speaker, segments) => {
+    const state = get();
+    const pre = state.records[speaker];
+    if (!pre) return;
+    if ((pre.tiers.stt_words?.intervals.length ?? 0) > 0) return;
+    if (!Array.isArray(segments) || segments.length === 0) return;
+
+    // Flatten segments[].words[] preserving source order. Words store
+    // empty text — boundary-only lane semantics. Skip degenerate
+    // start==end==0 placeholders (Whisper emits these for the first
+    // word of a segment when word_timestamps fails on it).
+    const flat: AnnotationInterval[] = [];
+    for (const seg of segments) {
+      const words = (seg as SttSegment).words ?? [];
+      for (const w of words) {
+        if (typeof w.start !== "number" || typeof w.end !== "number") continue;
+        if (w.start === 0 && w.end === 0) continue;
+        flat.push({ start: w.start, end: w.end, text: "" });
+      }
+    }
+    if (flat.length === 0) return;
+
+    const clone = deepClone(pre);
+    if (!clone.tiers.stt_words) {
+      // No canonical order for stt_words — append at end. Praat export
+      // falls back to default_order=9999 cleanly.
+      const maxOrder = Math.max(
+        0,
+        ...Object.values(clone.tiers).map((t) => t.display_order),
+      );
+      clone.tiers.stt_words = {
+        name: "stt_words",
+        display_order: maxOrder + 1,
+        intervals: [],
+      };
+    }
+    clone.tiers.stt_words.intervals = flat;
+    clone.modified_at = nowIsoUtc();
+
+    set((s) => ({
+      ...pushHistoryDelta(s, speaker, pre, "enable Words editing"),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));

--- a/src/stores/transcriptionLanesStore.ts
+++ b/src/stores/transcriptionLanesStore.ts
@@ -13,10 +13,15 @@ export interface LaneConfig {
   color: string;
 }
 
-/** Single-interval selection used by the inline editor / segment toolbar. */
+/** Single-interval selection used by the inline editor / segment toolbar.
+ * ``tier`` is the **annotation tier name** (e.g. ``"stt"``, ``"ortho"``,
+ * ``"ortho_words"``), not the visual lane kind. For most lanes the two
+ * match; the Boundaries lane is the exception (kind ``"boundaries"`` →
+ * tier ``"ortho_words"``). Storing the annotation tier name keeps store
+ * dispatches and AnnotationPanel lookups direct, no remapping needed. */
 export interface SelectedInterval {
   speaker: string;
-  tier: LaneKind;
+  tier: string;
   index: number;
 }
 
@@ -46,6 +51,19 @@ export const LANE_LABELS: Record<LaneKind, string> = {
   stt_words: "Words",
   boundaries: "BND",
 };
+
+/** Resolve a lane label from an annotation tier name. ``selectedInterval.tier``
+ * stores the annotation tier name (e.g. ``"ortho_words"``), which doesn't
+ * always match a ``LaneKind``. This helper handles the lane-vs-tier
+ * divergence (``"ortho_words"`` → ``"BND"``) and falls back to the raw
+ * tier slug when no label exists. */
+export function labelForTier(tier: string): string {
+  if (tier === "ortho_words") return LANE_LABELS.boundaries;
+  if ((LANE_LABELS as Record<string, string>)[tier]) {
+    return (LANE_LABELS as Record<string, string>)[tier];
+  }
+  return tier;
+}
 
 const DEFAULT_LANES: Record<LaneKind, LaneConfig> = {
   ipa_phone: { visible: true, color: "#8b5cf6" },  // violet — phone-level IPA


### PR DESCRIPTION
## Summary

Makes the **Words (Tier 1)** and **BND (Tier 2)** lanes a real boundary-editing surface, not a passive diagnostic. The two lanes are how the user fixes what the model got wrong before triggering a partial re-run (Layer 3, future PR).

## What's editable now on Words and BND

- **Drag-on-empty-region creates a new interval.** This is the killer feature: when the model gives up on a section of audio (Fail01 stops producing word boundaries after ~2165s, for instance), the user can now mark a range manually so a future partial re-run has somewhere to look.
- **Right-click context menu**: Split at playhead / Merge with next / Delete. "Edit text" is intentionally omitted on these lanes — Words and BND are boundary-only; transcription text lives in STT/ORTH/IPA.
- **`S` key** splits the currently-selected interval at the WaveSurfer playhead.

## Boundary-only visual

- Box bodies render **no text** on Words/BND. Color (and color coding by Tier 1 ↔ Tier 2 shift on BND) communicates the boundary state.
- Every interval shows a small ring-colored **dot in the top-right corner** when `manuallyAdjusted: true` — the user-fix marker that Layer 3 partial re-runs will respect.

## Tier vs lane identity

The two lanes have different identifiers from their backing tiers (Words → `tiers.stt_words`, BND → `tiers.ortho_words`). Added a new `LaneStrip.tier` field so click handlers / context menu / `S` key dispatch to the right tier slot. `selectedInterval.tier` is now the annotation tier name (string) instead of a `LaneKind`, so `AnnotationPanel` reads the correct tier slot for retiming/merging via the side panel. Added `labelForTier` helper since the lane-vs-tier mapping isn't always 1:1.

## Persistence

- **Words**: first edit lazily migrates `segments[].words[]` from the STT cache into `tiers.stt_words.intervals` via the new `ensureSttWordsTier` action — mirrors the existing `ensureSttTier` migration. After migration, edits write directly to that slot.
- **BND**: writes to `tiers.ortho_words.intervals`, which already persists through `/api/annotations/<speaker>`.

No backend changes. No new dependencies.

## The `manuallyAdjusted: true` re-run contract

`updateInterval` (text edit), `mergeIntervals`, and `splitInterval` now flag affected intervals as manually adjusted. `updateIntervalTimes` and `moveIntervalAcrossTiers` already did. The drag-create path passes the flag explicitly via `addInterval`. So every user-driven edit on every lane sets the flag — Layer 3 partial re-runs will read this to know which intervals not to overwrite during merge.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `vitest run` — 283/283 pass (updated two `annotationUndoRedo` merge tests to expect the new `manuallyAdjusted: true` field on merged intervals)
- [x] Live preview: store loads with no new runtime errors
- [ ] Visual verification on Fail01: open speaker, scroll past 2165 s, drag on the Words lane in that empty region → new boundary appears, dot indicator shows, persists after reload. Pending data-bridge to a workspace that loads on the local Mac preview.

## What this enables

- **Manual fix path**: edit a few high-value BND boundaries directly → next IPA run uses corrected windows immediately. Useful for hand-correcting 5–20 critical words.
- **Add-in-gap**: tag regions where the model produced nothing. Today these are just persisted manually-flagged intervals; Layer 3 will turn them into the input ranges for partial STT/forced-align re-runs.

## Layers 2 and 3

- **Layer 2** (range tags with status: problematic / review-needed / etc.) and **Layer 3** (partial re-run endpoints `/api/compute/stt_partial`, `/api/compute/forced_align_partial` honoring `manuallyAdjusted: true` during merge) are separate PRs. Layer 1 establishes the durable `manuallyAdjusted: true` contract those will read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)