### PR TITLE
refactor(annotate): extract annotation history helpers

### DIFF
--- a/src/stores/annotationStore.ts
+++ b/src/stores/annotationStore.ts
@@ -6,6 +6,14 @@ import type {
   SttSegment,
 } from "../api/types";
 import { getAnnotation, saveAnnotation } from "../api/client";
+import {
+  emptyHistory,
+  popRedoDelta,
+  popUndoDelta,
+  pushHistoryDelta,
+  tierLabel,
+} from "./annotationStoreHistory";
+import type { SpeakerHistory } from "./annotationStoreHistory";
 
 /* ------------------------------------------------------------------ */
 /*  Helpers (module-scope, not exported)                               */
@@ -65,78 +73,6 @@ function ensureCanonicalTiers(record: AnnotationRecord): AnnotationRecord {
 
 function deepClone<T>(val: T): T {
   return JSON.parse(JSON.stringify(val));
-}
-
-/* ------------------------------------------------------------------ */
-/*  Undo/redo history (session-only, per-speaker)                      */
-/* ------------------------------------------------------------------ */
-
-// Deep-cloned pre-mutation snapshots. Session-only — never persisted, cleared
-// when a speaker record is loaded/reloaded from the backend. The `label`
-// surfaces in toasts ("Undid merge with next").
-export interface HistoryEntry {
-  snapshot: AnnotationRecord;
-  label: string;
-}
-
-export interface SpeakerHistory {
-  undo: HistoryEntry[];
-  redo: HistoryEntry[];
-}
-
-// Human-readable tier names for undo/redo labels. Surfaced verbatim in
-// toasts ("Undid text edit (IPA)"), so keep these short and matched to the
-// LANE_LABELS the user already sees in TranscriptionLanes where possible.
-// Unknown/custom tiers fall through to the raw slug, which is still readable
-// (e.g. a custom "gloss" tier shows as "Undid text edit (gloss)").
-const TIER_LABEL: Record<string, string> = {
-  ipa_phone: "Phones",
-  ipa: "IPA",
-  ortho: "ORTH",
-  ortho_words: "ORTH words",
-  stt: "STT",
-  concept: "Concept",
-  sentence: "Sentence",
-  speaker: "Speaker",
-};
-
-function tierLabel(tier: string): string {
-  return TIER_LABEL[tier] ?? tier;
-}
-
-// Max undo-stack depth per speaker. Chosen to keep snapshot memory bounded
-// for long annotation sessions on large records (a full AnnotationRecord
-// with ~5k intervals across tiers is tens of KB; 50 snapshots ≈ a few MB
-// per speaker in the worst case).
-const HISTORY_CAP = 50;
-
-function emptyHistory(): SpeakerHistory {
-  return { undo: [], redo: [] };
-}
-
-/** Build a histories delta that pushes `pre` onto the speaker's undo stack
- * and clears redo. Called from inside every mutator with the pre-mutation
- * record so the snapshot captures "the state we're about to leave behind".
- * Returns a Partial<AnnotationStore> fragment ready to spread into set().
- *
- * Overflow behavior: when the undo stack reaches HISTORY_CAP (50), the
- * OLDEST entry is silently dropped (FIFO eviction via `shift()`) so the
- * most recent 50 operations stay undoable. No toast, no throw — the user
- * simply can't Ctrl+Z past the cap. The redo stack is not capped here; it
- * only grows via `undo()` and is naturally bounded by the undo depth. */
-function pushHistoryDelta(
-  state: { histories: Record<string, SpeakerHistory> },
-  speaker: string,
-  pre: AnnotationRecord,
-  label: string,
-): { histories: Record<string, SpeakerHistory> } {
-  const prev = state.histories[speaker] ?? emptyHistory();
-  const undo = [...prev.undo, { snapshot: deepClone(pre), label }];
-  // Drop the oldest snapshot (FIFO) once we exceed HISTORY_CAP. Only one can
-  // exceed per push since we append a single entry, so a single shift() is
-  // enough — no loop needed.
-  if (undo.length > HISTORY_CAP) undo.shift();
-  return { histories: { ...state.histories, [speaker]: { undo, redo: [] } } };
 }
 
 /* ------------------------------------------------------------------ */
@@ -336,7 +272,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, `save ${tierLabel(tier)} segment`),
+      histories: pushHistoryDelta(s.histories, speaker, pre, `save ${tierLabel(tier)} segment`),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -360,7 +296,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, `text edit (${tierLabel(tier)})`),
+      histories: pushHistoryDelta(s.histories, speaker, pre, `text edit (${tierLabel(tier)})`),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -394,7 +330,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, `add ${tierLabel(tier)} segment`),
+      histories: pushHistoryDelta(s.histories, speaker, pre, `add ${tierLabel(tier)} segment`),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -413,7 +349,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, `delete ${tierLabel(tier)} segment`),
+      histories: pushHistoryDelta(s.histories, speaker, pre, `delete ${tierLabel(tier)} segment`),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -441,7 +377,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, `retime ${tierLabel(tier)} segment`),
+      histories: pushHistoryDelta(s.histories, speaker, pre, `retime ${tierLabel(tier)} segment`),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -472,7 +408,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, `merge with next (${tierLabel(tier)})`),
+      histories: pushHistoryDelta(s.histories, speaker, pre, `merge with next (${tierLabel(tier)})`),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -511,7 +447,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, `split (${tierLabel(tier)})`),
+      histories: pushHistoryDelta(s.histories, speaker, pre, `split (${tierLabel(tier)})`),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -546,7 +482,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, "enable STT editing"),
+      histories: pushHistoryDelta(s.histories, speaker, pre, "enable STT editing"),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -593,7 +529,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, "enable Words editing"),
+      histories: pushHistoryDelta(s.histories, speaker, pre, "enable Words editing"),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -617,8 +553,8 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(
-        s,
+      histories: pushHistoryDelta(
+        s.histories,
         speaker,
         pre,
         anchor === null ? "clear concept anchor" : "confirm concept anchor",
@@ -658,7 +594,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, "retime lexeme"),
+      histories: pushHistoryDelta(s.histories, speaker, pre, "retime lexeme"),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -691,7 +627,7 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
     clone.modified_at = nowIsoUtc();
 
     set((s) => ({
-      ...pushHistoryDelta(s, speaker, pre, "mark lexeme manually adjusted"),
+      histories: pushHistoryDelta(s.histories, speaker, pre, "mark lexeme manually adjusted"),
       records: { ...s.records, [speaker]: clone },
       dirty: { ...s.dirty, [speaker]: true },
     }));
@@ -701,53 +637,29 @@ export const useAnnotationStore = create<AnnotationStore>()((set, get) => ({
 
   undo: (speaker) => {
     const state = get();
-    const hist = state.histories[speaker];
-    const current = state.records[speaker];
-    if (!hist || hist.undo.length === 0 || !current) return null;
-
-    const entry = hist.undo[hist.undo.length - 1];
-    const nextUndo = hist.undo.slice(0, -1);
-    // Symmetric: pushing the pre-undo record onto redo lets redo put it back.
-    // Reuse the label so the toast reads the same action either direction.
-    const nextRedo = [
-      ...hist.redo,
-      { snapshot: deepClone(current), label: entry.label },
-    ];
+    const delta = popUndoDelta(state.histories, state.records, speaker);
+    if (!delta) return null;
 
     set((s) => ({
-      records: { ...s.records, [speaker]: entry.snapshot },
+      records: { ...s.records, [speaker]: delta.record },
       dirty: { ...s.dirty, [speaker]: true },
-      histories: {
-        ...s.histories,
-        [speaker]: { undo: nextUndo, redo: nextRedo },
-      },
+      histories: delta.histories,
     }));
     scheduleAutosave(speaker);
-    return entry.label;
+    return delta.label;
   },
 
   redo: (speaker) => {
     const state = get();
-    const hist = state.histories[speaker];
-    const current = state.records[speaker];
-    if (!hist || hist.redo.length === 0 || !current) return null;
-
-    const entry = hist.redo[hist.redo.length - 1];
-    const nextRedo = hist.redo.slice(0, -1);
-    const nextUndo = [
-      ...hist.undo,
-      { snapshot: deepClone(current), label: entry.label },
-    ];
+    const delta = popRedoDelta(state.histories, state.records, speaker);
+    if (!delta) return null;
 
     set((s) => ({
-      records: { ...s.records, [speaker]: entry.snapshot },
+      records: { ...s.records, [speaker]: delta.record },
       dirty: { ...s.dirty, [speaker]: true },
-      histories: {
-        ...s.histories,
-        [speaker]: { undo: nextUndo, redo: nextRedo },
-      },
+      histories: delta.histories,
     }));
     scheduleAutosave(speaker);
-    return entry.label;
+    return delta.label;
   },
 }));

--- a/src/stores/annotationStoreHistory.test.ts
+++ b/src/stores/annotationStoreHistory.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { AnnotationRecord } from "../api/types";
+import {
+  emptyHistory,
+  HISTORY_CAP,
+  popRedoDelta,
+  popUndoDelta,
+  pushHistoryDelta,
+  tierLabel,
+} from "./annotationStoreHistory";
+import type { SpeakerHistory } from "./annotationStoreHistory";
+
+function record(text: string): AnnotationRecord {
+  return {
+    speaker: "S1",
+    tiers: {
+      ipa: {
+        name: "ipa",
+        display_order: 1,
+        intervals: [{ start: 0, end: 1, text }],
+      },
+    },
+    created_at: "2026-01-01T00:00:00Z",
+    modified_at: "2026-01-01T00:00:00Z",
+    source_wav: "x.wav",
+  };
+}
+
+describe("annotationStoreHistory", () => {
+  it("maps human tier labels and falls back to the raw slug", () => {
+    expect(tierLabel("ipa")).toBe("IPA");
+    expect(tierLabel("ortho_words")).toBe("ORTH words");
+    expect(tierLabel("custom_gloss")).toBe("custom_gloss");
+  });
+
+  it("pushHistoryDelta caps undo at HISTORY_CAP and clears redo", () => {
+    let histories: Record<string, SpeakerHistory> = {
+      S1: { undo: [], redo: [{ snapshot: record("redo"), label: "redo" }] },
+    };
+    for (let i = 0; i < HISTORY_CAP + 3; i += 1) {
+      histories = pushHistoryDelta(histories, "S1", record(`t${i}`), `label-${i}`);
+    }
+    expect(histories.S1.redo).toEqual([]);
+    expect(histories.S1.undo).toHaveLength(HISTORY_CAP);
+    expect(histories.S1.undo[0]?.label).toBe("label-3");
+    expect(histories.S1.undo[histories.S1.undo.length - 1]?.label).toBe(`label-${HISTORY_CAP + 2}`);
+  });
+
+  it("popUndoDelta restores the prior snapshot and queues redo", () => {
+    const current = record("current");
+    const previous = record("previous");
+    const histories = {
+      S1: {
+        undo: [{ snapshot: previous, label: "text edit (IPA)" }],
+        redo: emptyHistory().redo,
+      },
+    };
+
+    const delta = popUndoDelta(histories, { S1: current }, "S1");
+    expect(delta).not.toBeNull();
+    expect(delta?.label).toBe("text edit (IPA)");
+    expect(delta?.record.tiers.ipa.intervals[0].text).toBe("previous");
+    expect(delta?.histories.S1.undo).toEqual([]);
+    expect(delta?.histories.S1.redo).toHaveLength(1);
+    expect(delta?.histories.S1.redo[0]?.snapshot.tiers.ipa.intervals[0].text).toBe("current");
+  });
+
+  it("popRedoDelta reapplies the redone snapshot and pushes current back to undo", () => {
+    const current = record("current");
+    const redone = record("redone");
+    const histories = {
+      S1: {
+        undo: [{ snapshot: record("older"), label: "older" }],
+        redo: [{ snapshot: redone, label: "retime IPA segment" }],
+      },
+    };
+
+    const delta = popRedoDelta(histories, { S1: current }, "S1");
+    expect(delta).not.toBeNull();
+    expect(delta?.label).toBe("retime IPA segment");
+    expect(delta?.record.tiers.ipa.intervals[0].text).toBe("redone");
+    expect(delta?.histories.S1.redo).toEqual([]);
+    expect(delta?.histories.S1.undo).toHaveLength(2);
+    expect(delta?.histories.S1.undo[delta!.histories.S1.undo.length - 1]?.snapshot.tiers.ipa.intervals[0].text).toBe("current");
+  });
+});

--- a/src/stores/annotationStoreHistory.ts
+++ b/src/stores/annotationStoreHistory.ts
@@ -1,0 +1,115 @@
+import type { AnnotationRecord } from "../api/types";
+
+// Deep-cloned pre-mutation snapshots. Session-only — never persisted, cleared
+// when a speaker record is loaded/reloaded from the backend. The `label`
+// surfaces in toasts ("Undid merge with next").
+export interface HistoryEntry {
+  snapshot: AnnotationRecord;
+  label: string;
+}
+
+export interface SpeakerHistory {
+  undo: HistoryEntry[];
+  redo: HistoryEntry[];
+}
+
+export interface HistoryRestoreDelta {
+  histories: Record<string, SpeakerHistory>;
+  label: string;
+  record: AnnotationRecord;
+}
+
+// Human-readable tier names for undo/redo labels. Surfaced verbatim in
+// toasts ("Undid text edit (IPA)"), so keep these short and matched to the
+// LANE_LABELS the user already sees in TranscriptionLanes where possible.
+// Unknown/custom tiers fall through to the raw slug, which is still readable
+// (e.g. a custom "gloss" tier shows as "Undid text edit (gloss)").
+const TIER_LABEL: Record<string, string> = {
+  ipa_phone: "Phones",
+  ipa: "IPA",
+  ortho: "ORTH",
+  ortho_words: "ORTH words",
+  stt: "STT",
+  concept: "Concept",
+  sentence: "Sentence",
+  speaker: "Speaker",
+};
+
+export function tierLabel(tier: string): string {
+  return TIER_LABEL[tier] ?? tier;
+}
+
+// Max undo-stack depth per speaker. Chosen to keep snapshot memory bounded
+// for long annotation sessions on large records (a full AnnotationRecord
+// with ~5k intervals across tiers is tens of KB; 50 snapshots ≈ a few MB
+// per speaker in the worst case).
+export const HISTORY_CAP = 50;
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function emptyHistory(): SpeakerHistory {
+  return { undo: [], redo: [] };
+}
+
+/** Build the next histories object by pushing `pre` onto the speaker's undo
+ * stack and clearing redo. Called from inside every mutator with the
+ * pre-mutation record so the snapshot captures the state being left behind. */
+export function pushHistoryDelta(
+  histories: Record<string, SpeakerHistory>,
+  speaker: string,
+  pre: AnnotationRecord,
+  label: string,
+): Record<string, SpeakerHistory> {
+  const prev = histories[speaker] ?? emptyHistory();
+  const undo = [...prev.undo, { snapshot: deepClone(pre), label }];
+  if (undo.length > HISTORY_CAP) undo.shift();
+  return { ...histories, [speaker]: { undo, redo: [] } };
+}
+
+export function popUndoDelta(
+  histories: Record<string, SpeakerHistory>,
+  records: Record<string, AnnotationRecord>,
+  speaker: string,
+): HistoryRestoreDelta | null {
+  const hist = histories[speaker];
+  const current = records[speaker];
+  if (!hist || hist.undo.length === 0 || !current) return null;
+
+  const entry = hist.undo[hist.undo.length - 1];
+  const nextUndo = hist.undo.slice(0, -1);
+  const nextRedo = [...hist.redo, { snapshot: deepClone(current), label: entry.label }];
+
+  return {
+    label: entry.label,
+    record: entry.snapshot,
+    histories: {
+      ...histories,
+      [speaker]: { undo: nextUndo, redo: nextRedo },
+    },
+  };
+}
+
+export function popRedoDelta(
+  histories: Record<string, SpeakerHistory>,
+  records: Record<string, AnnotationRecord>,
+  speaker: string,
+): HistoryRestoreDelta | null {
+  const hist = histories[speaker];
+  const current = records[speaker];
+  if (!hist || hist.redo.length === 0 || !current) return null;
+
+  const entry = hist.redo[hist.redo.length - 1];
+  const nextRedo = hist.redo.slice(0, -1);
+  const nextUndo = [...hist.undo, { snapshot: deepClone(current), label: entry.label }];
+
+  return {
+    label: entry.label,
+    record: entry.snapshot,
+    histories: {
+      ...histories,
+      [speaker]: { undo: nextUndo, redo: nextRedo },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- implement PR B from handoff #117 by extracting annotation undo/redo bookkeeping into `src/stores/annotationStoreHistory.ts`
- keep `src/__tests__/annotationUndoRedo.test.ts` and `src/__tests__/moveInterval.test.ts` green as regression nets while wiring the store to the new pure history helpers
- add focused history-helper tests for tier labels, capped undo stacks, and undo/redo snapshot transitions

## Details
- moved `HistoryEntry` / `SpeakerHistory`, tier-label mapping, history-cap logic, and undo/redo snapshot transitions out of `src/stores/annotationStore.ts`
- store mutators now call `pushHistoryDelta(...)` via the extracted helper module instead of inlining history-stack bookkeeping
- `undo()` / `redo()` now delegate to pure `popUndoDelta(...)` / `popRedoDelta(...)` helpers, keeping the Zustand-side effects limited to record/dirty/autosave wiring
- `src/stores/annotationStore.ts` is now 665 LoC on this branch (down from 753 on `origin/main`)

## Test Plan
- `npm run test -- --run src/stores/annotationStoreHistory.test.ts src/__tests__/annotationUndoRedo.test.ts src/__tests__/moveInterval.test.ts`
- `npm run test -- --run`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`
