### PR TITLE
fix(live): sync path-separator fix from rebuild PR #77 (MC-323)

### DIFF
--- a/docs/plans/MC-323-display-readable-path-posix.md
+++ b/docs/plans/MC-323-display-readable-path-posix.md
@@ -1,0 +1,41 @@
+# MC-323 — Fix persisted Windows path-separator leakage in `chat_tools.py`
+
+## Objective
+Ship the smallest focused rebuild PR that fixes project-relative path serialization in `python/ai/chat_tools.py` so persisted metadata uses POSIX separators across platforms.
+
+## Scope
+- Add one regression test that fails on current code even on Linux by simulating Windows-style relative paths.
+- Apply the one-line fix in `_display_readable_path()`.
+- Re-run the new regression plus the two processed-import tests called out in the audit.
+- Run a focused backend validation set, then package as a rebuild PR.
+
+## Non-goals
+- Do not start chat_tools PR 2.
+- Do not refactor `mcp_adapter.py`.
+- Do not broaden this into fixture-only path normalization work unless required by the failing regression.
+
+## Grounded facts
+- Root cause identified in PR #72 audit: `python/ai/chat_tools.py:5316-5321`.
+- Current implementation uses `str(path.relative_to(self.project_root))`, which leaks backslashes on Windows.
+- Real-bug impact is on persisted metadata written by processed import (`source_index.json`, `annotation.source_audio`).
+- Rebuild `origin/main` is `ca4299c` at implementation time.
+
+## Files
+- `python/ai/chat_tools.py`
+- `python/ai/test_parse_memory_tool.py` or a new focused backend regression test file
+- `docs/plans/MC-323-display-readable-path-posix.md`
+
+## Validation plan
+1. New regression test fails first.
+2. New regression test passes after fix.
+3. Re-run:
+   - `python/ai/test_parse_memory_tool.py::test_import_processed_speaker_write_copies_assets_and_builds_workspace_files`
+   - `python/ai/test_parse_memory_tool.py::test_import_processed_speaker_preserves_existing_sources_and_clears_stale_optional_metadata`
+4. Run a focused backend test slice around display/import paths.
+5. Run `git diff --check` before PR.
+
+## Completion criteria
+- Persisted project-relative paths normalize to POSIX on all platforms.
+- Regression test exists and passed after failing first.
+- Focused validation is green.
+- Rebuild PR opened with `--repo TarahAssistant/PARSE-rebuild`.

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -5316,7 +5316,7 @@ class ParseChatTools:
     def _display_readable_path(self, path: Path) -> str:
         """Return a project-relative path if possible, else the absolute path."""
         try:
-            return str(path.relative_to(self.project_root))
+            return path.relative_to(self.project_root).as_posix()
         except ValueError:
             return str(path)
 

--- a/python/ai/test_display_readable_path.py
+++ b/python/ai/test_display_readable_path.py
@@ -1,0 +1,18 @@
+import pathlib
+import sys
+
+_HERE = pathlib.Path(__file__).resolve().parent
+_PYTHON_DIR = _HERE.parent
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+from ai.chat_tools import ParseChatTools
+
+
+def test_display_readable_path_normalizes_project_relative_windows_paths_to_posix(tmp_path) -> None:
+    tools = ParseChatTools(project_root=tmp_path)
+    tools.project_root = pathlib.PureWindowsPath("C:/proj")
+
+    path = pathlib.PureWindowsPath("C:/proj/audio/working/Fail02/speaker.wav")
+
+    assert tools._display_readable_path(path) == "audio/working/Fail02/speaker.wav"


### PR DESCRIPTION
## Summary

Cherry-picks the one-line fix from rebuild PR #77 (MC-323) to oracle. **Authorized by Lucas 2026-04-26** during coordinator sync (rebuild PR #96 / handoff PR #99).

**Bug**: `python/ai/chat_tools.py:_display_readable_path` was using `str(path.relative_to(self.project_root))`, which returns Windows backslashes on Windows. The result was being persisted to disk in `source_index.json` and `annotation.source_audio`, breaking cross-platform workspace portability.

**Fix**: one-line change to `path.relative_to(self.project_root).as_posix()` — always returns POSIX forward slashes regardless of OS.

## Origin

- Rebuild PR: TarahAssistant/PARSE-rebuild#77 (MC-323)
- Cherry-picked commit: `579639108b90e6a8e758594d79baeeee98b9e156`
- Oracle issues addressed: #231, #232
- Discovery: parse-back-end's PR #72 backend test failure audit on rebuild
- Authorization: rebuild PR #99 (oracle bug sync handoff) per Lucas's 2026-04-26 coordinator-sync decision

## Test plan

- [ ] Verify the change at `python/ai/chat_tools.py:_display_readable_path` uses `.as_posix()`
- [ ] `python3 -m pytest python/test_import_processed_speaker_*.py` passes (the 2 real-bug tests should now pass on oracle just as they do on rebuild)
- [ ] Manual verification on Windows: import a processed speaker, read `source_index.json`, verify forward slashes
- [ ] Closes #231, #232 when merged
