### PR TITLE
fix(ipa): source acoustic IPA windows from tiers.ortho_words (BND)

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -4338,10 +4338,23 @@ def _compute_speaker_ipa(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]
         raise RuntimeError("Annotation is not a JSON object")
 
     tiers = annotation.get("tiers") or {}
-    ortho_tier = tiers.get("ortho") or {}
-    ortho_intervals = list(ortho_tier.get("intervals") or [])
+    # Prefer the editable BND lane (`tiers.ortho_words`) when present —
+    # those intervals carry the refined word boundaries from Tier 2 forced
+    # alignment (PR #221) and any subsequent user edits (PR #224), so they
+    # are more authoritative than the coarse Whisper segments in
+    # `tiers.ortho`. Fall back to `tiers.ortho` when ortho_words is empty
+    # or absent.
+    ortho_words_tier = tiers.get("ortho_words") or {}
+    ortho_words_intervals = list(ortho_words_tier.get("intervals") or [])
+    if ortho_words_intervals:
+        ortho_intervals = ortho_words_intervals
+        ortho_source = "ortho_words"
+    else:
+        ortho_tier = tiers.get("ortho") or {}
+        ortho_intervals = list(ortho_tier.get("intervals") or [])
+        ortho_source = "ortho"
     if not ortho_intervals:
-        print("[IPA] no ortho intervals — early return", file=sys.stderr, flush=True)
+        print("[IPA] no ortho/ortho_words intervals — early return", file=sys.stderr, flush=True)
         return {"speaker": speaker, "filled": 0, "skipped": 0, "total": 0, "message": "No ortho intervals."}
 
     ipa_tier = tiers.setdefault("ipa", {"type": "interval", "display_order": 1, "intervals": []})
@@ -4395,10 +4408,18 @@ def _compute_speaker_ipa(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]
     _compute_checkpoint("IPA.get_aligner_begin")
     aligner = _get_ipa_aligner()
     _compute_checkpoint("IPA.get_aligner_done")
-    # Use the full Tier 2+3 path when the STT cache has word timestamps;
-    # fall back to coarse ORTH-interval CTC when it doesn't.
-    stt_segments = _read_stt_cache(speaker)
-    has_words = bool(stt_segments and any(seg.get("words") for seg in stt_segments))
+    # When the BND lane (ortho_words) is the source, treat each refined
+    # word interval as its own CTC window — don't re-run forced alignment
+    # from the STT cache, since that would ignore the editable word
+    # boundaries the user sees and edits in the BND lane.
+    # Otherwise, use the full Tier 2+3 path when the STT cache has word
+    # timestamps and fall back to coarse ORTH-interval CTC when it doesn't.
+    if ortho_source == "ortho_words":
+        stt_segments: List[Dict[str, Any]] = []
+        has_words = False
+    else:
+        stt_segments = _read_stt_cache(speaker)
+        has_words = bool(stt_segments and any(seg.get("words") for seg in stt_segments))
 
     exception_samples: List[str] = []
     skipped_empty_ortho = 0
@@ -4442,8 +4463,14 @@ def _compute_speaker_ipa(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]
         skipped = skipped_empty_ipa
         total = len(word_results)
     else:
-        print("[IPA] no STT word cache — using coarse ORTH-interval fallback", file=sys.stderr, flush=True)
-        _compute_checkpoint("IPA.loop_begin", n=len(ortho_intervals))
+        print(
+            "[IPA] using {0}-interval CTC ({1} intervals)".format(
+                ortho_source, len(ortho_intervals)
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
+        _compute_checkpoint("IPA.loop_begin", source=ortho_source, n=len(ortho_intervals))
 
         filled = 0
         skipped = 0
@@ -4544,6 +4571,7 @@ def _compute_speaker_ipa(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]
         "filled": filled,
         "skipped": skipped,
         "total": total,
+        "ortho_source": ortho_source,
         "skip_breakdown": skip_breakdown,
         "exception_samples": exception_samples,
     }

--- a/python/test_compute_speaker_ipa.py
+++ b/python/test_compute_speaker_ipa.py
@@ -57,20 +57,31 @@ class _FakeTensor:
         return (self._n,)
 
 
-def _seed_annotation(tmp_path: pathlib.Path, speaker: str, ortho: list, ipa: list):
+def _seed_annotation(
+    tmp_path: pathlib.Path,
+    speaker: str,
+    ortho: list,
+    ipa: list,
+    ortho_words: list = None,
+):
     (tmp_path / "annotations").mkdir(exist_ok=True)
+    tiers = {
+        "ipa":     {"type": "interval", "display_order": 1, "intervals": ipa},
+        "ortho":   {"type": "interval", "display_order": 2, "intervals": ortho},
+        "concept": {"type": "interval", "display_order": 3, "intervals": []},
+        "speaker": {"type": "interval", "display_order": 4, "intervals": []},
+    }
+    if ortho_words is not None:
+        tiers["ortho_words"] = {
+            "type": "interval", "display_order": 5, "intervals": ortho_words,
+        }
     annotation = {
         "version": 1,
         "project_id": "t",
         "speaker": speaker,
         "source_audio": "x.wav",
         "source_audio_duration_sec": 10.0,
-        "tiers": {
-            "ipa":     {"type": "interval", "display_order": 1, "intervals": ipa},
-            "ortho":   {"type": "interval", "display_order": 2, "intervals": ortho},
-            "concept": {"type": "interval", "display_order": 3, "intervals": []},
-            "speaker": {"type": "interval", "display_order": 4, "intervals": []},
-        },
+        "tiers": tiers,
         "metadata": {"language_code": "sdh", "created": "2026-01-01T00:00:00Z", "modified": "2026-01-01T00:00:00Z"},
     }
     (tmp_path / "annotations" / f"{speaker}.parse.json").write_text(
@@ -200,3 +211,106 @@ def test_skips_when_aligner_returns_empty(tmp_path, monkeypatch):
     assert result["filled"] == 0
     assert result["skipped"] == 1
     assert len(aligner.calls) == 1  # audio *was* tried; just produced nothing
+
+
+def test_prefers_ortho_words_over_ortho_when_present(tmp_path, monkeypatch):
+    """When `tiers.ortho_words` (BND) has intervals, IPA must use those
+    refined word-level boundaries instead of the coarse ortho segments,
+    and must not consult the STT cache (which would discard user edits to
+    the BND lane). One CTC call per ortho_words interval, IPA tier rebuilt
+    at word granularity."""
+    aligner = _StubAligner()
+    _install_stubs(monkeypatch, tmp_path, aligner)
+    # If the STT cache were ever consulted, this would steer the run
+    # through the forced-align branch and break the assertions below.
+    monkeypatch.setattr(
+        server, "_read_stt_cache",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("STT cache must not be read when ortho_words is present")
+        ),
+    )
+
+    ortho_segments = [
+        # Single coarse segment covering several words — would yield one
+        # CTC call under the legacy path and produce misaligned IPA.
+        {"start": 1.0, "end": 5.0, "text": "one two three"},
+    ]
+    ortho_words = [
+        {"start": 1.0, "end": 1.4, "text": "one"},
+        {"start": 2.0, "end": 2.5, "text": "two"},
+        {"start": 3.0, "end": 3.6, "text": "three"},
+    ]
+    _seed_annotation(tmp_path, "Fail01", ortho_segments, [], ortho_words=ortho_words)
+
+    result = server._compute_speaker_ipa("j1", {"speaker": "Fail01"})
+    assert result["ortho_source"] == "ortho_words"
+    assert result["filled"] == 3
+    assert result["total"] == 3
+    assert len(aligner.calls) == 3  # one CTC call per refined word
+
+    ann = _load_canonical(tmp_path, "Fail01")
+    ipa_intervals = ann["tiers"]["ipa"]["intervals"]
+    # IPA tier mirrors the BND word boundaries, not the coarse segment.
+    starts = sorted(round(i["start"], 3) for i in ipa_intervals)
+    assert starts == [1.0, 2.0, 3.0]
+
+
+def test_falls_back_to_ortho_when_ortho_words_missing(tmp_path, monkeypatch):
+    """Backward compatibility: speakers from before the BND split still
+    have only `tiers.ortho` and must keep working unchanged."""
+    aligner = _StubAligner()
+    _install_stubs(monkeypatch, tmp_path, aligner)
+    # No STT cache -> coarse ortho fallback (the historical behaviour).
+    monkeypatch.setattr(server, "_read_stt_cache", lambda *_a, **_kw: [])
+
+    ortho = [{"start": 1.0, "end": 1.5, "text": "hair"}]
+    _seed_annotation(tmp_path, "Fail02", ortho, [])  # no ortho_words tier
+
+    result = server._compute_speaker_ipa("j1", {"speaker": "Fail02"})
+    assert result["ortho_source"] == "ortho"
+    assert result["filled"] == 1
+    assert len(aligner.calls) == 1
+
+
+def test_falls_back_to_ortho_when_ortho_words_empty(tmp_path, monkeypatch):
+    """An ortho_words tier that exists but is empty (e.g. forced-align
+    failed) must not block the IPA fill — fall back to coarse ortho."""
+    aligner = _StubAligner()
+    _install_stubs(monkeypatch, tmp_path, aligner)
+    monkeypatch.setattr(server, "_read_stt_cache", lambda *_a, **_kw: [])
+
+    ortho = [{"start": 1.0, "end": 1.5, "text": "hair"}]
+    _seed_annotation(tmp_path, "Fail02", ortho, [], ortho_words=[])
+
+    result = server._compute_speaker_ipa("j1", {"speaker": "Fail02"})
+    assert result["ortho_source"] == "ortho"
+    assert result["filled"] == 1
+
+
+def test_ortho_words_respects_overwrite_false_at_matching_keys(tmp_path, monkeypatch):
+    """Existing IPA at a matching word-level (start, end) key must be
+    preserved when overwrite=False, even when sourced from ortho_words."""
+    aligner = _StubAligner()
+    _install_stubs(monkeypatch, tmp_path, aligner)
+    monkeypatch.setattr(
+        server, "_read_stt_cache",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("STT cache must not be read when ortho_words is present")
+        ),
+    )
+
+    ortho_words = [
+        {"start": 1.0, "end": 1.4, "text": "one"},
+        {"start": 2.0, "end": 2.5, "text": "two"},
+    ]
+    ipa = [{"start": 1.0, "end": 1.4, "text": "manual-keep"}]
+    _seed_annotation(tmp_path, "Fail01", [], ipa, ortho_words=ortho_words)
+
+    result = server._compute_speaker_ipa("j1", {"speaker": "Fail01"})
+    assert result["ortho_source"] == "ortho_words"
+    assert result["filled"] == 1   # only "two" filled
+    assert result["skipped"] == 1  # "one" preserved
+    ann = _load_canonical(tmp_path, "Fail01")
+    by_start = {round(i["start"], 3): i["text"] for i in ann["tiers"]["ipa"]["intervals"]}
+    assert by_start[1.0] == "manual-keep"
+    assert by_start[2.0] == "IPA_1"


### PR DESCRIPTION
## Summary
- The acoustic IPA fill job was reading time windows from `tiers.ortho` (or the STT word cache), so the refined BND (`tiers.ortho_words`) boundaries introduced in #221 / #224 — including any user edits — were being ignored. On Fail01, this surfaced as misaligned/missing phonemes on concepts like "one", "four", "five".
- `_compute_speaker_ipa` in `python/server.py` now prefers `tiers.ortho_words.intervals` when present and falls back to `tiers.ortho` when ortho_words is empty or absent. When the BND lane is the source, the STT-cache forced-align branch is bypassed so the user's BND edits aren't overwritten by a fresh re-alignment from raw STT word timestamps.
- `overwrite=False` still preserves existing IPA at matching `(start, end)` keys, so manual IPA edits survive a re-run on the same boundaries.

## Files changed
- `python/server.py` — interval sourcing + STT-cache bypass (+ `ortho_source` in result payload)
- `python/test_compute_speaker_ipa.py` — 4 new tests

## Test plan
- [x] `python -m pytest python/test_compute_speaker_ipa.py` — 10 passed
- [x] `python -m pytest python/test_compute_speaker_ortho.py python/test_compute_speaker_ortho_refine_lexemes.py python/test_lexeme_search.py` — 56 passed (no regressions in adjacent ortho/lexeme paths)
- [ ] Lucas: re-run acoustic IPA on Fail01 / Fail02 and confirm "one", "four", "five" align with the BND lane
- [ ] Lucas: confirm a speaker without `tiers.ortho_words` still computes IPA via the legacy path

## Backward compatibility
- Speakers from before the BND split (`tiers.ortho_words` absent) keep using `tiers.ortho` — covered by `test_falls_back_to_ortho_when_ortho_words_missing`.
- An `ortho_words` tier present-but-empty (e.g. forced-align failed) also falls back — covered by `test_falls_back_to_ortho_when_ortho_words_empty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)