### PR TITLE
feat(bnd-stt): MCP exposure + UI gate on tiers.ortho_words existence

### DIFF
--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -15,7 +15,8 @@ Tools exposed:
     stt_start, stt_status, pipeline_run, compute_status,
     stt_word_level_start, stt_word_level_status,
     forced_align_start, forced_align_status,
-    ipa_transcribe_acoustic_start, ipa_transcribe_acoustic_status
+    ipa_transcribe_acoustic_start, ipa_transcribe_acoustic_status,
+    retranscribe_with_boundaries_start, retranscribe_with_boundaries_status
   Offset alignment:
     detect_timestamp_offset, detect_timestamp_offset_from_pair,
     apply_timestamp_offset
@@ -1230,6 +1231,54 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             jobId: The job ID returned by ipa_transcribe_acoustic_start
         """
         result = tools.execute("ipa_transcribe_acoustic_status", {"jobId": jobId})
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def retranscribe_with_boundaries_start(
+        speaker: str,
+        language: Optional[str] = None,
+        dryRun: Optional[bool] = None,
+    ) -> str:
+        """Start a boundary-constrained STT job for a speaker.
+
+        Reads the speaker's BND lane (tiers.ortho_words) as authoritative
+        segment boundaries, slices the source audio in memory at each
+        (start, end) window, and runs faster-whisper independently on
+        every slice with word_timestamps=True. Per-segment results are
+        offset back into the global timeline and written to
+        coarse_transcripts/<speaker>.json with a top-level
+        source: "boundary_constrained" provenance marker.
+
+        This job is intentionally separate from stt_start — vanilla STT
+        remains independently runnable and is unaffected. Requires
+        tiers.ortho_words to already contain intervals; run
+        forced_align_start (or the Refine Boundaries (BND) UI button)
+        first if no BND data exists.
+
+        Args:
+            speaker: Speaker name
+            language: Optional ISO 639-1 code forwarded to faster-whisper.
+                Empty / omitted triggers auto-detect.
+            dryRun: Validate and describe the plan without launching the job
+        """
+        args: Dict[str, Any] = {"speaker": speaker}
+        if language is not None:
+            args["language"] = language
+        if dryRun is not None:
+            args["dryRun"] = dryRun
+        result = tools.execute("retranscribe_with_boundaries_start", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def retranscribe_with_boundaries_status(jobId: str) -> str:
+        """Read status of a boundary-constrained STT compute job.
+
+        Args:
+            jobId: The job ID returned by retranscribe_with_boundaries_start
+        """
+        result = tools.execute(
+            "retranscribe_with_boundaries_status", {"jobId": jobId},
+        )
         return json.dumps(result, indent=2, ensure_ascii=False)
 
     @mcp.tool()

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -128,19 +128,24 @@ def test_create_mcp_server_defaults_to_33_tools_without_config(tmp_path, monkeyp
     mcp_tools = asyncio.run(server.list_tools())
     tool_names = {tool.name for tool in mcp_tools}
 
-    assert len(mcp_tools) == 36
+    assert len(mcp_tools) == 38
     assert "mcp_get_exposure_mode" in tool_names
     assert "run_full_annotation_pipeline" in tool_names
     assert "prepare_compare_mode" in tool_names
     assert "export_complete_lingpy_dataset" in tool_names
+    # Boundary-constrained STT job control is part of the default MCP
+    # surface so external agents can drive the new flow without flipping
+    # `expose_all_tools`.
+    assert "retranscribe_with_boundaries_start" in tool_names
+    assert "retranscribe_with_boundaries_status" in tool_names
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is False
     assert payload["result"]["configSource"] is None
-    assert payload["result"]["mcpToolCount"] == 36
-    assert payload["result"]["parseChatToolCount"] == 50
+    assert payload["result"]["mcpToolCount"] == 38
+    assert payload["result"]["parseChatToolCount"] == 52
     assert payload["result"]["workflowToolCount"] == 3
 
 
@@ -161,14 +166,14 @@ def test_create_mcp_server_exposes_all_54_tools_when_enabled_in_config_dir(tmp_p
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
-    assert len(mcp_tools) == 54
+    assert len(mcp_tools) == 56
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is True
-    assert payload["result"]["mcpToolCount"] == 54
-    assert payload["result"]["parseChatToolCount"] == 50
+    assert payload["result"]["mcpToolCount"] == 56
+    assert payload["result"]["parseChatToolCount"] == 52
     assert payload["result"]["workflowToolCount"] == 3
 
 
@@ -187,7 +192,7 @@ def test_create_mcp_server_exposes_all_54_tools_when_enabled_in_root_config(tmp_
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
-    assert len(mcp_tools) == 54
+    assert len(mcp_tools) == 56
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
@@ -395,12 +400,123 @@ def test_stateful_job_starters_are_marked_stateful_with_project_preconditions(tm
         "stt_word_level_start",
         "forced_align_start",
         "ipa_transcribe_acoustic_start",
+        "retranscribe_with_boundaries_start",
         "audio_normalize_start",
     ]:
         spec = tools.tool_spec(tool_name)
         assert spec.mutability == "stateful_job"
         assert any(cond.id == "project_loaded" for cond in spec.preconditions)
         assert any(cond.kind == "job_state" for cond in spec.postconditions)
+
+
+def test_retranscribe_with_boundaries_start_dispatches_compute_job(tmp_path) -> None:
+    """The MCP wrapper must launch the canonical
+    ``retranscribe_with_boundaries`` compute_type, not an alias and not
+    the vanilla ``stt`` type. Mismatching here would silently route
+    through the standard STT job and bypass the in-memory BND slicing
+    path entirely — the whole reason this tool exists."""
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_start_compute(compute_type: str, payload: dict[str, object]) -> str:
+        calls.append((compute_type, dict(payload)))
+        return "job-bnd-stt"
+
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        start_compute_job=fake_start_compute,
+    )
+    payload = tools.execute(
+        "retranscribe_with_boundaries_start",
+        {"speaker": "Fail02", "language": "ku"},
+    )["result"]
+
+    assert calls == [(
+        "retranscribe_with_boundaries",
+        {"speaker": "Fail02", "language": "ku"},
+    )]
+    assert payload["jobId"] == "job-bnd-stt"
+    assert payload["status"] == "running"
+    assert payload["tier"] == "boundary_constrained_stt"
+    assert payload["speaker"] == "Fail02"
+    assert payload["language"] == "ku"
+
+
+def test_retranscribe_with_boundaries_start_omits_blank_language(tmp_path) -> None:
+    """An empty/whitespace-only language string must not be forwarded —
+    the backend handler treats it as auto-detect. Mirrors the standard
+    STT job's contract."""
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_start_compute(compute_type: str, payload: dict[str, object]) -> str:
+        calls.append((compute_type, dict(payload)))
+        return "job-bnd-stt"
+
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        start_compute_job=fake_start_compute,
+    )
+    tools.execute(
+        "retranscribe_with_boundaries_start",
+        {"speaker": "Fail02", "language": "   "},
+    )
+
+    # `language` must NOT appear in the forwarded payload.
+    assert calls == [("retranscribe_with_boundaries", {"speaker": "Fail02"})]
+
+
+def test_retranscribe_with_boundaries_start_dry_run_does_not_launch(tmp_path) -> None:
+    """dryRun=true must return a preview plan and skip the compute_job
+    callback entirely — the standard escape hatch for letting an agent
+    propose work before the user authorises a real run."""
+    calls: list[object] = []
+
+    def fake_start_compute(compute_type: str, payload: dict[str, object]) -> str:
+        calls.append((compute_type, payload))
+        return "job-bnd-stt"
+
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        start_compute_job=fake_start_compute,
+    )
+    payload = tools.execute(
+        "retranscribe_with_boundaries_start",
+        {"speaker": "Fail02", "dryRun": True},
+    )["result"]
+
+    assert payload["status"] == "dry_run"
+    assert payload["tool"] == "retranscribe_with_boundaries_start"
+    assert payload["plan"]["speaker"] == "Fail02"
+    assert calls == []
+
+
+def test_retranscribe_with_boundaries_status_reads_snapshot(tmp_path) -> None:
+    snapshot = {
+        "jobId": "job-bnd-stt",
+        "type": "retranscribe_with_boundaries",
+        "status": "complete",
+        "progress": 100.0,
+        "message": "done",
+        "result": {
+            "speaker": "Fail02",
+            "boundary_intervals": 12,
+            "segments_written": 12,
+            "source": "boundary_constrained",
+        },
+    }
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        get_job_snapshot=lambda job_id: snapshot,
+    )
+
+    payload = tools.execute(
+        "retranscribe_with_boundaries_status",
+        {"jobId": "job-bnd-stt"},
+    )["result"]
+
+    assert payload["jobId"] == "job-bnd-stt"
+    assert payload["status"] == "complete"
+    assert payload["tier"] == "boundary_constrained_stt"
+    assert payload["result"]["source"] == "boundary_constrained"
 
 
 def test_stt_start_supports_dry_run_preview(tmp_path) -> None:

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -57,6 +57,8 @@ DEFAULT_MCP_TOOL_NAMES = (
     "forced_align_status",
     "ipa_transcribe_acoustic_start",
     "ipa_transcribe_acoustic_status",
+    "retranscribe_with_boundaries_start",
+    "retranscribe_with_boundaries_status",
     "detect_timestamp_offset",
     "detect_timestamp_offset_from_pair",
     "apply_timestamp_offset",
@@ -815,6 +817,62 @@ class ParseChatTools:
             "ipa_transcribe_acoustic_status": ChatToolSpec(
                 name="ipa_transcribe_acoustic_status",
                 description="Read status/progress of an existing Tier 3 acoustic IPA job.",
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["jobId"],
+                    "properties": {
+                        "jobId": {"type": "string", "minLength": 1, "maxLength": 128},
+                    },
+                },
+            ),
+            # ── Boundary-constrained STT: re-transcribe using BND ─────
+            "retranscribe_with_boundaries_start": ChatToolSpec(
+                name="retranscribe_with_boundaries_start",
+                description=(
+                    "Start a boundary-constrained STT job for a speaker. "
+                    "Reads the speaker's BND lane (tiers.ortho_words) as "
+                    "authoritative segment boundaries, slices the source "
+                    "audio in memory at each (start, end) window, and runs "
+                    "faster-whisper independently on every slice with "
+                    "word_timestamps=True. Per-segment results are offset "
+                    "back into the global timeline and written to "
+                    "coarse_transcripts/<speaker>.json with a top-level "
+                    "source: \"boundary_constrained\" provenance marker. "
+                    "This is intentionally separate from stt_start — "
+                    "vanilla STT remains independently runnable. Requires "
+                    "tiers.ortho_words to already contain intervals; "
+                    "callers should run forced_align_start (or the "
+                    "Refine Boundaries (BND) UI button) first when no BND "
+                    "data exists. Returns a jobId for polling with "
+                    "retranscribe_with_boundaries_status."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["speaker"],
+                    "properties": {
+                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "language": {
+                            "type": "string",
+                            "minLength": 0,
+                            "maxLength": 8,
+                            "description": (
+                                "Optional ISO 639-1 language code forwarded "
+                                "to faster-whisper. Empty / omitted triggers "
+                                "auto-detect."
+                            ),
+                        },
+                        "dryRun": {"type": "boolean"},
+                    },
+                },
+            ),
+            "retranscribe_with_boundaries_status": ChatToolSpec(
+                name="retranscribe_with_boundaries_status",
+                description=(
+                    "Read status/progress of a boundary-constrained STT "
+                    "job started by retranscribe_with_boundaries_start."
+                ),
                 parameters={
                     "type": "object",
                     "additionalProperties": False,
@@ -2111,6 +2169,7 @@ class ParseChatTools:
             "stt_word_level_start",
             "forced_align_start",
             "ipa_transcribe_acoustic_start",
+            "retranscribe_with_boundaries_start",
             "audio_normalize_start",
         }
         if tool_name in stateful_job_tools:
@@ -2147,11 +2206,22 @@ class ParseChatTools:
                 ),
             )
 
+        if tool_name == "retranscribe_with_boundaries_start":
+            return (
+                _project_loaded_condition(),
+                _tool_condition(
+                    "ortho_words_intervals_present",
+                    "The requested speaker must already have non-empty tiers.ortho_words intervals — boundary-constrained STT slices the audio at those windows and has nothing to do without them.",
+                    kind=TOOL_CONDITION_KIND_PROJECT_STATE,
+                ),
+            )
+
         if tool_name in {
             "stt_status",
             "stt_word_level_status",
             "forced_align_status",
             "ipa_transcribe_acoustic_status",
+            "retranscribe_with_boundaries_status",
             "audio_normalize_status",
             "compute_status",
         }:
@@ -2203,6 +2273,7 @@ class ParseChatTools:
             "stt_word_level_start": "word_level_stt_job_started",
             "forced_align_start": "forced_alignment_job_started",
             "ipa_transcribe_acoustic_start": "acoustic_ipa_job_started",
+            "retranscribe_with_boundaries_start": "boundary_constrained_stt_job_started",
             "audio_normalize_start": "audio_normalize_job_started",
             "pipeline_run": "pipeline_job_started",
         }
@@ -2226,6 +2297,7 @@ class ParseChatTools:
             "enrichments_read",
             "forced_align_status",
             "ipa_transcribe_acoustic_status",
+            "retranscribe_with_boundaries_status",
             "jobs_list_active",
             "lexeme_notes_read",
             "parse_memory_read",
@@ -3037,6 +3109,75 @@ class ParseChatTools:
             args,
             expected_type="ipa_only",
             tier_label="tier3_acoustic_ipa",
+        )
+
+    def _tool_retranscribe_with_boundaries_start(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Start a boundary-constrained STT job (re-transcribe using BND).
+
+        Runs faster-whisper independently on each ``tiers.ortho_words``
+        window, in memory, and writes the merged segments to
+        ``coarse_transcripts/<speaker>.json`` with a top-level
+        ``source: "boundary_constrained"`` marker. Intentionally
+        separate from ``stt_start`` — the standard STT job remains
+        independently runnable and is unaffected by this tool.
+        """
+        speaker = self._normalize_speaker(args.get("speaker"))
+
+        language_raw = args.get("language")
+        language = str(language_raw).strip() if language_raw is not None else ""
+        # Empty string → omit so the backend handler picks up its
+        # auto-detect default. Mirrors the standard STT behaviour.
+
+        payload_body: Dict[str, Any] = {"speaker": speaker}
+        if language:
+            payload_body["language"] = language
+
+        if bool(args.get("dryRun", False)):
+            return {
+                "readOnly": True,
+                "previewOnly": True,
+                "status": "dry_run",
+                "tool": "retranscribe_with_boundaries_start",
+                "plan": payload_body,
+                "note": (
+                    "Dry run. Would launch the retranscribe_with_boundaries "
+                    "compute job, slicing the source audio at every "
+                    "tiers.ortho_words interval and running faster-whisper "
+                    "on each slice in memory. Writes the merged segments to "
+                    "coarse_transcripts/<speaker>.json with "
+                    "source: \"boundary_constrained\". The BND lane itself "
+                    "is never modified."
+                ),
+            }
+
+        if self._start_compute_job is None:
+            raise ChatToolExecutionError(
+                "Compute-job start callback is unavailable — wire ParseChatTools "
+                "with start_compute_job to enable boundary-constrained STT."
+            )
+
+        job_id = self._start_compute_job("retranscribe_with_boundaries", payload_body)
+
+        return {
+            "readOnly": True,
+            "previewOnly": True,
+            "jobId": job_id,
+            "status": "running",
+            "tier": "boundary_constrained_stt",
+            "speaker": speaker,
+            "language": language or None,
+            "message": (
+                "Boundary-constrained STT job started. Poll with "
+                "retranscribe_with_boundaries_status."
+            ),
+        }
+
+    def _tool_retranscribe_with_boundaries_status(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Read status of a boundary-constrained STT compute job."""
+        return self._generic_compute_status(
+            args,
+            expected_type="retranscribe_with_boundaries",
+            tier_label="boundary_constrained_stt",
         )
 
     def _generic_compute_status(

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -937,4 +937,71 @@ describe("Actions menu — transcription run flow", () => {
     // The coarse paragraph must NOT appear as the pre-filled value.
     expect(screen.queryByDisplayValue(COARSE_TEXT)).toBeNull();
   });
+
+  // ── BND-constrained STT button gating ────────────────────────────────
+  // The "Re-run STT with Boundaries" button has nothing to do without
+  // tiers.ortho_words intervals — clicking with an empty BND would just
+  // raise on the backend. These tests guard the disable gate so the
+  // foot-gun stays hidden behind a friendly tooltip until the user
+  // actually has BND data for the active speaker.
+
+  it("disables Re-run STT with Boundaries when the active speaker has no ortho_words intervals", async () => {
+    mockConfig = {
+      project_name: "PARSE",
+      language_code: "ku",
+      speakers: ["Fail01"],
+      concepts: [{ id: "1", label: "water" }],
+      audio_dir: "audio",
+      annotations_dir: "annotations",
+    };
+    // Speaker has STT/ortho but no ortho_words tier at all.
+    mockRecords = {
+      Fail01: makeRecord("Fail01", [
+        { conceptText: "water", ipa: "aw", ortho: "ئاو", start: 1, end: 2 },
+      ]),
+    };
+
+    render(<ParseUI />);
+    await switchToAnnotateMode();
+
+    const button = await screen.findByTestId("phonetic-retranscribe-with-boundaries");
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.getAttribute("title") ?? "").toMatch(/refine boundaries/i);
+  });
+
+  it("enables Re-run STT with Boundaries when the active speaker has ortho_words intervals", async () => {
+    mockConfig = {
+      project_name: "PARSE",
+      language_code: "ku",
+      speakers: ["Fail01"],
+      concepts: [{ id: "1", label: "water" }],
+      audio_dir: "audio",
+      annotations_dir: "annotations",
+    };
+    const base = makeRecord("Fail01", [
+      { conceptText: "water", ipa: "aw", ortho: "ئاو", start: 1, end: 2 },
+    ]);
+    mockRecords = {
+      Fail01: {
+        ...base,
+        tiers: {
+          ...base.tiers,
+          ortho_words: {
+            name: "ortho_words",
+            display_order: 4,
+            intervals: [
+              { start: 1.1, end: 1.4, text: "ئاو" },
+            ],
+          },
+        },
+      },
+    };
+
+    render(<ParseUI />);
+    await switchToAnnotateMode();
+
+    const button = await screen.findByTestId("phonetic-retranscribe-with-boundaries");
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+    expect(button.getAttribute("title") ?? "").toMatch(/respects your manual boundary corrections/i);
+  });
 });

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2749,6 +2749,16 @@ export function ParseUI() {
     return count;
   });
 
+  // BND interval count for the active speaker. Drives the "Re-run STT
+  // with Boundaries" button's enable gate — clicking with an empty
+  // tiers.ortho_words is a no-op the backend would reject anyway, so
+  // we hide the foot-gun behind a disabled state + a clear tooltip.
+  const bndIntervalCount = useAnnotationStore((s) => {
+    const speaker = selectedSpeakers[0] ?? null;
+    if (!speaker) return 0;
+    return s.records[speaker]?.tiers?.ortho_words?.intervals?.length ?? 0;
+  });
+
   // Briefly-flashed inline confirmation when the user captures an anchor
   // straight from the playback bar. Vanishes after a couple of seconds so
   // the chrome stays calm.
@@ -4711,9 +4721,17 @@ export function ParseUI() {
                         void bndSttJob.run();
                       }}
                       disabled={
-                        !selectedSpeakers[0] || bndSttJob.state.status === 'running'
+                        !selectedSpeakers[0]
+                        || bndIntervalCount === 0
+                        || bndSttJob.state.status === 'running'
                       }
-                      title="Re-run STT using the BND lane's word boundaries instead of letting Whisper segment from scratch. Useful after manually correcting boundaries."
+                      title={
+                        !selectedSpeakers[0]
+                          ? 'Select a speaker first.'
+                          : bndIntervalCount === 0
+                            ? 'No BND intervals yet for this speaker. Refine boundaries (Refine Boundaries (BND) above) before re-running STT.'
+                            : "Re-transcribe using the current BND boundaries. This respects your manual boundary corrections."
+                      }
                       className="flex w-full items-center gap-2 rounded-md bg-amber-50 px-2.5 py-1.5 text-[11px] font-semibold text-amber-800 ring-1 ring-amber-200 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Mic className="h-3.5 w-3.5"/>


### PR DESCRIPTION
## Why
PR [#240](https://github.com/ArdeleanLucas/PARSE/pull/240) shipped boundary-constrained STT end-to-end, but two spec items from the original prompt were deferred:

1. The "Re-run STT with Boundaries" button was always enabled — clicking on a speaker with no BND data fell through to a server-side error toast.
2. The new `retranscribe_with_boundaries` compute_type wasn't exposed via MCP, so external agents couldn't drive it.

This PR closes both gaps without touching the underlying handler or provider method (those already do the right thing).

## UI gate
- New `bndIntervalCount` selector reading `record.tiers.ortho_words.intervals.length` for the active speaker.
- The "Re-run STT with Boundaries" button is now disabled when the count is 0, with a tooltip explicitly pointing the user at the "Refine Boundaries (BND)" button right above.
- Two new vitest cases cover both branches of the gate (29 → 31 tests in `ParseUI.test.tsx`).

## MCP exposure
- `retranscribe_with_boundaries_start` + `retranscribe_with_boundaries_status` `ChatToolSpec` entries in `python/ai/chat_tools.py`, mirroring the `forced_align_start`/`ipa_transcribe_acoustic_start` pair.
- Registered in `DEFAULT_MCP_TOOL_NAMES` so external agents see them without flipping `expose_all_tools`.
- Proper mutability: `stateful_job` for start. Proper preconditions: project loaded + `ortho_words_intervals_present`. Proper postcondition: `boundary_constrained_stt_job_started` for start, `inspection_payload_returned` for status.
- Handlers `_tool_retranscribe_with_boundaries_{start,status}` dispatch the canonical `retranscribe_with_boundaries` compute_type — never an alias, never the vanilla `stt` type — so the in-memory BND slicing path is always taken.
- Matching `@mcp.tool()` wrappers in `python/adapters/mcp_adapter.py`, plus the tool list in the module docstring.
- `dryRun=true` returns a preview plan and skips the compute callback (standard escape hatch).

## Tests
- Backend: 5 new tests in `python/adapters/test_mcp_adapter.py` (canonical compute_type dispatch, blank-language omission, dryRun preview, status snapshot read, plus the existing `stateful_job_starters` test extended). Tool-count assertions bumped: defaults 36 → 38, all-tools 54 → 56, `parseChatToolCount` 50 → 52.
- Frontend: 2 new tests in `src/ParseUI.test.tsx` (button disabled with empty/missing BND, enabled with populated BND), plus tooltip text assertions.
- Backend sweep: 58 passed, 2 pre-existing `str | None` Python-3.10-syntax failures on origin/main (`test_stt_start_supports_dry_run_preview`, `test_audio_normalize_start_supports_dry_run_preview`) unrelated to this PR.
- Frontend: `tsc --noEmit` clean; `vitest run` 286/286 (was 284 before this PR).

## Test plan
- [x] `python -m pytest python/adapters/test_mcp_adapter.py -k 'retranscribe or stateful_job_starters'` — 5/5
- [x] `python -m pytest python/test_compute_speaker_retranscribe_with_boundaries.py python/test_transcribe_segments_in_memory.py` — still green
- [x] `tsc --noEmit` clean; `vitest run` 286/286
- [ ] **Lucas**: open Annotate mode on a speaker with no BND data, hover the "Re-run STT with Boundaries" button, confirm it's disabled with a tooltip pointing to "Refine Boundaries (BND)"
- [ ] **Lucas**: refine boundaries, confirm the button enables and the tooltip changes to the "respects your manual boundary corrections" form
- [ ] **Lucas**: from a connected MCP client (Claude Code, Cursor, etc.), call `retranscribe_with_boundaries_start` with a speaker name, confirm a jobId comes back; poll with `retranscribe_with_boundaries_status` until complete
- [ ] **Lucas**: dryRun=true should return a `status: "dry_run"` plan without launching anything

## Notes / scope
- **Source marker stays `boundary_constrained`** (snake_case) per merged PR #240 — renaming to `boundary-constrained` (hyphen, per the spec wording) would invalidate cache files already on disk and require coordinated reader updates in `_write_stt_cache`, `SttSegmentsPayload.source`, the lanes store, and the lane-badge match. Cosmetic, not load-bearing.
- Single-speaker per call. Multi-speaker batch fits on `TranscriptionRunModal` as a follow-up.
- Browser-preview verification skipped: the disabled-state gate is observable in principle, but exercising both states (empty vs populated BND) needs a live PARSE workspace + Python backend with annotations loaded — the preview can't synthesize a populated `tiers.ortho_words` from a static environment. The vitest gate test covers the same store contract end-to-end against the rendered button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)