### PR TITLE
fix(live): sync TranscriptionLanes hook-order fix from rebuild PR #19

### DIFF
--- a/src/components/annotate/TranscriptionLanes.test.tsx
+++ b/src/components/annotate/TranscriptionLanes.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import type { RefObject } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type WaveSurfer from "wavesurfer.js";
+import type { AnnotationRecord } from "../../api/types";
+
+let mockRecord: AnnotationRecord | null = null;
+let mockLanes: Record<string, { visible: boolean; color: string }> = {};
+let mockSttBySpeaker: Record<string, unknown[]> = {};
+let mockSttStatus: Record<string, "idle" | "loading" | "loaded" | "error"> = {};
+let mockSelectedInterval: { speaker: string; tier: string; index: number } | null = null;
+
+const mockEnsureStt = vi.fn();
+const mockSetSelectedInterval = vi.fn();
+const mockUpdateInterval = vi.fn();
+const mockRemoveInterval = vi.fn();
+const mockMergeIntervals = vi.fn();
+const mockSplitInterval = vi.fn();
+const mockAddInterval = vi.fn();
+const mockEnsureSttTier = vi.fn();
+const mockEnsureSttWordsTier = vi.fn();
+
+vi.mock("../../stores/transcriptionLanesStore", () => ({
+  LANE_LABELS: {
+    ipa_phone: "Phone IPA",
+    ipa: "IPA",
+    stt: "STT",
+    ortho: "ORTH",
+    stt_words: "Words",
+    boundaries: "BND",
+  },
+  useTranscriptionLanesStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      lanes: mockLanes,
+      sttBySpeaker: mockSttBySpeaker,
+      sttStatus: mockSttStatus,
+      ensureStt: mockEnsureStt,
+      selectedInterval: mockSelectedInterval,
+      setSelectedInterval: mockSetSelectedInterval,
+    }),
+}));
+
+vi.mock("../../stores/annotationStore", () => ({
+  useAnnotationStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      records: mockRecord ? { Fail01: mockRecord } : {},
+      updateInterval: mockUpdateInterval,
+      removeInterval: mockRemoveInterval,
+      mergeIntervals: mockMergeIntervals,
+      splitInterval: mockSplitInterval,
+      addInterval: mockAddInterval,
+      ensureSttTier: mockEnsureSttTier,
+      ensureSttWordsTier: mockEnsureSttWordsTier,
+    }),
+}));
+
+import { TranscriptionLanes } from "./TranscriptionLanes";
+
+function makeRecord(): AnnotationRecord {
+  return {
+    speaker: "Fail01",
+    tiers: {
+      ipa: {
+        name: "ipa",
+        display_order: 1,
+        intervals: [{ start: 1, end: 2, text: "aw" }],
+      },
+      ortho: {
+        name: "ortho",
+        display_order: 2,
+        intervals: [{ start: 1, end: 2, text: "ئاو" }],
+      },
+      concept: {
+        name: "concept",
+        display_order: 3,
+        intervals: [{ start: 1, end: 2, text: "water" }],
+      },
+      speaker: {
+        name: "speaker",
+        display_order: 4,
+        intervals: [],
+      },
+    },
+    created_at: "2026-01-01T00:00:00.000Z",
+    modified_at: "2026-01-01T00:00:00.000Z",
+    source_wav: "Fail01.wav",
+  };
+}
+
+function createMockWaveSurfer(): WaveSurfer {
+  const viewport = document.createElement("div");
+  Object.defineProperty(viewport, "clientWidth", { value: 640, configurable: true });
+  const wrapper = document.createElement("div");
+  Object.defineProperty(wrapper, "clientWidth", { value: 640, configurable: true });
+  viewport.appendChild(wrapper);
+
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  return {
+    options: { minPxPerSec: 120 },
+    getDuration: () => 10,
+    getWrapper: () => wrapper,
+    on: (event: string, handler: (...args: unknown[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)?.add(handler);
+    },
+    un: (event: string, handler: (...args: unknown[]) => void) => {
+      listeners.get(event)?.delete(handler);
+    },
+    getCurrentTime: () => 0,
+  } as unknown as WaveSurfer;
+}
+
+describe("TranscriptionLanes", () => {
+  beforeEach(() => {
+    mockRecord = makeRecord();
+    mockLanes = {
+      ipa_phone: { visible: false, color: "#a855f7" },
+      ipa: { visible: true, color: "#0f172a" },
+      stt: { visible: false, color: "#1d4ed8" },
+      ortho: { visible: true, color: "#059669" },
+      stt_words: { visible: false, color: "#7c3aed" },
+      boundaries: { visible: false, color: "#dc2626" },
+    };
+    mockSttBySpeaker = {};
+    mockSttStatus = { Fail01: "idle" };
+    mockSelectedInterval = null;
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+  });
+
+  it("renders after waveform metrics initialize without triggering a hook-order crash", async () => {
+    const wsRef = { current: createMockWaveSurfer() } as RefObject<WaveSurfer | null>;
+
+    render(
+      <TranscriptionLanes
+        speaker="Fail01"
+        wsRef={wsRef}
+        audioReady={true}
+        onSeek={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTitle("IPA lane")).toBeTruthy());
+    expect(screen.getByTitle("ORTH lane")).toBeTruthy();
+  });
+});

--- a/src/components/annotate/TranscriptionLanes.tsx
+++ b/src/components/annotate/TranscriptionLanes.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type WaveSurfer from "wavesurfer.js";
 import { useAnnotationStore } from "../../stores/annotationStore";
 import {
@@ -491,25 +491,10 @@ export function TranscriptionLanes({
     return out;
   }, [lanes, sttBySpeaker, sttStatus, record, speaker]);
 
-  if (strips.length === 0 || !audioReady || pxPerSec <= 0 || duration <= 0) {
-    return null;
-  }
-
-  const innerWidth = Math.max(viewportWidth, pxPerSec * duration);
-  const visibleStartSec = Math.max(0, (scrollLeft - VIRTUAL_BUFFER_PX) / pxPerSec);
-  const visibleEndSec =
-    (scrollLeft + viewportWidth + VIRTUAL_BUFFER_PX) / pxPerSec;
-
-  const commitEdit = (tier: string, sourceIdx: number, text: string) => {
-    const trimmed = text.trim();
-    if (!speaker) return;
-    updateInterval(speaker, tier, sourceIdx, trimmed);
-    setEditing(null);
-  };
-
-  // Strip lookup by kind (used by the context menu / pending-drag commit).
-  const stripByKind = (kind: LaneKind): LaneStrip | undefined =>
-    strips.find((s) => s.kind === kind);
+  const stripByKind = useCallback(
+    (kind: LaneKind): LaneStrip | undefined => strips.find((s) => s.kind === kind),
+    [strips],
+  );
 
   // Drag-to-create on a boundary-only lane: while pendingDrag is active,
   // track mouse moves anywhere on the page (the user may drag past the
@@ -550,8 +535,23 @@ export function TranscriptionLanes({
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingDrag, speaker, pxPerSec, duration]);
+  }, [addInterval, duration, pendingDrag, pxPerSec, speaker, stripByKind]);
+
+  if (strips.length === 0 || !audioReady || pxPerSec <= 0 || duration <= 0) {
+    return null;
+  }
+
+  const innerWidth = Math.max(viewportWidth, pxPerSec * duration);
+  const visibleStartSec = Math.max(0, (scrollLeft - VIRTUAL_BUFFER_PX) / pxPerSec);
+  const visibleEndSec =
+    (scrollLeft + viewportWidth + VIRTUAL_BUFFER_PX) / pxPerSec;
+
+  const commitEdit = (tier: string, sourceIdx: number, text: string) => {
+    const trimmed = text.trim();
+    if (!speaker) return;
+    updateInterval(speaker, tier, sourceIdx, trimmed);
+    setEditing(null);
+  };
 
   return (
     <div className="mt-2 space-y-1 px-5">


### PR DESCRIPTION
## Summary

Cherry-picks the React hook-order fix from rebuild PR #19 to oracle. **Authorized by Lucas 2026-04-26** during coordinator sync (rebuild PR #96 / handoff PR #99).

**Bug**: `src/components/annotate/TranscriptionLanes.tsx` had hooks called in non-stable order between renders, causing React to throw "Rendered more hooks than during the previous render." This crashes the `/annotate` route when entering Annotate mode on the Saha01 fixture.

**Fix**: per rebuild PR #19's commit — moves hook calls to top-level, ensures consistent hook order regardless of conditional render branches.

## Why this is a partial sync

Rebuild PR #19 also touched `src/ParseUI.test.tsx` with test infrastructure changes that don't apply cleanly to oracle (ParseUI.tsx on oracle hasn't been decomposed yet). Only the TranscriptionLanes `.tsx` + `.test.tsx` changes are synced — those ARE the actual bug fix and its dedicated regression coverage. The ParseUI.test.tsx changes were rebuild-specific test scaffolding, not part of the fix itself.

## Origin

- Rebuild PR: TarahAssistant/PARSE-rebuild#19
- Cherry-picked merge commit: `7b3369684ea840156a15cd3a982e1304a8df8cd9` (TranscriptionLanes files only)
- Oracle issue addressed: #230
- Discovery: rebuild PR #66 Annotate parity pass — recorded oracle's crash as a "deviation" while rebuild loaded successfully
- Authorization: rebuild PR #99 (oracle bug sync handoff) per Lucas's 2026-04-26 coordinator-sync decision

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run test -- --run src/components/annotate/TranscriptionLanes` passes (the new TranscriptionLanes.test.tsx file is the regression coverage)
- [ ] Manual verification: open `/annotate` on Saha01 fixture, verify it loads (not ErrorBoundary) and waveform appears
- [ ] Closes #230 when merged

## Why now

Lucas's live thesis annotate workflow is currently broken on the Saha01 fixture; this fix restores it. **Prerequisite for thesis data processing tonight.** Companion to #233 (path-separator fix sync from rebuild PR #77).
