### PR TITLE
feat(stt): re-run STT using BND boundaries (boundary-constrained STT)

### DIFF
--- a/python/ai/provider.py
+++ b/python/ai/provider.py
@@ -1441,6 +1441,148 @@ class LocalWhisperProvider(AIProvider):
                     best_conf = conf
         return (" ".join(parts).strip(), float(best_conf))
 
+    def transcribe_segments_in_memory(
+        self,
+        audio_array: Any,
+        intervals: List[Tuple[float, float]],
+        *,
+        language: Optional[str] = None,
+        progress_callback: Optional[Callable[[float, int], None]] = None,
+        sample_rate: int = 16000,
+    ) -> List[SegmentWithWords]:
+        """Transcribe a list of ``(start_sec, end_sec)`` audio windows from
+        a preloaded mono-16kHz waveform, in global-timeline coordinates.
+
+        For each interval, this method slices ``audio_array`` (a torch
+        Tensor or numpy array of samples), runs faster-whisper with
+        ``word_timestamps=True``, and offsets the returned segment +
+        word ``start``/``end`` values by the interval's start time so
+        the output sits on the same timeline as the source audio.
+
+        No temporary files are written — slices are passed to the model
+        as numpy arrays. Intervals with ``end <= start`` or zero
+        intersection with the audio are skipped.
+
+        Returns a flat list of ``SegmentWithWords`` dicts sorted by
+        global start time. Output may legitimately overlap when input
+        intervals overlap; callers (e.g. boundary-constrained STT) get
+        to decide how to merge.
+        """
+        if audio_array is None or not intervals:
+            return []
+
+        # Normalize to numpy float32 once. faster-whisper accepts numpy
+        # arrays directly; converting torch tensors here keeps the slicing
+        # loop below allocation-free.
+        try:
+            import numpy as _np
+        except ImportError as exc:  # pragma: no cover - numpy ships with torch
+            raise RuntimeError(
+                "numpy is required for boundary-constrained STT"
+            ) from exc
+
+        if hasattr(audio_array, "numpy") and not isinstance(audio_array, _np.ndarray):
+            try:
+                audio_np = audio_array.detach().cpu().numpy()
+            except AttributeError:
+                audio_np = audio_array.numpy()
+        else:
+            audio_np = audio_array
+        audio_np = _np.ascontiguousarray(audio_np, dtype=_np.float32)
+        total_samples = int(audio_np.shape[0])
+        if total_samples <= 0:
+            return []
+
+        model = self._load_whisper_model()
+        selected_language = (language or self.language) or None
+
+        kwargs: Dict[str, Any] = {
+            "language": selected_language,
+            "beam_size": self.beam_size,
+            "task": self.task,
+            # Each slice is already a coherent utterance per the user's
+            # boundary edits — VAD and previous-text conditioning would
+            # only second-guess that decision.
+            "vad_filter": False,
+            "word_timestamps": True,
+            "condition_on_previous_text": False,
+        }
+        if self.compression_ratio_threshold is not None:
+            kwargs["compression_ratio_threshold"] = self.compression_ratio_threshold
+        if self.initial_prompt:
+            kwargs["initial_prompt"] = self.initial_prompt
+
+        segs_out: List[SegmentWithWords] = []
+        n = len(intervals)
+        for idx, (start_sec, end_sec) in enumerate(intervals):
+            try:
+                start_sec_f = float(start_sec)
+                end_sec_f = float(end_sec)
+            except (TypeError, ValueError):
+                continue
+            if end_sec_f <= start_sec_f:
+                continue
+            start_sample = max(0, int(round(start_sec_f * sample_rate)))
+            end_sample = min(total_samples, int(round(end_sec_f * sample_rate)))
+            if end_sample <= start_sample:
+                continue
+
+            window = audio_np[start_sample:end_sample]
+            try:
+                segs_iter, _info = model.transcribe(window, **kwargs)
+            except Exception as exc:
+                print(
+                    "[WARN] transcribe_segments_in_memory: interval {0:.2f}-{1:.2f}s failed: {2}".format(
+                        start_sec_f, end_sec_f, exc,
+                    ),
+                    file=sys.stderr,
+                )
+                continue
+
+            for segment in segs_iter:
+                local_start = float(_dict_or_attr(segment, "start", 0.0) or 0.0)
+                local_end = float(_dict_or_attr(segment, "end", local_start) or local_start)
+                text = str(_dict_or_attr(segment, "text", "") or "").strip()
+                avg_logprob = _dict_or_attr(segment, "avg_logprob", None)
+                # Offset back into the global timeline. Clamp to the
+                # interval bounds — faster-whisper occasionally emits
+                # end times slightly past the clip length.
+                global_start = start_sec_f + local_start
+                global_end = min(end_sec_f, start_sec_f + local_end)
+                if global_end < global_start:
+                    global_end = global_start
+
+                seg_dict: SegmentWithWords = {
+                    "start": global_start,
+                    "end": global_end,
+                    "text": text,
+                    "confidence": _confidence_from_logprob(avg_logprob),
+                }
+                words_local = _extract_word_spans(segment)
+                if words_local:
+                    words_global = []
+                    for w in words_local:
+                        try:
+                            w_start = float(w.get("start", 0.0) or 0.0)
+                            w_end = float(w.get("end", w_start) or w_start)
+                        except (TypeError, ValueError):
+                            continue
+                        words_global.append({
+                            **w,
+                            "start": start_sec_f + w_start,
+                            "end": min(end_sec_f, start_sec_f + w_end),
+                        })
+                    if words_global:
+                        seg_dict["words"] = words_global
+                segs_out.append(seg_dict)
+
+            if progress_callback is not None:
+                progress = ((idx + 1) / n) * 100.0
+                progress_callback(progress, idx + 1)
+
+        segs_out.sort(key=lambda s: (float(s.get("start", 0.0)), float(s.get("end", 0.0))))
+        return segs_out
+
 
 class OpenAIProvider(AIProvider):
     """OpenAI-backed provider for STT and IPA conversion."""

--- a/python/server.py
+++ b/python/server.py
@@ -1132,19 +1132,36 @@ def _stt_cache_path(speaker: str) -> pathlib.Path:
     return _project_root() / "coarse_transcripts" / "{0}.json".format(speaker)
 
 
-def _write_stt_cache(speaker: str, source_wav: str, language: Optional[str], segments: List[Dict[str, Any]]) -> None:
+def _write_stt_cache(
+    speaker: str,
+    source_wav: str,
+    language: Optional[str],
+    segments: List[Dict[str, Any]],
+    *,
+    source: Optional[str] = None,
+) -> None:
+    """Persist the STT result for a speaker.
+
+    ``source`` is an optional provenance marker written into the cache
+    payload alongside the segments — e.g. ``"boundary_constrained"`` for
+    the BND-anchored re-transcription job. Default ``None`` keeps the
+    legacy schema (no ``source`` key) for the standard STT flow so
+    existing readers stay byte-compatible.
+    """
     speaker_norm = str(speaker or "").strip()
     if not speaker_norm or not isinstance(segments, list) or not segments:
         return
     cache_path = _stt_cache_path(speaker_norm)
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
+        payload: Dict[str, Any] = {
             "speaker": speaker_norm,
             "source_wav": source_wav,
             "language": language,
             "segments": segments,
         }
+        if source:
+            payload["source"] = source
         with open(cache_path, "w", encoding="utf-8") as fh:
             json.dump(payload, fh, ensure_ascii=False)
     except OSError as exc:
@@ -4823,6 +4840,138 @@ def _compute_speaker_boundaries(job_id: str, payload: Dict[str, Any]) -> Dict[st
     }
 
 
+def _compute_speaker_retranscribe_with_boundaries(
+    job_id: str, payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Re-run STT using the user-corrected BND lane as authoritative
+    segment boundaries.
+
+    Reads ``tiers.ortho_words`` from the speaker's annotation, slices the
+    full audio in memory at those exact (start, end) windows, and runs
+    faster-whisper on each slice individually with
+    ``word_timestamps=True``. The model never sees the silences between
+    intervals and never gets to second-guess the user's segmentation —
+    that is the whole point of this job versus the standard STT run.
+
+    Per-slice segments are translated back into the global timeline and
+    written to ``coarse_transcripts/<speaker>.json`` with a top-level
+    ``source: "boundary_constrained"`` marker so downstream readers (and
+    the UI badge) can distinguish this output from a vanilla STT run.
+    The BND lane itself is never modified — boundary-constrained STT is
+    a re-transcription, not a re-segmentation.
+
+    Payload: ``{ "speaker": "Fail02", "language": "ku" }``. ``language``
+    is optional; ``None``/empty triggers faster-whisper auto-detect.
+    """
+    speaker = _normalize_speaker_id(payload.get("speaker"))
+    language_raw = payload.get("language")
+    language = str(language_raw).strip() if language_raw is not None else None
+    if not language:
+        language = None
+    print(
+        "[BND-STT] enter speaker={0} language={1!r}".format(speaker, language),
+        file=sys.stderr,
+        flush=True,
+    )
+
+    canonical_path = _project_root() / _annotation_record_relative_path(speaker)
+    legacy_path = _project_root() / _annotation_legacy_record_relative_path(speaker)
+    if canonical_path.is_file():
+        annotation_path = canonical_path
+    elif legacy_path.is_file():
+        annotation_path = legacy_path
+    else:
+        raise RuntimeError("No annotation found for speaker {0!r}".format(speaker))
+
+    annotation = _read_json_file(annotation_path, {})
+    if not isinstance(annotation, dict):
+        raise RuntimeError("Annotation is not a JSON object")
+
+    tiers = annotation.get("tiers") or {}
+    ortho_words_tier = tiers.get("ortho_words") if isinstance(tiers.get("ortho_words"), dict) else None
+    raw_intervals = list((ortho_words_tier or {}).get("intervals") or [])
+
+    intervals: List[Tuple[float, float]] = []
+    for iv in raw_intervals:
+        if not isinstance(iv, dict):
+            continue
+        try:
+            start_sec = float(iv.get("start", 0.0) or 0.0)
+            end_sec = float(iv.get("end", start_sec) or start_sec)
+        except (TypeError, ValueError):
+            continue
+        if end_sec <= start_sec:
+            continue
+        intervals.append((start_sec, end_sec))
+
+    if not intervals:
+        raise RuntimeError(
+            "No BND intervals available for {0!r}. Refine boundaries first "
+            "before re-running STT with boundary constraints.".format(speaker)
+        )
+
+    intervals.sort(key=lambda iv: (iv[0], iv[1]))
+
+    _set_job_progress(job_id, 5.0, message="Resolving audio")
+    audio_path = _pipeline_audio_path_for_speaker(speaker)
+
+    _set_job_progress(job_id, 10.0, message="Loading audio")
+    from ai.forced_align import _load_audio_mono_16k
+    audio_tensor = _load_audio_mono_16k(audio_path)
+
+    _set_job_progress(job_id, 15.0, message="Loading STT provider")
+    provider = get_stt_provider()
+    if not hasattr(provider, "transcribe_segments_in_memory"):
+        raise RuntimeError(
+            "Boundary-constrained STT requires a provider that supports "
+            "in-memory segment transcription (LocalWhisperProvider). The "
+            "active provider {0!r} does not.".format(type(provider).__name__)
+        )
+
+    n_intervals = len(intervals)
+
+    def _on_progress(pct: float, n_done: int) -> None:
+        # Map provider 0-100 to our 15-95 band so the leading "loading"
+        # phase isn't lost.
+        scaled = 15.0 + max(0.0, min(100.0, pct)) * 0.80
+        _set_job_progress(
+            job_id, scaled,
+            message="Re-transcribing {0}/{1}".format(n_done, n_intervals),
+        )
+
+    segments = provider.transcribe_segments_in_memory(
+        audio_tensor,
+        intervals,
+        language=language,
+        progress_callback=_on_progress,
+    )
+
+    _set_job_progress(job_id, 96.0, message="Writing STT cache")
+    _write_stt_cache(
+        speaker,
+        str(audio_path),
+        language,
+        segments,
+        source="boundary_constrained",
+    )
+
+    print(
+        "[BND-STT] speaker={0} intervals={1} segments={2}".format(
+            speaker, n_intervals, len(segments),
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+
+    return {
+        "speaker": speaker,
+        "language": language,
+        "boundary_intervals": n_intervals,
+        "segments_written": len(segments),
+        "source": "boundary_constrained",
+    }
+
+
 def _pipeline_audio_path_for_speaker(speaker: str) -> pathlib.Path:
     """Resolve the best audio file to feed a Whisper-family model for a speaker.
 
@@ -6152,6 +6301,14 @@ def _run_compute_job(job_id: str, compute_type: str, payload: Dict[str, Any]) ->
             result = _compute_training_job(job_id, payload)
         elif normalized_type == "stt":
             result = _compute_stt(job_id, payload)
+        elif normalized_type in {
+            "retranscribe_with_boundaries",
+            "retranscribe-with-boundaries",
+            "boundary_constrained_stt",
+            "boundary-constrained-stt",
+            "bnd_stt",
+        }:
+            result = _compute_speaker_retranscribe_with_boundaries(job_id, payload)
         elif normalized_type in {"offset_detect", "offset-detect"}:
             result = _compute_offset_detect(job_id, payload)
         elif normalized_type in {"offset_detect_from_pair", "offset-detect-from-pair"}:

--- a/python/test_compute_speaker_retranscribe_with_boundaries.py
+++ b/python/test_compute_speaker_retranscribe_with_boundaries.py
@@ -1,0 +1,342 @@
+"""Unit tests for _compute_speaker_retranscribe_with_boundaries.
+
+The boundary-constrained STT job re-runs faster-whisper on each
+``tiers.ortho_words`` interval individually, in memory, and writes the
+result to ``coarse_transcripts/<speaker>.json`` with a
+``source: "boundary_constrained"`` provenance marker. These tests stub
+the audio loader and a fake STT provider so they stay hermetic (no
+torch, no real model).
+
+Verified:
+  - happy path: BND intervals → provider receives them in order
+  - cache writes ``source: "boundary_constrained"`` and the merged segments
+  - error when ``tiers.ortho_words`` is missing or empty
+  - dispatch routing through ``_run_compute_job`` for all aliases
+  - provider lacking ``transcribe_segments_in_memory`` raises a clear error
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import server  # noqa: E402
+
+
+class _FakeAudioTensor:
+    """Minimal tensor stand-in. The provider stub never reads it; the
+    handler only needs ``_load_audio_mono_16k`` to return *something*."""
+
+    def numel(self) -> int:
+        return 16000 * 60  # 60s placeholder
+
+    @property
+    def shape(self) -> Tuple[int]:
+        return (16000 * 60,)
+
+
+class _StubSttProvider:
+    """Records the intervals + language passed in and returns a
+    deterministic global-time segment per interval so the handler's
+    cache-write path can be asserted."""
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def transcribe_segments_in_memory(
+        self,
+        audio_array: Any,
+        intervals: List[Tuple[float, float]],
+        *,
+        language: str | None = None,
+        progress_callback=None,
+        sample_rate: int = 16000,
+    ) -> List[Dict[str, Any]]:
+        self.calls.append({
+            "intervals": list(intervals),
+            "language": language,
+        })
+        if progress_callback is not None:
+            for i, _ in enumerate(intervals):
+                progress_callback(((i + 1) / len(intervals)) * 100.0, i + 1)
+        return [
+            {
+                "start": float(s),
+                "end": float(e),
+                "text": "seg_{0:.2f}".format(s),
+                "confidence": 0.9,
+                "words": [{"word": "w", "start": float(s), "end": float(e), "prob": 0.9}],
+            }
+            for s, e in intervals
+        ]
+
+
+class _LegacyProvider:
+    """Provider that lacks transcribe_segments_in_memory — the handler
+    must reject this with a clear error rather than crashing on attr
+    lookup."""
+
+    def transcribe(self, *args, **kwargs):
+        raise AssertionError("transcribe must not be called by BND-STT")
+
+
+def _seed_annotation(
+    tmp_path: pathlib.Path,
+    speaker: str,
+    ortho_words: List[Dict[str, Any]] | None,
+    source_audio: str = "raw/Fail02.wav",
+) -> None:
+    annotations_dir = tmp_path / "annotations"
+    annotations_dir.mkdir(exist_ok=True)
+    tiers: Dict[str, Any] = {
+        "ipa":     {"type": "interval", "display_order": 1, "intervals": []},
+        "ortho":   {"type": "interval", "display_order": 2, "intervals": []},
+        "concept": {"type": "interval", "display_order": 3, "intervals": []},
+        "speaker": {"type": "interval", "display_order": 4, "intervals": []},
+    }
+    if ortho_words is not None:
+        tiers["ortho_words"] = {
+            "type": "interval", "display_order": 5, "intervals": ortho_words,
+        }
+    annotation = {
+        "version": 1,
+        "project_id": "t",
+        "speaker": speaker,
+        "source_audio": source_audio,
+        "source_audio_duration_sec": 60.0,
+        "tiers": tiers,
+        "metadata": {
+            "language_code": "sdh",
+            "created": "2026-01-01T00:00:00Z",
+            "modified": "2026-01-01T00:00:00Z",
+        },
+    }
+    (annotations_dir / f"{speaker}.parse.json").write_text(
+        json.dumps(annotation), encoding="utf-8",
+    )
+
+
+def _write_fake_source_wav(tmp_path: pathlib.Path, rel: str) -> None:
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfake")
+
+
+def _read_cache(tmp_path: pathlib.Path, speaker: str) -> Dict[str, Any]:
+    return json.loads(
+        (tmp_path / "coarse_transcripts" / f"{speaker}.json").read_text("utf-8"),
+    )
+
+
+def _install_stubs(tmp_path: pathlib.Path, monkeypatch, provider) -> None:
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(server, "_set_job_progress", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "get_stt_provider", lambda: provider)
+    from ai import forced_align as fa
+    monkeypatch.setattr(fa, "_load_audio_mono_16k", lambda path: _FakeAudioTensor())
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_writes_boundary_constrained_cache(tmp_path, monkeypatch):
+    provider = _StubSttProvider()
+    _install_stubs(tmp_path, monkeypatch, provider)
+
+    ortho_words = [
+        {"start": 1.0, "end": 1.4, "text": "one"},
+        {"start": 2.0, "end": 2.6, "text": "two"},
+        {"start": 3.0, "end": 3.5, "text": "three"},
+    ]
+    _seed_annotation(tmp_path, "Fail02", ortho_words)
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_retranscribe_with_boundaries(
+        "j1", {"speaker": "Fail02", "language": "ku"},
+    )
+
+    assert result["speaker"] == "Fail02"
+    assert result["language"] == "ku"
+    assert result["boundary_intervals"] == 3
+    assert result["segments_written"] == 3
+    assert result["source"] == "boundary_constrained"
+
+    # Provider received the BND intervals in order, as (start, end) tuples,
+    # and the configured language.
+    assert len(provider.calls) == 1
+    assert provider.calls[0]["language"] == "ku"
+    assert provider.calls[0]["intervals"] == [(1.0, 1.4), (2.0, 2.6), (3.0, 3.5)]
+
+    # Cache contains the marker + the segments.
+    cache = _read_cache(tmp_path, "Fail02")
+    assert cache["source"] == "boundary_constrained"
+    assert cache["language"] == "ku"
+    assert cache["speaker"] == "Fail02"
+    assert len(cache["segments"]) == 3
+    assert [round(s["start"], 2) for s in cache["segments"]] == [1.0, 2.0, 3.0]
+
+
+def test_skips_zero_and_inverted_bnd_intervals(tmp_path, monkeypatch):
+    """The handler filters bad BND intervals before calling the provider —
+    zero-range and inverted spans never reach the model."""
+    provider = _StubSttProvider()
+    _install_stubs(tmp_path, monkeypatch, provider)
+
+    ortho_words = [
+        {"start": 1.0, "end": 1.0, "text": "zero"},   # zero-range
+        {"start": 2.0, "end": 1.5, "text": "inv"},     # inverted
+        {"start": 3.0, "end": 3.5, "text": "ok"},      # valid
+    ]
+    _seed_annotation(tmp_path, "Fail02", ortho_words)
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_retranscribe_with_boundaries(
+        "j1", {"speaker": "Fail02"},
+    )
+
+    assert result["boundary_intervals"] == 1
+    assert provider.calls[0]["intervals"] == [(3.0, 3.5)]
+
+
+def test_empty_language_becomes_none_for_auto_detect(tmp_path, monkeypatch):
+    """Empty / whitespace-only language must translate to None so the
+    provider falls back to auto-detect, mirroring the standard STT flow."""
+    provider = _StubSttProvider()
+    _install_stubs(tmp_path, monkeypatch, provider)
+
+    ortho_words = [{"start": 1.0, "end": 1.5, "text": "x"}]
+    _seed_annotation(tmp_path, "Fail02", ortho_words)
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    result = server._compute_speaker_retranscribe_with_boundaries(
+        "j1", {"speaker": "Fail02", "language": "  "},
+    )
+    assert result["language"] is None
+    assert provider.calls[0]["language"] is None
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+def test_raises_when_ortho_words_missing(tmp_path, monkeypatch):
+    provider = _StubSttProvider()
+    _install_stubs(tmp_path, monkeypatch, provider)
+
+    _seed_annotation(tmp_path, "Fail02", ortho_words=None)
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    with pytest.raises(RuntimeError, match="Refine boundaries first"):
+        server._compute_speaker_retranscribe_with_boundaries(
+            "j1", {"speaker": "Fail02"},
+        )
+
+    # No cache should have been written.
+    assert not (tmp_path / "coarse_transcripts" / "Fail02.json").exists()
+
+
+def test_raises_when_ortho_words_empty(tmp_path, monkeypatch):
+    provider = _StubSttProvider()
+    _install_stubs(tmp_path, monkeypatch, provider)
+
+    _seed_annotation(tmp_path, "Fail02", ortho_words=[])
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    with pytest.raises(RuntimeError, match="Refine boundaries first"):
+        server._compute_speaker_retranscribe_with_boundaries(
+            "j1", {"speaker": "Fail02"},
+        )
+
+
+def test_raises_when_provider_lacks_in_memory_method(tmp_path, monkeypatch):
+    """A provider that can't transcribe in memory (e.g. cloud-only
+    wrapper) must produce a clear error rather than a cryptic
+    AttributeError. This guards against silently regressing the
+    LocalWhisperProvider requirement."""
+    provider = _LegacyProvider()
+    _install_stubs(tmp_path, monkeypatch, provider)
+
+    _seed_annotation(tmp_path, "Fail02", [{"start": 0.0, "end": 1.0, "text": "x"}])
+    _write_fake_source_wav(tmp_path, "raw/Fail02.wav")
+
+    with pytest.raises(RuntimeError, match="in-memory segment transcription"):
+        server._compute_speaker_retranscribe_with_boundaries(
+            "j1", {"speaker": "Fail02"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("alias", [
+    "retranscribe_with_boundaries",
+    "retranscribe-with-boundaries",
+    "boundary_constrained_stt",
+    "boundary-constrained-stt",
+    "bnd_stt",
+])
+def test_run_compute_job_dispatches_all_aliases(tmp_path, monkeypatch, alias):
+    provider = _StubSttProvider()
+    _install_stubs(tmp_path, monkeypatch, provider)
+
+    speaker = "Disp_{0}".format(alias.replace("-", "_"))
+    _seed_annotation(
+        tmp_path, speaker,
+        [{"start": 0.0, "end": 1.0, "text": "x"}],
+        source_audio="raw/{0}.wav".format(speaker),
+    )
+    _write_fake_source_wav(tmp_path, "raw/{0}.wav".format(speaker))
+
+    captured: Dict[str, Any] = {}
+
+    def fake_complete(job_id, result, **kwargs):
+        captured["result"] = result
+
+    def fake_error(job_id, err):
+        captured["error"] = err
+
+    monkeypatch.setattr(server, "_set_job_complete", fake_complete)
+    monkeypatch.setattr(server, "_set_job_error", fake_error)
+
+    server._run_compute_job(f"j-{alias}", alias, {"speaker": speaker})
+    assert "error" not in captured, captured
+    assert captured["result"]["source"] == "boundary_constrained"
+
+
+# ---------------------------------------------------------------------------
+# Cache writer source-marker semantics
+# ---------------------------------------------------------------------------
+
+def test_write_stt_cache_omits_source_when_unset(tmp_path, monkeypatch):
+    """Backward-compat: a normal STT run that doesn't pass ``source`` must
+    not introduce the new key into the on-disk schema. Otherwise old
+    readers parsing the file as a strict struct would tip over on the
+    first vanilla STT run after the upgrade."""
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    server._write_stt_cache(
+        "Fail02", "raw/Fail02.wav", "ku",
+        [{"start": 0.0, "end": 1.0, "text": "hi"}],
+    )
+
+    cache = _read_cache(tmp_path, "Fail02")
+    assert "source" not in cache
+
+
+def test_write_stt_cache_emits_source_when_set(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_project_root", lambda: tmp_path)
+
+    server._write_stt_cache(
+        "Fail02", "raw/Fail02.wav", "ku",
+        [{"start": 0.0, "end": 1.0, "text": "hi"}],
+        source="boundary_constrained",
+    )
+
+    cache = _read_cache(tmp_path, "Fail02")
+    assert cache["source"] == "boundary_constrained"

--- a/python/test_transcribe_segments_in_memory.py
+++ b/python/test_transcribe_segments_in_memory.py
@@ -1,0 +1,211 @@
+"""Unit tests for LocalWhisperProvider.transcribe_segments_in_memory.
+
+This is the in-memory windowed transcribe path used by the BND-anchored
+re-transcription job. The tests stub faster-whisper's WhisperModel so
+they stay hermetic (no model download, no torch CUDA), and verify:
+
+  - one model.transcribe() call per (start, end) interval
+  - returned segments are offset back into the global timeline
+  - per-word start/end values are also offset
+  - zero-range and inverted intervals are skipped
+  - vad_filter is forced off + word_timestamps forced on, regardless of
+    what the provider config says, since each window is already a
+    coherent utterance per the user's BND edits
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from ai import provider as provider_module
+from ai.provider import LocalWhisperProvider
+
+
+class _StubWord:
+    def __init__(self, word: str, start: float, end: float, prob: float = 0.9) -> None:
+        self.word = word
+        self.start = start
+        self.end = end
+        self.probability = prob
+
+
+class _StubSegment:
+    def __init__(
+        self,
+        start: float,
+        end: float,
+        text: str,
+        words: List[_StubWord] | None = None,
+        avg_logprob: float = -0.3,
+    ) -> None:
+        self.start = start
+        self.end = end
+        self.text = text
+        self.avg_logprob = avg_logprob
+        if words is not None:
+            self.words = words
+
+
+class _StubInfo:
+    def __init__(self, duration: float = 1.0) -> None:
+        self.duration = duration
+
+
+class _RecordingWhisperModel:
+    """Records every transcribe() call. Returns a deterministic local-time
+    segment so the test can assert global-time offsetting works."""
+
+    calls: List[Dict[str, Any]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def transcribe(
+        self, audio: Any, **kwargs: Any,
+    ) -> Tuple[Any, _StubInfo]:
+        # Audio comes in as a numpy float32 array — record its length so
+        # the test can verify the slice was the expected duration.
+        n = int(np.asarray(audio).shape[0]) if audio is not None else 0
+        type(self).calls.append({"length": n, **kwargs})
+        # Local-time segment 0.10-0.40s with one word, mirroring what
+        # faster-whisper would emit for a sub-second clip.
+        seg = _StubSegment(
+            start=0.10, end=0.40, text="ok",
+            words=[_StubWord("ok", 0.12, 0.38, prob=0.9)],
+        )
+        return iter([seg]), _StubInfo()
+
+
+def _make_provider(tmp_path: pathlib.Path, monkeypatch: Any) -> LocalWhisperProvider:
+    _RecordingWhisperModel.calls = []
+    monkeypatch.setattr(
+        provider_module, "_register_cuda_dll_directories", lambda: None, raising=False,
+    )
+    import faster_whisper  # type: ignore
+    monkeypatch.setattr(faster_whisper, "WhisperModel", _RecordingWhisperModel, raising=True)
+    return LocalWhisperProvider(
+        config={"stt": {"language": ""}},
+        config_path=tmp_path / "ai_config.json",
+    )
+
+
+def test_one_model_call_per_interval(tmp_path, monkeypatch):
+    provider = _make_provider(tmp_path, monkeypatch)
+    audio = np.zeros(16000 * 5, dtype=np.float32)  # 5s of silence
+    intervals = [(0.5, 1.0), (2.0, 2.5), (3.0, 4.0)]
+
+    out = provider.transcribe_segments_in_memory(audio, intervals)
+
+    assert len(_RecordingWhisperModel.calls) == 3
+    # Slice lengths in samples (end-start)*16000
+    assert _RecordingWhisperModel.calls[0]["length"] == int(round(0.5 * 16000))
+    assert _RecordingWhisperModel.calls[1]["length"] == int(round(0.5 * 16000))
+    assert _RecordingWhisperModel.calls[2]["length"] == int(round(1.0 * 16000))
+
+    # Three input intervals → three output segments.
+    assert len(out) == 3
+
+
+def test_segments_offset_to_global_timeline(tmp_path, monkeypatch):
+    """Stub returns local 0.10-0.40s; the third interval starts at 3.0s
+    so the global segment must be 3.10-3.40s, not 0.10-0.40s."""
+    provider = _make_provider(tmp_path, monkeypatch)
+    audio = np.zeros(16000 * 5, dtype=np.float32)
+
+    out = provider.transcribe_segments_in_memory(audio, [(3.0, 4.0)])
+
+    assert len(out) == 1
+    seg = out[0]
+    assert seg["start"] == 3.10
+    assert seg["end"] == 3.40
+    assert seg["text"] == "ok"
+    # Word-level timestamps must also be offset.
+    assert "words" in seg
+    assert seg["words"][0]["start"] == 3.12
+    assert seg["words"][0]["end"] == 3.38
+
+
+def test_skips_zero_and_inverted_intervals(tmp_path, monkeypatch):
+    provider = _make_provider(tmp_path, monkeypatch)
+    audio = np.zeros(16000 * 5, dtype=np.float32)
+    intervals = [
+        (1.0, 1.0),   # zero range — skip
+        (2.0, 1.5),   # inverted — skip
+        (3.0, 3.5),   # valid
+    ]
+
+    out = provider.transcribe_segments_in_memory(audio, intervals)
+
+    assert len(_RecordingWhisperModel.calls) == 1
+    assert len(out) == 1
+
+
+def test_clamps_segment_end_to_interval_end(tmp_path, monkeypatch):
+    """faster-whisper sometimes returns end times slightly past the clip
+    length. The provider must clamp to the interval's end so the BND
+    boundary is never crossed in the global timeline."""
+    class _OvershootModel(_RecordingWhisperModel):
+        def transcribe(self, audio, **kwargs):
+            type(self).calls.append({"length": int(np.asarray(audio).shape[0]), **kwargs})
+            # Local end 0.6s for a 0.5s clip — overshoot.
+            seg = _StubSegment(start=0.0, end=0.6, text="x", words=[])
+            return iter([seg]), _StubInfo()
+
+    monkeypatch.setattr(
+        provider_module, "_register_cuda_dll_directories", lambda: None, raising=False,
+    )
+    import faster_whisper  # type: ignore
+    monkeypatch.setattr(faster_whisper, "WhisperModel", _OvershootModel, raising=True)
+    provider = LocalWhisperProvider(config={"stt": {}}, config_path=tmp_path / "x.json")
+
+    audio = np.zeros(16000, dtype=np.float32)  # 1s
+    out = provider.transcribe_segments_in_memory(audio, [(0.0, 0.5)])
+
+    assert len(out) == 1
+    assert out[0]["end"] == 0.5  # clamped to interval.end, not 0.6
+
+
+def test_kwargs_force_word_timestamps_and_disable_vad(tmp_path, monkeypatch):
+    """Each BND interval is already a coherent utterance per the user's
+    edit; VAD and previous-text conditioning would only second-guess
+    that decision. word_timestamps must be on so the BND lane can later
+    compare Tier 1 word boxes."""
+    provider = _make_provider(tmp_path, monkeypatch)
+    audio = np.zeros(16000, dtype=np.float32)
+    provider.transcribe_segments_in_memory(audio, [(0.0, 0.5)], language="ku")
+
+    assert _RecordingWhisperModel.calls[0]["word_timestamps"] is True
+    assert _RecordingWhisperModel.calls[0]["vad_filter"] is False
+    assert _RecordingWhisperModel.calls[0]["condition_on_previous_text"] is False
+    assert _RecordingWhisperModel.calls[0]["language"] == "ku"
+
+
+def test_empty_intervals_returns_empty(tmp_path, monkeypatch):
+    provider = _make_provider(tmp_path, monkeypatch)
+    audio = np.zeros(16000, dtype=np.float32)
+    assert provider.transcribe_segments_in_memory(audio, []) == []
+    assert _RecordingWhisperModel.calls == []
+
+
+def test_progress_callback_fires_per_interval(tmp_path, monkeypatch):
+    provider = _make_provider(tmp_path, monkeypatch)
+    audio = np.zeros(16000 * 3, dtype=np.float32)
+    intervals = [(0.0, 0.5), (1.0, 1.5), (2.0, 2.5)]
+
+    progress_calls: List[Tuple[float, int]] = []
+
+    def _on_progress(pct: float, n: int) -> None:
+        progress_calls.append((pct, n))
+
+    provider.transcribe_segments_in_memory(
+        audio, intervals, progress_callback=_on_progress,
+    )
+
+    assert len(progress_calls) == 3
+    assert progress_calls[-1][1] == 3
+    assert abs(progress_calls[-1][0] - 100.0) < 0.01

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2171,6 +2171,10 @@ export function ParseUI() {
     },
     autoDismissMs: 4000,
   });
+  // BND-constrained STT speaker placeholder — the actual job hook is
+  // declared further down, after `sttLanguageRef` exists so the start
+  // closure can forward the user's STT language without a TDZ dance.
+  const [bndSttSpeaker, setBndSttSpeaker] = useState<string | null>(null);
   const [clefModalOpen, setClefModalOpen] = useState(false);
   // Sources Report modal — shows provider attribution for every populated
   // reference form. Opened from the Compute panel's CLEF status row; read-
@@ -2384,6 +2388,35 @@ export function ParseUI() {
     try { localStorage.setItem('parse.stt.language', sttLanguage); }
     catch { /* storage unavailable */ }
   }, [sttLanguage]);
+
+  // Boundary-constrained STT — re-transcribe using the user's BND
+  // (tiers.ortho_words) as authoritative segment boundaries. Forwards
+  // the active speaker + STT language in the request body and reloads
+  // the STT cache + annotation on completion so the lane picks up the
+  // new "BND" badge without a full project refetch.
+  const bndSttJob = useActionJob({
+    start: () => {
+      if (!bndSttSpeaker) {
+        return Promise.reject(
+          new Error('Pick a speaker before re-transcribing with boundaries.'),
+        );
+      }
+      return startCompute('retranscribe_with_boundaries', {
+        speaker: bndSttSpeaker,
+        language: sttLanguageRef.current || undefined,
+      });
+    },
+    poll: (jobId) => pollCompute('retranscribe_with_boundaries', jobId),
+    label: 'Re-transcribing with BND…',
+    onComplete: async () => {
+      if (bndSttSpeaker) {
+        await useTranscriptionLanesStore.getState().reloadStt(bndSttSpeaker);
+        await useAnnotationStore.getState().loadSpeaker(bndSttSpeaker);
+      }
+    },
+    autoDismissMs: 4000,
+  });
+
   const activeActionSpeaker = selectedSpeakers[0] ?? null;
   const loadSpeaker = useAnnotationStore((s) => s.loadSpeaker);
   const loadEnrichments = useEnrichmentStore((s) => s.load);
@@ -4657,6 +4690,61 @@ export function ParseUI() {
                         {boundariesJob.state.error?.includes('Run STT first')
                           ? 'Please run STT first before refining boundaries.'
                           : (boundariesJob.state.error ?? 'Boundary refinement failed.')}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* --- BND-constrained STT re-transcription --------------- */}
+                  {/* Re-runs faster-whisper using tiers.ortho_words as
+                       authoritative segment windows — no auto-segmentation,
+                       no full pipeline. Reuses the same STT language input
+                       as the normal "Run STT" action. Distinct from the
+                       vanilla STT job; only this button writes the
+                       "boundary_constrained" provenance marker. */}
+                  <div className="mb-2">
+                    <button
+                      data-testid="phonetic-retranscribe-with-boundaries"
+                      onClick={() => {
+                        const speaker = selectedSpeakers[0] ?? null;
+                        if (!speaker) return;
+                        setBndSttSpeaker(speaker);
+                        void bndSttJob.run();
+                      }}
+                      disabled={
+                        !selectedSpeakers[0] || bndSttJob.state.status === 'running'
+                      }
+                      title="Re-run STT using the BND lane's word boundaries instead of letting Whisper segment from scratch. Useful after manually correcting boundaries."
+                      className="flex w-full items-center gap-2 rounded-md bg-amber-50 px-2.5 py-1.5 text-[11px] font-semibold text-amber-800 ring-1 ring-amber-200 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Mic className="h-3.5 w-3.5"/>
+                      <span className="flex-1 text-left">
+                        {bndSttJob.state.status === 'running'
+                          ? 'Re-transcribing with BND…'
+                          : 'Re-run STT with Boundaries'}
+                      </span>
+                      {bndSttJob.state.status === 'running' && (
+                        <span className="rounded bg-white/70 px-1 font-mono text-[9px] text-amber-700">
+                          {Math.round(bndSttJob.state.progress * 100)}%
+                        </span>
+                      )}
+                    </button>
+                    {bndSttJob.state.status === 'running'
+                      && bndSttJob.state.etaMs !== null
+                      && bndSttJob.state.etaMs > 0 && (
+                      <div className="mt-1 text-[10px] text-amber-700">
+                        ~{formatEta(bndSttJob.state.etaMs)} left
+                      </div>
+                    )}
+                    {bndSttJob.state.status === 'complete' && (
+                      <div className="mt-1 text-[10px] text-emerald-700">
+                        STT re-transcribed using BND boundaries.
+                      </div>
+                    )}
+                    {bndSttJob.state.status === 'error' && (
+                      <div className="mt-1 text-[10px] text-rose-700">
+                        {bndSttJob.state.error?.includes('No BND intervals')
+                          ? 'Refine boundaries (BND) first before re-running STT.'
+                          : (bndSttJob.state.error ?? 'BND-constrained STT failed.')}
                       </div>
                     )}
                   </div>

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -80,6 +80,12 @@ export interface SttSegmentsPayload {
   source_wav?: string;
   language?: string | null;
   segments: SttSegment[];
+  /** Provenance marker. Set to ``"boundary_constrained"`` when the cache
+   * was populated by the BND-anchored re-transcription job (which uses
+   * the user's edited tiers.ortho_words intervals as authoritative
+   * windows instead of letting Whisper segment from scratch). Absent
+   * for vanilla STT runs so the legacy on-disk shape is preserved. */
+  source?: string;
 }
 
 export interface ConceptEntry {

--- a/src/components/annotate/TranscriptionLanes.tsx
+++ b/src/components/annotate/TranscriptionLanes.tsx
@@ -50,6 +50,16 @@ interface LaneStrip {
   status?: "idle" | "loading" | "loaded" | "error";
   /** Custom empty-state message; falls back to a generic per-tier hint. */
   emptyHint?: string;
+  /** Provenance tag rendered next to the lane label (e.g. ``"BND"`` for
+   * STT cached by the boundary-constrained re-transcription job). The
+   * STT lane sets this when ``sttSourceBySpeaker[speaker] ===
+   * "boundary_constrained"`` so the user can tell at a glance whether
+   * the visible STT respects their BND edits or came from vanilla
+   * Whisper. */
+  sourceBadge?: string;
+  /** Tooltip explaining the source badge, used as the label cell's
+   * ``title`` attribute when ``sourceBadge`` is set. */
+  sourceBadgeTitle?: string;
 }
 
 // Lane order is hard-coded top-to-bottom and intentionally independent of
@@ -139,6 +149,7 @@ export function TranscriptionLanes({
   const lanes = useTranscriptionLanesStore((s) => s.lanes);
   const sttBySpeaker = useTranscriptionLanesStore((s) => s.sttBySpeaker);
   const sttStatus = useTranscriptionLanesStore((s) => s.sttStatus);
+  const sttSourceBySpeaker = useTranscriptionLanesStore((s) => s.sttSourceBySpeaker);
   const ensureStt = useTranscriptionLanesStore((s) => s.ensureStt);
   const selectedInterval = useTranscriptionLanesStore((s) => s.selectedInterval);
   const setSelectedInterval = useTranscriptionLanesStore((s) => s.setSelectedInterval);
@@ -434,6 +445,12 @@ export function TranscriptionLanes({
       // for legacy records that haven't been touched since the new tier
       // landed. Edits create the tier entry and from then on it wins.
       if (kind === "stt") {
+        const sttSource = sttSourceBySpeaker[speaker];
+        const isBoundaryConstrained = sttSource === "boundary_constrained";
+        const sourceBadge = isBoundaryConstrained ? "BND" : undefined;
+        const sourceBadgeTitle = isBoundaryConstrained
+          ? "STT was re-transcribed using your BND boundaries (boundary-constrained mode)."
+          : undefined;
         const tierIvs: AnnotationInterval[] = record?.tiers?.stt?.intervals ?? [];
         const hasTierStt = tierIvs.length > 0;
         if (hasTierStt) {
@@ -450,6 +467,8 @@ export function TranscriptionLanes({
             label: LANE_LABELS.stt,
             intervals: filtered,
             sourceIndices,
+            sourceBadge,
+            sourceBadgeTitle,
           });
         } else {
           // Pre-migration: STT sourced from the API cache. Emit identity
@@ -467,6 +486,8 @@ export function TranscriptionLanes({
             needsMigration: true,
             migrate: () => ensureSttTier(speaker, segs),
             status: sttStatus[speaker] ?? "idle",
+            sourceBadge,
+            sourceBadgeTitle,
           });
         }
         continue;
@@ -489,7 +510,7 @@ export function TranscriptionLanes({
       });
     }
     return out;
-  }, [lanes, sttBySpeaker, sttStatus, record, speaker]);
+  }, [lanes, sttBySpeaker, sttStatus, sttSourceBySpeaker, record, speaker]);
 
   const stripByKind = useCallback(
     (kind: LaneKind): LaneStrip | undefined => strips.find((s) => s.kind === kind),
@@ -597,11 +618,20 @@ export function TranscriptionLanes({
         return (
           <div key={strip.kind} className="relative flex items-stretch">
             <div
-              className="flex shrink-0 items-center justify-center border-r border-slate-100 text-[9px] font-semibold uppercase tracking-wider"
+              data-testid={`lane-label-${strip.kind}`}
+              className="flex shrink-0 flex-col items-center justify-center border-r border-slate-100 text-[9px] font-semibold uppercase tracking-wider"
               style={{ width: LABEL_COL_PX, color }}
-              title={`${strip.label} lane`}
+              title={strip.sourceBadgeTitle ?? `${strip.label} lane`}
             >
-              {strip.label}
+              <span>{strip.label}</span>
+              {strip.sourceBadge && (
+                <span
+                  data-testid={`lane-source-badge-${strip.kind}`}
+                  className="mt-0.5 rounded bg-amber-100 px-1 text-[7px] font-bold tracking-wider text-amber-800 ring-1 ring-amber-300"
+                >
+                  {strip.sourceBadge}
+                </span>
+              )}
             </div>
             <div className="relative flex-1 overflow-hidden" style={{ height: LANE_HEIGHT_PX }}>
               <div

--- a/src/stores/transcriptionLanesStore.ts
+++ b/src/stores/transcriptionLanesStore.ts
@@ -32,6 +32,12 @@ interface PersistedState {
 interface TranscriptionLanesStore extends PersistedState {
   sttBySpeaker: Record<string, SttSegment[]>;
   sttStatus: Record<string, "idle" | "loading" | "loaded" | "error">;
+  /** Provenance marker per speaker — currently only set to
+   * ``"boundary_constrained"`` by the BND-anchored re-transcription job.
+   * The STT lane reads this to render a small badge so the user can
+   * tell at a glance whether the visible STT was produced by vanilla
+   * Whisper or constrained to their BND edits. */
+  sttSourceBySpeaker: Record<string, string | undefined>;
   selectedInterval: SelectedInterval | null;
 
   toggleLane: (kind: LaneKind) => void;
@@ -89,14 +95,17 @@ async function fetchSttInto(
   try {
     const payload = await getSttSegments(speaker);
     const segments = Array.isArray(payload?.segments) ? payload.segments : [];
+    const source = typeof payload?.source === "string" ? payload.source : undefined;
     set((s) => ({
       sttBySpeaker: { ...s.sttBySpeaker, [speaker]: segments },
       sttStatus: { ...s.sttStatus, [speaker]: "loaded" },
+      sttSourceBySpeaker: { ...s.sttSourceBySpeaker, [speaker]: source },
     }));
   } catch {
     set((s) => ({
       sttBySpeaker: { ...s.sttBySpeaker, [speaker]: [] },
       sttStatus: { ...s.sttStatus, [speaker]: "error" },
+      sttSourceBySpeaker: { ...s.sttSourceBySpeaker, [speaker]: undefined },
     }));
   }
 }
@@ -107,6 +116,7 @@ export const useTranscriptionLanesStore = create<TranscriptionLanesStore>()(
       lanes: DEFAULT_LANES,
       sttBySpeaker: {},
       sttStatus: {},
+      sttSourceBySpeaker: {},
       selectedInterval: null,
 
       toggleLane: (kind) =>


### PR DESCRIPTION
## Summary
- After PR #224 landed editable BND boundaries (`tiers.ortho_words`), users still had no way to feed those edits back into STT — vanilla "Run STT" segments from scratch and ignores them. This adds an explicit, separate-from-vanilla path that re-transcribes a speaker while respecting their hand-corrected BND.
- The job is independent: normal "Run STT" keeps its current free-segmentation behaviour. Only the new "Re-run STT with Boundaries" button writes the `source: "boundary_constrained"` provenance marker.

## Backend
- **New provider method** `LocalWhisperProvider.transcribe_segments_in_memory(audio_array, intervals, language=...)` in `python/ai/provider.py`. Slices a preloaded torch/numpy waveform per `(start, end)` window, calls `model.transcribe()` directly on each numpy slice (no temp files), and offsets every returned segment + word `start`/`end` back into the global timeline. Forces `vad_filter=False`, `word_timestamps=True`, `condition_on_previous_text=False` per slice — each slice is already a coherent utterance per the user's edit. Clamps segment ends to interval bounds so a faster-whisper overshoot can't bleed past a BND edge.
- **New handler** `_compute_speaker_retranscribe_with_boundaries(job_id, payload)` in `python/server.py`. Reads `tiers.ortho_words`, loads audio once via `_load_audio_mono_16k`, fetches the STT provider, calls the new method, and writes the result to `coarse_transcripts/<speaker>.json` with a top-level `source: "boundary_constrained"` provenance marker. Errors clearly when BND is missing/empty ("Refine boundaries first…") or when the active provider lacks in-memory transcription.
- **Dispatcher**: routed under `/api/compute/retranscribe_with_boundaries` (aliases: `retranscribe-with-boundaries`, `boundary_constrained_stt`, `boundary-constrained-stt`, `bnd_stt`). No new endpoint code — the generic `/api/compute/<type>` handler picks it up.
- **`_write_stt_cache`** gained an optional `source` keyword arg. Vanilla STT runs don't pass it, so the legacy on-disk shape is byte-compatible — only the new job emits the `source` field. Tests cover both cases.

## Frontend
- **New "Re-run STT with Boundaries" button** in the Phonetic Tools section of the right sidebar (`src/ParseUI.tsx`). Honors the existing STT language input. Inline progress / ETA / completion / user-friendly error mapping for the no-BND case.
- **`/api/stt-segments/<speaker>`** already passes the cache dict through verbatim, so the new `source` field surfaces with no endpoint change. Frontend types (`SttSegmentsPayload.source?`) and the transcription-lanes store (`sttSourceBySpeaker`) track it.
- **STT lane label** renders a small amber "BND" badge (with explanatory tooltip) when the active speaker's STT was produced by the boundary-constrained job, so the user can tell at a glance whether the visible STT respects their edits.

## Tests
- `python/test_transcribe_segments_in_memory.py` (7 cases): one `model.transcribe` call per interval, global-timeline offsetting for segments + words, zero/inverted skip, end-clamping, kwarg forcing, empty-input short-circuit, progress callback fire.
- `python/test_compute_speaker_retranscribe_with_boundaries.py` (13 cases): happy-path cache write, BND filter semantics, empty-language → auto-detect, missing/empty BND error, legacy-provider rejection, dispatch routing for all 5 aliases, plus `_write_stt_cache` back-compat (no `source` key when unset, present when set).
- Backend: 20/20 new tests pass; adjacent compute_speaker_ipa / compute_speaker_ortho / run_stt_job tests still green. (Two pre-existing `test_stt_configurable_transcribe.py::test_ortho_*` failures on `origin/main` are unrelated to this PR — the same two fail on a clean checkout of `c2fb743`.)
- Frontend: `tsc --noEmit` clean; full `vitest run` 284/284.

## Test plan
- [x] `python -m pytest python/test_transcribe_segments_in_memory.py python/test_compute_speaker_retranscribe_with_boundaries.py` — 20/20
- [x] `tsc --noEmit` clean; `vitest run` 284/284
- [ ] **Lucas**: pick a speaker with refined BND, click "Re-run STT with Boundaries", confirm the STT lane re-renders with new text and the small amber **BND** badge appears next to the STT label
- [ ] **Lucas**: confirm a normal "Run STT" afterwards clears the BND badge (because the cache no longer carries `source: "boundary_constrained"`)
- [ ] **Lucas**: confirm the no-BND error path shows "Refine boundaries (BND) first before re-running STT."
- [ ] **Lucas**: confirm the STT language input is honored end-to-end (e.g. set `fa`, run, verify Persian transcription on the resulting segments)

## Notes / scope
- Single-speaker per click. Multi-speaker batch fits naturally on the existing `TranscriptionRunModal` flow as a follow-up.
- This PR depends on `LocalWhisperProvider` for the in-memory path. Cloud-only providers raise a clear error rather than silently downgrading; we can add a fallback (write each slice to a temp file) in a follow-up if Lucas wants the job to also work behind cloud Whisper.
- MCP/OpenAPI exposure intentionally deferred — the new compute_type rides through the existing generic surface, so wrappers can be added without backend changes.
- Browser-preview verification was skipped: the BND-STT end-to-end flow needs the live Python backend with faster-whisper + a real STT cache + audio + a populated `tiers.ortho_words`, which can't be reproduced from a static preview environment. The Lucas-side checks above cover the live-data verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)