### PR TITLE
refactor: extract server static and workspace config helpers

### DIFF
--- a/python/app/__init__.py
+++ b/python/app/__init__.py
@@ -1,0 +1,1 @@
+"""PARSE application-layer modules extracted from the HTTP server monolith."""

--- a/python/app/http/__init__.py
+++ b/python/app/http/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP-focused helpers for the PARSE application layer."""

--- a/python/app/http/static_paths.py
+++ b/python/app/http/static_paths.py
@@ -1,0 +1,47 @@
+"""Static asset path resolution for the PARSE HTTP server."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import List
+from urllib.parse import unquote, urlparse
+
+
+def dist_dir(project_root: pathlib.Path) -> pathlib.Path:
+    root = project_root.resolve()
+    return root / "dist"
+
+
+def dist_index_path(project_root: pathlib.Path) -> pathlib.Path:
+    return dist_dir(project_root) / "index.html"
+
+
+def has_built_frontend(project_root: pathlib.Path) -> bool:
+    return dist_index_path(project_root).is_file()
+
+
+def static_request_parts(raw_path: str) -> List[str]:
+    request_path = urlparse(raw_path).path or "/"
+    pure_path = pathlib.PurePosixPath(unquote(request_path))
+    return [part for part in pure_path.parts if part not in {"/", "", ".", ".."}]
+
+
+def resolve_static_request_path(raw_path: str, project_root: pathlib.Path) -> pathlib.Path:
+    root = project_root.resolve()
+    parts = static_request_parts(raw_path)
+    root_candidate = root.joinpath(*parts) if parts else root
+
+    if not has_built_frontend(root):
+        return root_candidate
+
+    dist_candidate = dist_dir(root).joinpath(*parts) if parts else dist_index_path(root)
+    if parts and dist_candidate.exists():
+        return dist_candidate
+    if parts and root_candidate.exists():
+        return root_candidate
+
+    request_suffix = pathlib.PurePosixPath("/".join(parts)).suffix if parts else ""
+    if not parts or request_suffix == "":
+        return dist_index_path(root)
+
+    return root_candidate

--- a/python/app/services/__init__.py
+++ b/python/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service-layer helpers extracted from the PARSE server monolith."""

--- a/python/app/services/workspace_config.py
+++ b/python/app/services/workspace_config.py
@@ -1,0 +1,106 @@
+"""Workspace/frontend configuration helpers for the PARSE HTTP server."""
+
+from __future__ import annotations
+
+import copy
+import csv
+import json
+import pathlib
+from typing import Any, Dict, List, Optional
+
+
+def _read_json_dict(path: pathlib.Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _collect_speakers(project_payload: Dict[str, Any], source_index_payload: Dict[str, Any]) -> List[str]:
+    speakers: List[str] = []
+
+    speakers_value = project_payload.get("speakers")
+    if isinstance(speakers_value, dict):
+        speakers.extend(str(key).strip() for key in speakers_value.keys() if str(key).strip())
+    elif isinstance(speakers_value, list):
+        speakers.extend(str(item).strip() for item in speakers_value if str(item).strip())
+
+    source_speakers = source_index_payload.get("speakers")
+    if isinstance(source_speakers, dict):
+        speakers.extend(str(key).strip() for key in source_speakers.keys() if str(key).strip())
+
+    return sorted(dict.fromkeys(speakers))
+
+
+def _load_concepts(project_root: pathlib.Path) -> List[Dict[str, Any]]:
+    concepts_path = project_root / "concepts.csv"
+    concepts: List[Dict[str, Any]] = []
+    if not concepts_path.exists():
+        return concepts
+
+    with concepts_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            cid = str(row.get("id") or "").strip()
+            label = str(row.get("concept_en") or "").strip()
+            if not (cid and label):
+                continue
+
+            entry: Dict[str, Any] = {"id": cid, "label": label}
+            survey_item = str(row.get("survey_item") or "").strip()
+            if survey_item:
+                entry["survey_item"] = survey_item
+
+            custom_order_raw = str(row.get("custom_order") or "").strip()
+            if custom_order_raw:
+                try:
+                    entry["custom_order"] = int(custom_order_raw)
+                except ValueError:
+                    try:
+                        entry["custom_order"] = float(custom_order_raw)
+                    except ValueError:
+                        pass
+            concepts.append(entry)
+
+    return concepts
+
+
+def build_workspace_frontend_config(
+    project_root: pathlib.Path,
+    base_config: Optional[Dict[str, Any]] = None,
+    *,
+    schema_version: int,
+) -> Dict[str, Any]:
+    root = project_root.resolve()
+    config = copy.deepcopy(base_config) if isinstance(base_config, dict) else {}
+
+    project_payload = _read_json_dict(root / "project.json")
+    source_index_payload = _read_json_dict(root / "source_index.json")
+    speakers = _collect_speakers(project_payload, source_index_payload)
+    concepts = _load_concepts(root)
+
+    language_block = project_payload.get("language") if isinstance(project_payload.get("language"), dict) else {}
+    language_code = str(
+        project_payload.get("language_code")
+        or language_block.get("code")
+        or config.get("language_code")
+        or "und"
+    ).strip() or "und"
+    project_name = str(
+        project_payload.get("project_name")
+        or project_payload.get("name")
+        or config.get("project_name")
+        or "PARSE"
+    ).strip() or "PARSE"
+
+    config["project_name"] = project_name
+    config["language_code"] = language_code
+    config["speakers"] = speakers
+    config["concepts"] = concepts
+    config["audio_dir"] = str(project_payload.get("audio_dir") or config.get("audio_dir") or "audio")
+    config["annotations_dir"] = str(project_payload.get("annotations_dir") or config.get("annotations_dir") or "annotations")
+    config["schema_version"] = schema_version
+    return config

--- a/python/server.py
+++ b/python/server.py
@@ -27,6 +27,14 @@ from ai.chat_tools import ChatToolExecutionError, ChatToolValidationError, Parse
 from ai.workflow_tools import WorkflowTools
 from ai.provider import get_chat_config, get_llm_provider, get_ortho_provider, get_stt_provider, load_ai_config, resolve_context_window
 from ai.ipa_transcribe import transcribe_slice as _acoustic_transcribe_slice
+from app.http.static_paths import (
+    dist_dir as _app_dist_dir,
+    dist_index_path as _app_dist_index_path,
+    has_built_frontend as _app_has_built_frontend,
+    resolve_static_request_path as _app_resolve_static_request_path,
+    static_request_parts as _app_static_request_parts,
+)
+from app.services.workspace_config import build_workspace_frontend_config as _app_build_workspace_frontend_config
 from audio_pipeline_paths import build_normalized_output_path
 from external_api.catalog import build_mcp_http_catalog, get_mcp_tool_entry, mcp_exposure_payload, resolve_catalog_mode
 from external_api.openapi import build_openapi_document, render_redoc_html, render_swagger_ui_html
@@ -329,46 +337,26 @@ def _write_json_file(path: pathlib.Path, payload: Dict[str, Any]) -> None:
 
 
 def _dist_dir(project_root: Optional[pathlib.Path] = None) -> pathlib.Path:
-    root = (project_root or _project_root()).resolve()
-    return root / "dist"
+    return _app_dist_dir(project_root or _project_root())
 
 
 def _dist_index_path(project_root: Optional[pathlib.Path] = None) -> pathlib.Path:
-    return _dist_dir(project_root) / "index.html"
+    return _app_dist_index_path(project_root or _project_root())
 
 
 def _has_built_frontend(project_root: Optional[pathlib.Path] = None) -> bool:
-    return _dist_index_path(project_root).is_file()
+    return _app_has_built_frontend(project_root or _project_root())
 
 
 def _static_request_parts(raw_path: str) -> List[str]:
-    request_path = urlparse(raw_path).path or "/"
-    pure_path = pathlib.PurePosixPath(unquote(request_path))
-    return [part for part in pure_path.parts if part not in {"/", "", ".", ".."}]
+    return _app_static_request_parts(raw_path)
 
 
 def _resolve_static_request_path(
     raw_path: str,
     project_root: Optional[pathlib.Path] = None,
 ) -> pathlib.Path:
-    root = (project_root or _project_root()).resolve()
-    parts = _static_request_parts(raw_path)
-    root_candidate = root.joinpath(*parts) if parts else root
-
-    if not _has_built_frontend(root):
-        return root_candidate
-
-    dist_candidate = _dist_dir(root).joinpath(*parts) if parts else _dist_index_path(root)
-    if parts and dist_candidate.exists():
-        return dist_candidate
-    if parts and root_candidate.exists():
-        return root_candidate
-
-    request_suffix = pathlib.PurePosixPath("/".join(parts)).suffix if parts else ""
-    if not parts or request_suffix == "":
-        return _dist_index_path(root)
-
-    return root_candidate
+    return _app_resolve_static_request_path(raw_path, project_root or _project_root())
 
 
 def _project_json_path() -> pathlib.Path:
@@ -700,75 +688,11 @@ def _annotation_source_duration(speaker: str, source_wav: str) -> Optional[float
 
 
 def _workspace_frontend_config(base_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    config = copy.deepcopy(base_config) if isinstance(base_config, dict) else {}
-
-    project_payload = _read_json_file(_project_json_path(), {})
-    if not isinstance(project_payload, dict):
-        project_payload = {}
-    source_index_payload = _read_json_file(_source_index_path(), {})
-    if not isinstance(source_index_payload, dict):
-        source_index_payload = {}
-
-    speakers: List[str] = []
-    speakers_value = project_payload.get("speakers")
-    if isinstance(speakers_value, dict):
-        speakers.extend(str(key).strip() for key in speakers_value.keys() if str(key).strip())
-    elif isinstance(speakers_value, list):
-        speakers.extend(str(item).strip() for item in speakers_value if str(item).strip())
-
-    source_speakers = source_index_payload.get("speakers")
-    if isinstance(source_speakers, dict):
-        speakers.extend(str(key).strip() for key in source_speakers.keys() if str(key).strip())
-    speakers = sorted(dict.fromkeys(speakers))
-
-    concepts_path = _project_root() / "concepts.csv"
-    concepts: list = []
-    if concepts_path.exists():
-        import csv as _csv
-        with open(concepts_path, newline="", encoding="utf-8") as f:
-            reader = _csv.DictReader(f)
-            for row in reader:
-                cid = str(row.get("id") or "").strip()
-                label = str(row.get("concept_en") or "").strip()
-                if not (cid and label):
-                    continue
-                entry: Dict[str, Any] = {"id": cid, "label": label}
-                survey_item = str(row.get("survey_item") or "").strip()
-                if survey_item:
-                    entry["survey_item"] = survey_item
-                custom_order_raw = str(row.get("custom_order") or "").strip()
-                if custom_order_raw:
-                    try:
-                        entry["custom_order"] = int(custom_order_raw)
-                    except ValueError:
-                        try:
-                            entry["custom_order"] = float(custom_order_raw)
-                        except ValueError:
-                            pass
-                concepts.append(entry)
-
-    language_block = project_payload.get("language") if isinstance(project_payload.get("language"), dict) else {}
-    language_code = str(
-        project_payload.get("language_code")
-        or language_block.get("code")
-        or config.get("language_code")
-        or "und"
-    ).strip() or "und"
-    project_name = str(
-        project_payload.get("project_name")
-        or project_payload.get("name")
-        or config.get("project_name")
-        or "PARSE"
-    ).strip() or "PARSE"
-
-    config["project_name"] = project_name
-    config["language_code"] = language_code
-    config["speakers"] = speakers
-    config["concepts"] = concepts
-    config["audio_dir"] = str(project_payload.get("audio_dir") or config.get("audio_dir") or "audio")
-    config["annotations_dir"] = str(project_payload.get("annotations_dir") or config.get("annotations_dir") or "annotations")
-    config["schema_version"] = CONFIG_SCHEMA_VERSION
-    return config
+    return _app_build_workspace_frontend_config(
+        _project_root(),
+        base_config,
+        schema_version=CONFIG_SCHEMA_VERSION,
+    )
 
 
 def _annotation_empty_tier(display_order: int) -> Dict[str, Any]:

--- a/python/test_app_http_static_paths.py
+++ b/python/test_app_http_static_paths.py
@@ -1,0 +1,62 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from app.http.static_paths import (
+    dist_dir,
+    dist_index_path,
+    has_built_frontend,
+    resolve_static_request_path,
+    static_request_parts,
+)
+
+
+def test_dist_helpers_resolve_from_project_root(tmp_path: pathlib.Path) -> None:
+    assert dist_dir(tmp_path) == tmp_path / "dist"
+    assert dist_index_path(tmp_path) == tmp_path / "dist" / "index.html"
+    assert has_built_frontend(tmp_path) is False
+
+
+
+def test_resolve_static_request_path_prefers_dist_assets(tmp_path: pathlib.Path) -> None:
+    dist_index = tmp_path / "dist" / "index.html"
+    dist_index.parent.mkdir(parents=True)
+    dist_index.write_text("<html></html>", encoding="utf-8")
+    dist_asset = tmp_path / "dist" / "assets" / "app.js"
+    dist_asset.parent.mkdir(parents=True)
+    dist_asset.write_text("console.log('ok');", encoding="utf-8")
+
+    resolved = resolve_static_request_path("/assets/app.js", project_root=tmp_path)
+
+    assert resolved == dist_asset
+
+
+
+def test_resolve_static_request_path_uses_spa_fallback_for_compare_route(tmp_path: pathlib.Path) -> None:
+    dist_index = tmp_path / "dist" / "index.html"
+    dist_index.parent.mkdir(parents=True)
+    dist_index.write_text("<html></html>", encoding="utf-8")
+
+    resolved = resolve_static_request_path("/compare", project_root=tmp_path)
+
+    assert resolved == dist_index
+
+
+
+def test_resolve_static_request_path_keeps_audio_under_project_root(tmp_path: pathlib.Path) -> None:
+    dist_index = tmp_path / "dist" / "index.html"
+    dist_index.parent.mkdir(parents=True)
+    dist_index.write_text("<html></html>", encoding="utf-8")
+    audio_file = tmp_path / "audio" / "Fail01.wav"
+    audio_file.parent.mkdir(parents=True)
+    audio_file.write_bytes(b"wav")
+
+    resolved = resolve_static_request_path("/audio/Fail01.wav", project_root=tmp_path)
+
+    assert resolved == audio_file
+
+
+
+def test_static_request_parts_strip_traversal_segments() -> None:
+    assert static_request_parts("/../dist//assets/../app.js") == ["dist", "assets", "app.js"]

--- a/python/test_app_services_workspace_config.py
+++ b/python/test_app_services_workspace_config.py
@@ -1,0 +1,68 @@
+import csv
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from app.services.workspace_config import build_workspace_frontend_config
+
+
+def test_build_workspace_frontend_config_merges_project_speakers_and_concepts(tmp_path: pathlib.Path) -> None:
+    project = tmp_path
+    (project / "project.json").write_text(
+        json.dumps(
+            {
+                "project_id": "southern-kurdish-dialect-comparison",
+                "name": "Southern Kurdish Dialect Comparison",
+                "language": {"code": "sdh"},
+                "speakers": {"Fail02": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / "source_index.json").write_text(
+        json.dumps({"speakers": {"Fail02": {}, "Kalh01": {}}}),
+        encoding="utf-8",
+    )
+    with open(project / "concepts.csv", "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["id", "concept_en"])
+        writer.writeheader()
+        writer.writerow({"id": "1", "concept_en": "ash"})
+        writer.writerow({"id": "2", "concept_en": "bark"})
+
+    result = build_workspace_frontend_config(project, {"chat": {"enabled": True}}, schema_version=7)
+
+    assert result["project_name"] == "Southern Kurdish Dialect Comparison"
+    assert result["language_code"] == "sdh"
+    assert result["speakers"] == ["Fail02", "Kalh01"]
+    assert result["audio_dir"] == "audio"
+    assert result["annotations_dir"] == "annotations"
+    assert result["schema_version"] == 7
+    assert result["concepts"] == [
+        {"id": "1", "label": "ash"},
+        {"id": "2", "label": "bark"},
+    ]
+
+
+def test_build_workspace_frontend_config_preserves_config_defaults_when_project_fields_missing(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "project.json").write_text(json.dumps({}), encoding="utf-8")
+
+    result = build_workspace_frontend_config(
+        tmp_path,
+        {
+            "project_name": "Fallback Project",
+            "language_code": "ckb",
+            "audio_dir": "custom-audio",
+            "annotations_dir": "custom-annotations",
+        },
+        schema_version=3,
+    )
+
+    assert result["project_name"] == "Fallback Project"
+    assert result["language_code"] == "ckb"
+    assert result["audio_dir"] == "custom-audio"
+    assert result["annotations_dir"] == "custom-annotations"
+    assert result["speakers"] == []
+    assert result["concepts"] == []
+    assert result["schema_version"] == 3


### PR DESCRIPTION
## Summary
- extract static asset path helpers from `python/server.py` into `python/app/http/static_paths.py`
- extract workspace/frontend config assembly into `python/app/services/workspace_config.py`
- keep `python/server.py` behavior stable via thin wrapper functions and add direct module tests for both extracted slices

## Test Plan
- `pytest python/test_app_http_static_paths.py python/test_app_services_workspace_config.py python/test_server_workspace_config.py python/test_server_static_paths.py -q`
- `python -m py_compile python/server.py python/app/http/static_paths.py python/app/services/workspace_config.py`
- `./node_modules/.bin/tsc --noEmit`
- `npm run test -- --run`
