### PR TITLE
feat(bnd): standalone boundaries refresh job + Phonetic Tools button

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -4660,6 +4660,141 @@ def _compute_speaker_forced_align(job_id: str, payload: Dict[str, Any]) -> Dict[
     }
 
 
+def _compute_speaker_boundaries(job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Standalone BND job — refresh ``tiers.ortho_words`` only.
+
+    Runs Tier 2 forced alignment (``ai.forced_align.align_segments`` via
+    ``_ortho_tier2_align_to_words``) on the speaker's cached STT segments
+    and writes the refined word boundaries to ``tiers.ortho_words``. No
+    Whisper, no IPA — this is the fast lane users can re-run repeatedly
+    while iterating on boundaries before paying for slow ORTH/IPA passes.
+
+    Intervals previously flagged ``manuallyAdjusted=True`` are preserved
+    verbatim — model output never overwrites a user edit. Aligned words
+    that overlap a manual interval are dropped, so manual edits anchor
+    their slice of the timeline. Pass ``overwrite=True`` to discard
+    manual edits as well.
+
+    All freshly generated intervals carry ``manuallyAdjusted=False`` so
+    downstream code (offset shift, IPA preference) can branch on the
+    flag without ambiguity.
+
+    Payload: ``{ "speaker": "Fail02", "overwrite": false }``.
+    """
+    speaker = _normalize_speaker_id(payload.get("speaker"))
+    overwrite = bool(payload.get("overwrite", False))
+    print(
+        "[BND] enter speaker={0} overwrite={1}".format(speaker, overwrite),
+        file=sys.stderr,
+        flush=True,
+    )
+
+    canonical_path = _project_root() / _annotation_record_relative_path(speaker)
+    legacy_path = _project_root() / _annotation_legacy_record_relative_path(speaker)
+    if canonical_path.is_file():
+        annotation_path = canonical_path
+    elif legacy_path.is_file():
+        annotation_path = legacy_path
+    else:
+        raise RuntimeError("No annotation found for speaker {0!r}".format(speaker))
+
+    annotation = _read_json_file(annotation_path, {})
+    if not isinstance(annotation, dict):
+        raise RuntimeError("Annotation is not a JSON object")
+
+    tiers = annotation.get("tiers") or {}
+
+    # Tier 1 STT segments + nested Whisper word timestamps are the seed
+    # for forced alignment. Without them we can't refine anything.
+    _set_job_progress(job_id, 5.0, message="Reading STT cache")
+    stt_segments = _read_stt_cache(speaker) or []
+    has_words = bool(stt_segments and any(seg.get("words") for seg in stt_segments))
+    if not has_words:
+        raise RuntimeError(
+            "No STT word-level timestamps cached for {0!r}. Run STT first "
+            "before refining boundaries.".format(speaker)
+        )
+
+    # Existing ortho_words: split into manual edits (preserved) and the
+    # rest (regenerated). When overwrite=True, even manual edits are
+    # discarded so the alignment is fully fresh.
+    existing_tier_raw = tiers.get("ortho_words")
+    existing_tier = existing_tier_raw if isinstance(existing_tier_raw, dict) else None
+    existing_intervals = list((existing_tier or {}).get("intervals") or [])
+    if overwrite:
+        manual_intervals: List[Dict[str, Any]] = []
+    else:
+        manual_intervals = [
+            iv for iv in existing_intervals
+            if isinstance(iv, dict) and bool(iv.get("manuallyAdjusted"))
+        ]
+
+    _set_job_progress(job_id, 15.0, message="Resolving audio")
+    audio_path = _pipeline_audio_path_for_speaker(speaker)
+
+    _set_job_progress(job_id, 30.0, message="Running forced alignment")
+    aligned_words = _ortho_tier2_align_to_words(audio_path, stt_segments)
+
+    def _overlaps(a: Dict[str, Any], b: Dict[str, Any]) -> bool:
+        try:
+            a_start = float(a.get("start", 0.0) or 0.0)
+            a_end = float(a.get("end", a_start) or a_start)
+            b_start = float(b.get("start", 0.0) or 0.0)
+            b_end = float(b.get("end", b_start) or b_start)
+        except (TypeError, ValueError):
+            return False
+        return a_start < b_end and a_end > b_start
+
+    if manual_intervals:
+        aligned_words = [
+            w for w in aligned_words
+            if not any(_overlaps(w, m) for m in manual_intervals)
+        ]
+
+    # Mark every model-generated interval as not-manually-adjusted so the
+    # flag is unambiguous on disk (matches the PR-197 normalization
+    # contract for the editable lanes).
+    for w in aligned_words:
+        w["manuallyAdjusted"] = False
+
+    combined = sorted(
+        manual_intervals + aligned_words,
+        key=lambda iv: (
+            float(iv.get("start", 0.0) or 0.0),
+            float(iv.get("end", 0.0) or 0.0),
+        ),
+    )
+
+    _set_job_progress(job_id, 90.0, message="Writing tiers.ortho_words")
+    if existing_tier is None:
+        existing_tier = {"type": "interval", "display_order": 4, "intervals": []}
+    existing_tier["intervals"] = combined
+    tiers["ortho_words"] = existing_tier
+    annotation["tiers"] = tiers
+    _annotation_touch_metadata(annotation, preserve_created=True)
+
+    _write_json_file(annotation_path, annotation)
+    if canonical_path != annotation_path and canonical_path.is_file():
+        _write_json_file(canonical_path, annotation)
+    if legacy_path != annotation_path and legacy_path.is_file():
+        _write_json_file(legacy_path, annotation)
+
+    print(
+        "[BND] speaker={0} generated={1} preserved_manual={2} total={3}".format(
+            speaker, len(aligned_words), len(manual_intervals), len(combined),
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+
+    return {
+        "speaker": speaker,
+        "generated": len(aligned_words),
+        "preserved_manual": len(manual_intervals),
+        "total": len(combined),
+    }
+
+
 def _pipeline_audio_path_for_speaker(speaker: str) -> pathlib.Path:
     """Resolve the best audio file to feed a Whisper-family model for a speaker.
 
@@ -5981,6 +6116,8 @@ def _run_compute_job(job_id: str, compute_type: str, payload: Dict[str, Any]) ->
             result = _compute_speaker_ortho(job_id, payload)
         elif normalized_type in {"forced_align", "forced-align", "align"}:
             result = _compute_speaker_forced_align(job_id, payload)
+        elif normalized_type in {"boundaries", "bnd", "ortho_words", "ortho-words"}:
+            result = _compute_speaker_boundaries(job_id, payload)
         elif normalized_type in {"full_pipeline", "full-pipeline", "pipeline"}:
             result = _compute_full_pipeline(job_id, payload)
         elif normalized_type in {"train_ipa_model", "train-ipa-model", "train_ipa"}:

--- a/python/test_compute_speaker_boundaries.py
+++ b/python/test_compute_speaker_boundaries.py
@@ -1,0 +1,299 @@
+"""Unit tests for _compute_speaker_boundaries (the standalone BND job).
+
+The boundaries job is the fast lane: forced alignment only — no Whisper,
+no IPA — written to ``tiers.ortho_words``. These tests stub
+``ai.forced_align.align_segments`` so they stay hermetic (no torch, no
+real model) and verify:
+
+  - dispatch through ``_run_compute_job`` for ``"boundaries"`` and aliases
+  - missing STT cache produces a clear error
+  - manuallyAdjusted=True intervals survive a re-run by default
+  - aligned words overlapping a manual interval are dropped
+  - overwrite=True discards even manual edits
+  - generated intervals always carry manuallyAdjusted=False
+"""
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server  # noqa: E402
+
+
+def _seed_annotation(tmp_path, speaker, ortho_words=None, source_audio="raw/Fail02.wav"):
+    annotations_dir = tmp_path / "annotations"
+    annotations_dir.mkdir(exist_ok=True)
+    tiers = {
+        "ipa":     {"type": "interval", "display_order": 1, "intervals": []},
+        "ortho":   {"type": "interval", "display_order": 2, "intervals": []},
+        "concept": {"type": "interval", "display_order": 3, "intervals": []},
+        "speaker": {"type": "interval", "display_order": 4, "intervals": []},
+    }
+    if ortho_words is not None:
+        tiers["ortho_words"] = {
+            "type": "interval", "display_order": 5, "intervals": ortho_words,
+        }
+    annotation = {
+        "version": 1,
+        "project_id": "t",
+        "speaker": speaker,
+        "source_audio": source_audio,
+        "source_audio_duration_sec": 10.0,
+        "tiers": tiers,
+        "metadata": {
+            "language_code": "sdh",
+            "created": "2026-01-01T00:00:00Z",
+            "modified": "2026-01-01T00:00:00Z",
+        },
+    }
+    (annotations_dir / f"{speaker}.parse.json").write_text(
+        json.dumps(annotation), encoding="utf-8",
+    )
+    return annotation
+
+
+def _write_fake_source_wav(tmp_path, rel_path):
+    path = tmp_path / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfake")
+    return path
+
+
+def _write_stt_cache(tmp_path, speaker, segments):
+    """Drop a coarse_transcripts/<speaker>.json so _read_stt_cache finds it."""
+    cache_dir = tmp_path / "coarse_transcripts"
+    cache_dir.mkdir(exist_ok=True)
+    payload = {
+        "speaker": speaker,
+        "source_wav": "raw/{0}.wav".format(speaker),
+        "language": "ku",
+        "segments": segments,
+    }
+    (cache_dir / f"{speaker}.json").write_text(
+        json.dumps(payload), encoding="utf-8",
+    )
+
+
+def _load_canonical(tmp_path, speaker):
+    return json.loads((tmp_path / "annotations" / f"{speaker}.parse.json").read_text("utf-8"))
+
+
+def _install_align_stub(monkeypatch, fake_aligned):
+    """Stub ai.forced_align.align_segments to return a fixed result."""
+    import ai.forced_align as fa
+
+    def _fake(audio_path, segments, **kwargs):
+        return fake_aligned
+
+    monkeypatch.setattr(fa, "align_segments", _fake)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: empty ortho_words -> populated from forced alignment
+# ---------------------------------------------------------------------------
+
+def test_writes_ortho_words_from_stt_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+
+    segments = [
+        {
+            "start": 0.0, "end": 2.0, "text": "بەش سەرە",
+            "words": [
+                {"word": "بەش", "start": 0.05, "end": 0.55, "prob": 0.95},
+                {"word": "سەرە", "start": 0.60, "end": 1.20, "prob": 0.90},
+            ],
+        },
+    ]
+    aligned = [[
+        {"word": "بەش", "start": 0.08, "end": 0.52, "confidence": 0.97,
+         "method": "wav2vec2"},
+        {"word": "سەرە", "start": 0.62, "end": 1.18, "confidence": 0.93,
+         "method": "wav2vec2"},
+    ]]
+    _install_align_stub(monkeypatch, aligned)
+
+    _seed_annotation(tmp_path, "Fail02")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+    _write_stt_cache(tmp_path, "Fail02", segments)
+
+    result = server._compute_speaker_boundaries("j1", {"speaker": "Fail02"})
+    assert result["generated"] == 2
+    assert result["preserved_manual"] == 0
+    assert result["total"] == 2
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    words = ann["tiers"]["ortho_words"]["intervals"]
+    assert [iv["text"] for iv in words] == ["بەش", "سەرە"]
+    assert words[0]["start"] == pytest.approx(0.08)
+    assert words[0]["end"] == pytest.approx(0.52)
+    assert words[0]["source"] == "forced_align"
+    # Generated intervals must carry manuallyAdjusted=False — the on-disk
+    # contract requires the flag to be present (not absent) so downstream
+    # code can branch unambiguously.
+    assert words[0]["manuallyAdjusted"] is False
+    assert words[1]["manuallyAdjusted"] is False
+
+
+# ---------------------------------------------------------------------------
+# Error: no STT cache -> raise with a guidance message the UI can show
+# ---------------------------------------------------------------------------
+
+def test_raises_when_no_stt_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    _seed_annotation(tmp_path, "Fail02")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+    # No coarse_transcripts/Fail02.json on disk
+
+    with pytest.raises(RuntimeError, match="Run STT first"):
+        server._compute_speaker_boundaries("j1", {"speaker": "Fail02"})
+
+
+def test_raises_when_stt_cache_has_no_word_timestamps(tmp_path, monkeypatch):
+    """Whisper without word_timestamps=True caches segments with no
+    words[]; forced alignment can't seed off that, so we error early
+    instead of silently returning an empty BND."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    segments = [{"start": 0.0, "end": 2.0, "text": "no words here"}]
+    _seed_annotation(tmp_path, "Fail02")
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+    _write_stt_cache(tmp_path, "Fail02", segments)
+
+    with pytest.raises(RuntimeError, match="Run STT first"):
+        server._compute_speaker_boundaries("j1", {"speaker": "Fail02"})
+
+
+# ---------------------------------------------------------------------------
+# manuallyAdjusted preservation
+# ---------------------------------------------------------------------------
+
+def test_preserves_manually_adjusted_intervals(tmp_path, monkeypatch):
+    """A re-run must keep `manuallyAdjusted=True` intervals verbatim and
+    drop any aligned word that would overlap them — manual edits anchor
+    their slice of the timeline."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+
+    segments = [
+        {
+            "start": 0.0, "end": 2.0, "text": "a b c",
+            "words": [
+                {"word": "a", "start": 0.0, "end": 0.5, "prob": 0.9},
+                {"word": "b", "start": 0.5, "end": 1.0, "prob": 0.9},
+                {"word": "c", "start": 1.0, "end": 1.5, "prob": 0.9},
+            ],
+        },
+    ]
+    # Aligner returns fresh boundaries for all three words; only "b"
+    # overlaps the user's manual interval at 0.45-1.05 and must be
+    # dropped. "a" ends before 0.45, "c" starts after 1.05.
+    aligned = [[
+        {"word": "a", "start": 0.02, "end": 0.40, "confidence": 0.95},
+        {"word": "b", "start": 0.50, "end": 0.95, "confidence": 0.92},
+        {"word": "c", "start": 1.10, "end": 1.45, "confidence": 0.93},
+    ]]
+    _install_align_stub(monkeypatch, aligned)
+
+    manual = [
+        {"start": 0.45, "end": 1.05, "text": "user-edited",
+         "manuallyAdjusted": True},
+    ]
+    _seed_annotation(tmp_path, "Fail02", ortho_words=manual)
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+    _write_stt_cache(tmp_path, "Fail02", segments)
+
+    result = server._compute_speaker_boundaries("j1", {"speaker": "Fail02"})
+    assert result["preserved_manual"] == 1
+    assert result["generated"] == 2  # "a" and "c" — "b" dropped (overlap)
+    assert result["total"] == 3
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    words = ann["tiers"]["ortho_words"]["intervals"]
+    by_text = {iv["text"]: iv for iv in words}
+    assert by_text["user-edited"]["manuallyAdjusted"] is True
+    assert by_text["user-edited"]["start"] == pytest.approx(0.45)
+    assert by_text["a"]["manuallyAdjusted"] is False
+    assert by_text["c"]["manuallyAdjusted"] is False
+    assert "b" not in by_text  # overlap with manual interval -> dropped
+
+
+def test_overwrite_true_discards_manual_intervals(tmp_path, monkeypatch):
+    """Explicit overwrite=True is the escape hatch — it ignores the
+    manuallyAdjusted flag and rebuilds the entire BND lane from the
+    aligner output."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+
+    segments = [
+        {
+            "start": 0.0, "end": 2.0, "text": "a",
+            "words": [{"word": "a", "start": 0.0, "end": 0.5, "prob": 0.9}],
+        },
+    ]
+    aligned = [[
+        {"word": "a", "start": 0.02, "end": 0.45, "confidence": 0.95},
+    ]]
+    _install_align_stub(monkeypatch, aligned)
+
+    manual = [
+        {"start": 0.4, "end": 1.1, "text": "user-edited",
+         "manuallyAdjusted": True},
+    ]
+    _seed_annotation(tmp_path, "Fail02", ortho_words=manual)
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+    _write_stt_cache(tmp_path, "Fail02", segments)
+
+    result = server._compute_speaker_boundaries(
+        "j1", {"speaker": "Fail02", "overwrite": True},
+    )
+    assert result["preserved_manual"] == 0
+    assert result["generated"] == 1
+    assert result["total"] == 1
+
+    ann = _load_canonical(tmp_path, "Fail02")
+    words = ann["tiers"]["ortho_words"]["intervals"]
+    assert [iv["text"] for iv in words] == ["a"]
+    assert words[0]["manuallyAdjusted"] is False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("alias", ["boundaries", "bnd", "ortho_words", "ortho-words"])
+def test_run_compute_job_dispatches_boundaries(tmp_path, monkeypatch, alias):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+
+    segments = [
+        {
+            "start": 0.0, "end": 1.0, "text": "a",
+            "words": [{"word": "a", "start": 0.0, "end": 0.5, "prob": 0.9}],
+        },
+    ]
+    aligned = [[{"word": "a", "start": 0.0, "end": 0.5, "confidence": 0.9}]]
+    _install_align_stub(monkeypatch, aligned)
+
+    speaker = "Disp_{0}".format(alias.replace("-", "_"))
+    _seed_annotation(tmp_path, speaker, source_audio="raw/{0}.wav".format(speaker))
+    _write_fake_source_wav(tmp_path, "raw/{0}.wav".format(speaker))
+    _write_stt_cache(tmp_path, speaker, segments)
+
+    captured: dict = {}
+
+    def fake_complete(job_id, result, **kwargs):
+        captured["result"] = result
+
+    def fake_error(job_id, err):
+        captured["error"] = err
+
+    monkeypatch.setattr(server, "_set_job_complete", fake_complete)
+    monkeypatch.setattr(server, "_set_job_error", fake_error)
+
+    server._run_compute_job("j-{0}".format(alias), alias, {"speaker": speaker})
+    assert "error" not in captured, captured
+    assert captured["result"]["generated"] == 1

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2150,6 +2150,27 @@ export function ParseUI() {
   const [speakerPicker, setSpeakerPicker] = useState<string | null>(null);
   const [computeMode, setComputeMode] = useState('cognates');
   const { start: startComputeJob, state: computeJobState, reset: resetComputeJob } = useComputeJob(computeMode);
+  // Standalone BND job — Tier 2 forced alignment only, no Whisper/IPA.
+  // Lives outside `useComputeJob` because it needs to forward the active
+  // speaker in the request body and reload that speaker's annotation on
+  // completion so the Boundaries lane re-renders without a manual refresh.
+  const [boundariesSpeaker, setBoundariesSpeaker] = useState<string | null>(null);
+  const boundariesJob = useActionJob({
+    start: () => {
+      if (!boundariesSpeaker) {
+        return Promise.reject(new Error('Pick a speaker before refining boundaries.'));
+      }
+      return startCompute('boundaries', { speaker: boundariesSpeaker });
+    },
+    poll: (jobId) => pollCompute('boundaries', jobId),
+    label: 'Refining word boundaries…',
+    onComplete: async () => {
+      if (boundariesSpeaker) {
+        await useAnnotationStore.getState().loadSpeaker(boundariesSpeaker);
+      }
+    },
+    autoDismissMs: 4000,
+  });
   const [clefModalOpen, setClefModalOpen] = useState(false);
   // Sources Report modal — shows provider attribution for every populated
   // reference form. Opened from the Compute panel's CLEF status row; read-
@@ -4581,6 +4602,64 @@ export function ParseUI() {
                   )}
 
                   <TranscriptionLanesControls/>
+
+                  {/* --- BND (Boundaries) standalone refresh ------------- */}
+                  {/* Forced-align only: fast, no Whisper/IPA. Run this to
+                       check and hand-correct boundaries before paying for
+                       the slow ORTH/IPA passes. Existing manuallyAdjusted
+                       intervals on the BND lane are preserved by the
+                       backend; aligned words overlapping them are dropped. */}
+                  <div className="mb-2">
+                    <button
+                      data-testid="phonetic-refine-boundaries"
+                      onClick={() => {
+                        const speaker = selectedSpeakers[0] ?? null;
+                        if (!speaker) return;
+                        setBoundariesSpeaker(speaker);
+                        // useActionJob.run() reads boundariesSpeaker on the
+                        // next render via the start() closure; the state
+                        // setter above runs synchronously before run() since
+                        // React batches inside the click handler.
+                        void boundariesJob.run();
+                      }}
+                      disabled={
+                        !selectedSpeakers[0] || boundariesJob.state.status === 'running'
+                      }
+                      title="Run fast boundary refinement independently. Useful before running slow ORTH/IPA models."
+                      className="flex w-full items-center gap-2 rounded-md bg-amber-50 px-2.5 py-1.5 text-[11px] font-semibold text-amber-800 ring-1 ring-amber-200 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Scissors className="h-3.5 w-3.5"/>
+                      <span className="flex-1 text-left">
+                        {boundariesJob.state.status === 'running'
+                          ? 'Refining boundaries…'
+                          : 'Refine Boundaries (BND)'}
+                      </span>
+                      {boundariesJob.state.status === 'running' && (
+                        <span className="rounded bg-white/70 px-1 font-mono text-[9px] text-amber-700">
+                          {Math.round(boundariesJob.state.progress * 100)}%
+                        </span>
+                      )}
+                    </button>
+                    {boundariesJob.state.status === 'running'
+                      && boundariesJob.state.etaMs !== null
+                      && boundariesJob.state.etaMs > 0 && (
+                      <div className="mt-1 text-[10px] text-amber-700">
+                        ~{formatEta(boundariesJob.state.etaMs)} left
+                      </div>
+                    )}
+                    {boundariesJob.state.status === 'complete' && (
+                      <div className="mt-1 text-[10px] text-emerald-700">
+                        Boundaries refreshed.
+                      </div>
+                    )}
+                    {boundariesJob.state.status === 'error' && (
+                      <div className="mt-1 text-[10px] text-rose-700">
+                        {boundariesJob.state.error?.includes('Run STT first')
+                          ? 'Please run STT first before refining boundaries.'
+                          : (boundariesJob.state.error ?? 'Boundary refinement failed.')}
+                      </div>
+                    )}
+                  </div>
 
                   <button className="mb-1.5 flex w-full items-center gap-2 rounded-md bg-indigo-50 px-2.5 py-1.5 text-[11px] font-semibold text-indigo-800 ring-1 ring-indigo-200 hover:bg-indigo-100">
                     <Layers className="h-3.5 w-3.5"/>


### PR DESCRIPTION
## Summary
- The BND lane (`tiers.ortho_words`) was only generated as a side-effect of the full ORTH/IPA pipeline. Users couldn't iterate on word boundaries without re-running the slow Whisper/wav2vec2 chain.
- This adds BND as an independent fast lane: a new `compute_boundaries` job that runs Tier 2 forced alignment only — no Whisper, no IPA — plus a "Refine Boundaries (BND)" button in the right sidebar's Phonetic Tools section.

## Backend
- `_compute_speaker_boundaries(job_id, payload)` in `python/server.py`. Reads cached STT segments (`segments[].words[]`) as alignment seeds, runs `_ortho_tier2_align_to_words`, writes refined word boundaries to `tiers.ortho_words`.
- Wired into the existing dispatcher: `POST /api/compute/boundaries` (aliases: `bnd`, `ortho_words`, `ortho-words`). No new endpoint code — the generic `/api/compute/<type>` handler picks it up.
- `manuallyAdjusted=True` intervals are preserved across re-runs; aligned words overlapping a manual interval are dropped so user edits anchor their slice of the timeline. `overwrite=True` rebuilds the lane from scratch (the escape hatch).
- Generated intervals always carry `manuallyAdjusted=False`, matching the PR-197 on-disk normalization contract.
- Raises a clear "Run STT first" message when the STT cache has no word-level timestamps, so the UI can surface the next step.

## Frontend
- New button in `src/ParseUI.tsx` (Phonetic Tools section, just under `TranscriptionLanesControls`).
- Uses `useActionJob` directly (rather than `useComputeJob`) because BND needs to forward the active speaker in the body and reload only that speaker's annotation on completion — keeps the BND lane re-render snappy without a full project refetch.
- Inline progress %, ETA, completion banner, and a friendly error mapping for the no-STT-cache case.
- Tooltip: "Run fast boundary refinement independently. Useful before running slow ORTH/IPA models."

## Tests
- New `python/test_compute_speaker_boundaries.py` (9 cases): happy-path write, missing-STT-cache and missing-word-timestamps errors, `manuallyAdjusted` preservation incl. overlap-drop, `overwrite=True` override, and dispatch routing for all four compute_type aliases.
- Backend: 41 passed, 1 skipped across `test_compute_speaker_boundaries.py`, `test_compute_speaker_ipa.py`, `test_compute_speaker_ortho.py`, `test_compute_speaker_ortho_refine_lexemes.py`.
- Frontend: `tsc --noEmit` clean; full `vitest run` 284/284.

## Test plan
- [x] `python -m pytest python/test_compute_speaker_boundaries.py` — 9 passed
- [x] Adjacent ortho/ipa/refine_lexemes tests still green
- [x] `tsc --noEmit` clean; `vitest run` 284/284
- [ ] **Lucas**: select a speaker, click "Refine Boundaries (BND)" in Phonetic Tools, confirm BND lane refreshes within seconds without running ORTH/IPA
- [ ] **Lucas**: hand-edit a BND interval (sets `manuallyAdjusted=true`), re-click the button, confirm the manual interval survives and surrounding words realign around it
- [ ] **Lucas**: verify the "Run STT first" path on a speaker without an STT cache shows the inline guidance message
- [ ] **Lucas**: confirm the lane re-renders without a manual page refresh

## Notes / scope
- Single-speaker per click for now. The user-facing spec mentions "all speakers in the workspace" as a follow-up; that fits naturally on top of the existing `TranscriptionRunModal` batch flow and is intentionally out of scope here to keep this PR small and the button feel "lightweight and quick".
- MCP/OpenAPI exposure is also intentionally deferred — the new compute_type rides through the existing generic `/api/compute/<type>` surface, so MCP wrappers can be added in a follow-up without backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)