### PR TITLE
feat(bnd): expose compute_boundaries via MCP + STT-existence gate

### DIFF
--- a/python/adapters/mcp_adapter.py
+++ b/python/adapters/mcp_adapter.py
@@ -15,6 +15,7 @@ Tools exposed:
     stt_start, stt_status, pipeline_run, compute_status,
     stt_word_level_start, stt_word_level_status,
     forced_align_start, forced_align_status,
+    compute_boundaries_start, compute_boundaries_status,
     ipa_transcribe_acoustic_start, ipa_transcribe_acoustic_status,
     retranscribe_with_boundaries_start, retranscribe_with_boundaries_status
   Offset alignment:
@@ -1196,6 +1197,57 @@ def create_mcp_server(project_root: Optional[str] = None) -> "FastMCP":
             jobId: The job ID returned by forced_align_start
         """
         result = tools.execute("forced_align_status", {"jobId": jobId})
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def compute_boundaries_start(
+        speaker: str,
+        overwrite: Optional[bool] = None,
+        dryRun: Optional[bool] = None,
+    ) -> str:
+        """Start a standalone BND (Boundaries) job for a speaker.
+
+        Runs Tier 2 forced alignment
+        (torchaudio.functional.forced_align against
+        facebook/wav2vec2-xlsr-53-espeak-cv-ft) on the speaker's cached
+        STT word timestamps and writes the refined word boundaries to
+        tiers.ortho_words. No Whisper rerun, no IPA — this is the fast
+        lane for iterating on word boundaries before paying for the
+        slow ORTH/IPA passes.
+
+        Distinct from forced_align_start (which writes a *.aligned.json
+        artifact instead of the BND tier) and from
+        retranscribe_with_boundaries_start (which feeds BND back into
+        faster-whisper). Existing tiers.ortho_words intervals flagged
+        manuallyAdjusted=True are preserved verbatim and anchor their
+        slice of the timeline; aligned words overlapping a manual
+        interval are dropped. Pass overwrite=true to discard manual
+        edits as well. Requires the speaker's STT cache to already
+        carry word-level timestamps — run stt_word_level_start first
+        if it doesn't.
+
+        Args:
+            speaker: Speaker name
+            overwrite: When true, discards manuallyAdjusted intervals
+                and rebuilds tiers.ortho_words fully (default: false)
+            dryRun: Validate and describe the plan without launching the job
+        """
+        args: Dict[str, Any] = {"speaker": speaker}
+        if overwrite is not None:
+            args["overwrite"] = overwrite
+        if dryRun is not None:
+            args["dryRun"] = dryRun
+        result = tools.execute("compute_boundaries_start", args)
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    @mcp.tool()
+    def compute_boundaries_status(jobId: str) -> str:
+        """Read status of a standalone BND compute job.
+
+        Args:
+            jobId: The job ID returned by compute_boundaries_start
+        """
+        result = tools.execute("compute_boundaries_status", {"jobId": jobId})
         return json.dumps(result, indent=2, ensure_ascii=False)
 
     @mcp.tool()

--- a/python/adapters/test_mcp_adapter.py
+++ b/python/adapters/test_mcp_adapter.py
@@ -128,7 +128,7 @@ def test_create_mcp_server_defaults_to_33_tools_without_config(tmp_path, monkeyp
     mcp_tools = asyncio.run(server.list_tools())
     tool_names = {tool.name for tool in mcp_tools}
 
-    assert len(mcp_tools) == 38
+    assert len(mcp_tools) == 40
     assert "mcp_get_exposure_mode" in tool_names
     assert "run_full_annotation_pipeline" in tool_names
     assert "prepare_compare_mode" in tool_names
@@ -138,14 +138,19 @@ def test_create_mcp_server_defaults_to_33_tools_without_config(tmp_path, monkeyp
     # `expose_all_tools`.
     assert "retranscribe_with_boundaries_start" in tool_names
     assert "retranscribe_with_boundaries_status" in tool_names
+    # Standalone BND (forced-align → tiers.ortho_words) is also default-
+    # exposed so an agent can iterate on word boundaries before paying
+    # for the slow ORTH/IPA passes.
+    assert "compute_boundaries_start" in tool_names
+    assert "compute_boundaries_status" in tool_names
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is False
     assert payload["result"]["configSource"] is None
-    assert payload["result"]["mcpToolCount"] == 38
-    assert payload["result"]["parseChatToolCount"] == 52
+    assert payload["result"]["mcpToolCount"] == 40
+    assert payload["result"]["parseChatToolCount"] == 54
     assert payload["result"]["workflowToolCount"] == 3
 
 
@@ -166,14 +171,14 @@ def test_create_mcp_server_exposes_all_54_tools_when_enabled_in_config_dir(tmp_p
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
-    assert len(mcp_tools) == 56
+    assert len(mcp_tools) == 58
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
     assert payload["ok"] is True
     assert payload["result"]["exposeAllTools"] is True
-    assert payload["result"]["mcpToolCount"] == 56
-    assert payload["result"]["parseChatToolCount"] == 52
+    assert payload["result"]["mcpToolCount"] == 58
+    assert payload["result"]["parseChatToolCount"] == 54
     assert payload["result"]["workflowToolCount"] == 3
 
 
@@ -192,7 +197,7 @@ def test_create_mcp_server_exposes_all_54_tools_when_enabled_in_root_config(tmp_
     monkeypatch.delenv("PARSE_PROJECT_ROOT", raising=False)
     server = create_mcp_server(str(tmp_path))
     mcp_tools = asyncio.run(server.list_tools())
-    assert len(mcp_tools) == 56
+    assert len(mcp_tools) == 58
 
     _, meta = asyncio.run(server.call_tool("mcp_get_exposure_mode", {}))
     payload = json.loads(meta["result"])
@@ -399,6 +404,7 @@ def test_stateful_job_starters_are_marked_stateful_with_project_preconditions(tm
         "stt_start",
         "stt_word_level_start",
         "forced_align_start",
+        "compute_boundaries_start",
         "ipa_transcribe_acoustic_start",
         "retranscribe_with_boundaries_start",
         "audio_normalize_start",
@@ -517,6 +523,136 @@ def test_retranscribe_with_boundaries_status_reads_snapshot(tmp_path) -> None:
     assert payload["status"] == "complete"
     assert payload["tier"] == "boundary_constrained_stt"
     assert payload["result"]["source"] == "boundary_constrained"
+
+
+# ── compute_boundaries_start / _status (standalone BND) ─────────────────
+
+
+def test_compute_boundaries_start_dispatches_canonical_compute_type(tmp_path) -> None:
+    """The MCP wrapper must launch the canonical ``boundaries`` compute_type
+    so the dispatcher routes to ``_compute_speaker_boundaries`` (which writes
+    tiers.ortho_words). Routing through ``forced_align`` instead would write
+    a *.aligned.json artifact and never touch the BND lane — silently wrong."""
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_start_compute(compute_type: str, payload: dict[str, object]) -> str:
+        calls.append((compute_type, dict(payload)))
+        return "job-bnd"
+
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        start_compute_job=fake_start_compute,
+    )
+    payload = tools.execute(
+        "compute_boundaries_start",
+        {"speaker": "Fail02"},
+    )["result"]
+
+    assert calls == [("boundaries", {"speaker": "Fail02", "overwrite": False})]
+    assert payload["jobId"] == "job-bnd"
+    assert payload["status"] == "running"
+    assert payload["tier"] == "tier2_boundaries_only"
+    assert payload["speaker"] == "Fail02"
+    assert payload["overwrite"] is False
+
+
+def test_compute_boundaries_start_forwards_overwrite_flag(tmp_path) -> None:
+    """overwrite=true must reach the backend so manual edits get rebuilt."""
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_start_compute(compute_type: str, payload: dict[str, object]) -> str:
+        calls.append((compute_type, dict(payload)))
+        return "job-bnd"
+
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        start_compute_job=fake_start_compute,
+    )
+    tools.execute(
+        "compute_boundaries_start",
+        {"speaker": "Fail02", "overwrite": True},
+    )
+
+    assert calls == [("boundaries", {"speaker": "Fail02", "overwrite": True})]
+
+
+def test_compute_boundaries_start_dry_run_does_not_launch(tmp_path) -> None:
+    """dryRun=true must return a preview plan and skip the compute callback."""
+    calls: list[object] = []
+
+    def fake_start_compute(compute_type: str, payload: dict[str, object]) -> str:
+        calls.append((compute_type, payload))
+        return "job-bnd"
+
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        start_compute_job=fake_start_compute,
+    )
+    payload = tools.execute(
+        "compute_boundaries_start",
+        {"speaker": "Fail02", "dryRun": True},
+    )["result"]
+
+    assert payload["status"] == "dry_run"
+    assert payload["tool"] == "compute_boundaries_start"
+    assert payload["plan"]["speaker"] == "Fail02"
+    assert calls == []
+
+
+def test_compute_boundaries_status_reads_snapshot(tmp_path) -> None:
+    snapshot = {
+        "jobId": "job-bnd",
+        "type": "boundaries",
+        "status": "complete",
+        "progress": 100.0,
+        "message": "done",
+        "result": {
+            "speaker": "Fail02",
+            "generated": 8,
+            "preserved_manual": 2,
+            "total": 10,
+        },
+    }
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        get_job_snapshot=lambda job_id: snapshot,
+    )
+
+    payload = tools.execute(
+        "compute_boundaries_status",
+        {"jobId": "job-bnd"},
+    )["result"]
+
+    assert payload["jobId"] == "job-bnd"
+    assert payload["status"] == "complete"
+    assert payload["tier"] == "tier2_boundaries_only"
+    assert payload["result"]["generated"] == 8
+    assert payload["result"]["preserved_manual"] == 2
+
+
+def test_compute_boundaries_distinct_from_forced_align_and_retranscribe(tmp_path) -> None:
+    """Three BND-adjacent tools must dispatch to three different compute_types
+    so the user's choice between them is honoured end-to-end. A regression
+    that collapsed any pair would silently hijack one workflow into another
+    (e.g. compute_boundaries → forced_align would write the wrong artifact)."""
+    seen: list[str] = []
+
+    def fake_start_compute(compute_type: str, payload: dict[str, object]) -> str:
+        seen.append(compute_type)
+        return "job"
+
+    tools = ParseChatTools(
+        project_root=tmp_path,
+        start_compute_job=fake_start_compute,
+    )
+    tools.execute("forced_align_start", {"speaker": "Fail02"})
+    tools.execute("compute_boundaries_start", {"speaker": "Fail02"})
+    tools.execute(
+        "retranscribe_with_boundaries_start",
+        {"speaker": "Fail02"},
+    )
+
+    assert seen == ["forced_align", "boundaries", "retranscribe_with_boundaries"]
 
 
 def test_stt_start_supports_dry_run_preview(tmp_path) -> None:

--- a/python/ai/chat_tools.py
+++ b/python/ai/chat_tools.py
@@ -55,6 +55,8 @@ DEFAULT_MCP_TOOL_NAMES = (
     "stt_word_level_status",
     "forced_align_start",
     "forced_align_status",
+    "compute_boundaries_start",
+    "compute_boundaries_status",
     "ipa_transcribe_acoustic_start",
     "ipa_transcribe_acoustic_status",
     "retranscribe_with_boundaries_start",
@@ -778,6 +780,68 @@ class ParseChatTools:
             "forced_align_status": ChatToolSpec(
                 name="forced_align_status",
                 description="Read status/progress of an existing Tier 2 forced-alignment job.",
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["jobId"],
+                    "properties": {
+                        "jobId": {"type": "string", "minLength": 1, "maxLength": 128},
+                    },
+                },
+            ),
+            # ── Standalone BND refresh: forced-align → tiers.ortho_words ──
+            "compute_boundaries_start": ChatToolSpec(
+                name="compute_boundaries_start",
+                description=(
+                    "Start a standalone BND (Boundaries) job for a "
+                    "speaker. Runs Tier 2 forced alignment "
+                    "(torchaudio.functional.forced_align against "
+                    "facebook/wav2vec2-xlsr-53-espeak-cv-ft) on the "
+                    "speaker's cached STT word timestamps and writes the "
+                    "refined word boundaries to tiers.ortho_words — no "
+                    "Whisper rerun, no IPA. This is the fast lane for "
+                    "iterating on word boundaries before paying for the "
+                    "slow ORTH/IPA passes; it is intentionally separate "
+                    "from forced_align_start (which writes a *.aligned.json "
+                    "artifact instead of the BND tier) and from "
+                    "retranscribe_with_boundaries_start (which feeds BND "
+                    "back into faster-whisper). "
+                    "Existing tiers.ortho_words intervals flagged "
+                    "manuallyAdjusted=True are preserved verbatim and "
+                    "anchor their slice of the timeline; aligned words "
+                    "overlapping a manual interval are dropped. Pass "
+                    "overwrite=true to discard manual edits as well. "
+                    "Requires the speaker's STT cache "
+                    "(coarse_transcripts/<speaker>.json) to already carry "
+                    "word-level timestamps — run stt_word_level_start "
+                    "first if it doesn't. Returns a jobId for polling "
+                    "with compute_boundaries_status."
+                ),
+                parameters={
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["speaker"],
+                    "properties": {
+                        "speaker": {"type": "string", "minLength": 1, "maxLength": 200},
+                        "overwrite": {
+                            "type": "boolean",
+                            "description": (
+                                "When true, discards even manuallyAdjusted "
+                                "intervals on tiers.ortho_words and rebuilds "
+                                "the lane fully from forced alignment "
+                                "(default: false)."
+                            ),
+                        },
+                        "dryRun": {"type": "boolean"},
+                    },
+                },
+            ),
+            "compute_boundaries_status": ChatToolSpec(
+                name="compute_boundaries_status",
+                description=(
+                    "Read status/progress of a standalone BND job started "
+                    "by compute_boundaries_start."
+                ),
                 parameters={
                     "type": "object",
                     "additionalProperties": False,
@@ -2168,6 +2232,7 @@ class ParseChatTools:
             "stt_start",
             "stt_word_level_start",
             "forced_align_start",
+            "compute_boundaries_start",
             "ipa_transcribe_acoustic_start",
             "retranscribe_with_boundaries_start",
             "audio_normalize_start",
@@ -2206,6 +2271,16 @@ class ParseChatTools:
                 ),
             )
 
+        if tool_name == "compute_boundaries_start":
+            return (
+                _project_loaded_condition(),
+                _tool_condition(
+                    "stt_word_timestamps_cached",
+                    "The requested speaker must already have a coarse_transcripts/<speaker>.json STT cache containing segment-level word timestamps — forced alignment uses those words as seeds. Run stt_word_level_start first if absent.",
+                    kind=TOOL_CONDITION_KIND_FILE_PRESENCE,
+                ),
+            )
+
         if tool_name == "retranscribe_with_boundaries_start":
             return (
                 _project_loaded_condition(),
@@ -2220,6 +2295,7 @@ class ParseChatTools:
             "stt_status",
             "stt_word_level_status",
             "forced_align_status",
+            "compute_boundaries_status",
             "ipa_transcribe_acoustic_status",
             "retranscribe_with_boundaries_status",
             "audio_normalize_status",
@@ -2272,6 +2348,7 @@ class ParseChatTools:
             "stt_start": "stt_job_started",
             "stt_word_level_start": "word_level_stt_job_started",
             "forced_align_start": "forced_alignment_job_started",
+            "compute_boundaries_start": "boundaries_job_started",
             "ipa_transcribe_acoustic_start": "acoustic_ipa_job_started",
             "retranscribe_with_boundaries_start": "boundary_constrained_stt_job_started",
             "audio_normalize_start": "audio_normalize_job_started",
@@ -2296,6 +2373,7 @@ class ParseChatTools:
             "detect_timestamp_offset_from_pair",
             "enrichments_read",
             "forced_align_status",
+            "compute_boundaries_status",
             "ipa_transcribe_acoustic_status",
             "retranscribe_with_boundaries_status",
             "jobs_list_active",
@@ -3055,6 +3133,71 @@ class ParseChatTools:
             args,
             expected_type="forced_align",
             tier_label="tier2_forced_align",
+        )
+
+    def _tool_compute_boundaries_start(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Start a standalone BND (Boundaries) compute job.
+
+        Routes through the canonical ``boundaries`` compute_type so the
+        backend picks the ``_compute_speaker_boundaries`` handler that
+        writes ``tiers.ortho_words``. Intentionally distinct from
+        ``forced_align_start`` (which writes a ``*.aligned.json``
+        artifact instead) and from ``retranscribe_with_boundaries_start``
+        (which feeds BND back into faster-whisper).
+        """
+        speaker = self._normalize_speaker(args.get("speaker"))
+        overwrite = bool(args.get("overwrite", False))
+
+        payload_body: Dict[str, Any] = {
+            "speaker": speaker,
+            "overwrite": overwrite,
+        }
+
+        if bool(args.get("dryRun", False)):
+            return {
+                "readOnly": True,
+                "previewOnly": True,
+                "status": "dry_run",
+                "tool": "compute_boundaries_start",
+                "plan": payload_body,
+                "note": (
+                    "Dry run. Would launch the boundaries compute job, "
+                    "running torchaudio.functional.forced_align against "
+                    "facebook/wav2vec2-xlsr-53-espeak-cv-ft on the "
+                    "speaker's cached STT word timestamps and writing the "
+                    "refined word boundaries to tiers.ortho_words. No "
+                    "Whisper rerun, no IPA. Existing manuallyAdjusted "
+                    "intervals are preserved unless overwrite=true."
+                ),
+            }
+
+        if self._start_compute_job is None:
+            raise ChatToolExecutionError(
+                "Compute-job start callback is unavailable — wire ParseChatTools "
+                "with start_compute_job to enable standalone BND."
+            )
+
+        job_id = self._start_compute_job("boundaries", payload_body)
+
+        return {
+            "readOnly": True,
+            "previewOnly": True,
+            "jobId": job_id,
+            "status": "running",
+            "tier": "tier2_boundaries_only",
+            "speaker": speaker,
+            "overwrite": overwrite,
+            "message": (
+                "Boundaries job started. Poll with compute_boundaries_status."
+            ),
+        }
+
+    def _tool_compute_boundaries_status(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Read status of a standalone BND compute job."""
+        return self._generic_compute_status(
+            args,
+            expected_type="boundaries",
+            tier_label="tier2_boundaries_only",
         )
 
     def _tool_ipa_transcribe_acoustic_start(self, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/ParseUI.test.tsx
+++ b/src/ParseUI.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen, fireEvent, cleanup, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { AnnotationRecord, AnnotationInterval, ProjectConfig, Tag } from "./api/types";
+import { useTranscriptionLanesStore } from "./stores/transcriptionLanesStore";
 
 const { mockGetAuthStatus, mockPollAuth, mockStartAuthFlow } = vi.hoisted(() => ({
   mockGetAuthStatus: vi.fn(),
@@ -967,6 +968,81 @@ describe("Actions menu — transcription run flow", () => {
     const button = await screen.findByTestId("phonetic-retranscribe-with-boundaries");
     expect((button as HTMLButtonElement).disabled).toBe(true);
     expect(button.getAttribute("title") ?? "").toMatch(/refine boundaries/i);
+  });
+
+  // ── Refine Boundaries (BND) button gating on STT word timestamps ───────
+  // The standalone BND job uses the speaker's cached STT word timestamps
+  // as forced-alignment seeds. Without them the backend raises
+  // "Run STT first" — these tests confirm we surface that disabled state
+  // in the UI instead of letting the user click into a guaranteed error.
+
+  it("disables Refine Boundaries (BND) when the active speaker has no STT word timestamps", async () => {
+    mockConfig = {
+      project_name: "PARSE",
+      language_code: "ku",
+      speakers: ["Fail01"],
+      concepts: [{ id: "1", label: "water" }],
+      audio_dir: "audio",
+      annotations_dir: "annotations",
+    };
+    mockRecords = {
+      Fail01: makeRecord("Fail01", [
+        { conceptText: "water", ipa: "aw", ortho: "ئاو", start: 1, end: 2 },
+      ]),
+    };
+    // Reset the lanes store so the previous test's STT data doesn't leak.
+    useTranscriptionLanesStore.setState({
+      sttBySpeaker: {},
+      sttStatus: {},
+      sttSourceBySpeaker: {},
+    });
+
+    render(<ParseUI />);
+    await switchToAnnotateMode();
+
+    const button = await screen.findByTestId("phonetic-refine-boundaries");
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.getAttribute("title") ?? "").toMatch(/run stt first/i);
+  });
+
+  it("enables Refine Boundaries (BND) when the speaker's STT cache has word timestamps", async () => {
+    mockConfig = {
+      project_name: "PARSE",
+      language_code: "ku",
+      speakers: ["Fail01"],
+      concepts: [{ id: "1", label: "water" }],
+      audio_dir: "audio",
+      annotations_dir: "annotations",
+    };
+    mockRecords = {
+      Fail01: makeRecord("Fail01", [
+        { conceptText: "water", ipa: "aw", ortho: "ئاو", start: 1, end: 2 },
+      ]),
+    };
+    // Seed an STT segment with word-level timestamps. ``status: "loaded"``
+    // keeps ensureStt from racing in and overwriting our seed during the
+    // first lane render.
+    useTranscriptionLanesStore.setState({
+      sttBySpeaker: {
+        Fail01: [
+          {
+            start: 1.0,
+            end: 2.0,
+            text: "ئاو",
+            words: [{ word: "ئاو", start: 1.05, end: 1.85, prob: 0.92 }],
+          },
+        ],
+      },
+      sttStatus: { Fail01: "loaded" },
+      sttSourceBySpeaker: {},
+    });
+
+    render(<ParseUI />);
+    await switchToAnnotateMode();
+
+    const button = await screen.findByTestId("phonetic-refine-boundaries");
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+    expect(button.getAttribute("title") ?? "").toMatch(/run fast boundary refinement/i);
   });
 
   it("enables Re-run STT with Boundaries when the active speaker has ortho_words intervals", async () => {

--- a/src/ParseUI.tsx
+++ b/src/ParseUI.tsx
@@ -2759,6 +2759,18 @@ export function ParseUI() {
     return s.records[speaker]?.tiers?.ortho_words?.intervals?.length ?? 0;
   });
 
+  // Whether the active speaker has cached STT segments carrying nested
+  // word-level timestamps. The standalone BND ("Refine Boundaries") job
+  // uses those words as alignment seeds — without them the backend
+  // raises "Run STT first…", which we'd rather pre-empt with a disabled
+  // button + a tooltip pointing at the STT action.
+  const sttHasWordTimestamps = useTranscriptionLanesStore((s) => {
+    const speaker = selectedSpeakers[0] ?? null;
+    if (!speaker) return false;
+    const segs = s.sttBySpeaker[speaker] ?? [];
+    return segs.some((seg) => Array.isArray(seg.words) && seg.words.length > 0);
+  });
+
   // Briefly-flashed inline confirmation when the user captures an anchor
   // straight from the playback bar. Vanishes after a couple of seconds so
   // the chrome stays calm.
@@ -4666,9 +4678,17 @@ export function ParseUI() {
                         void boundariesJob.run();
                       }}
                       disabled={
-                        !selectedSpeakers[0] || boundariesJob.state.status === 'running'
+                        !selectedSpeakers[0]
+                        || !sttHasWordTimestamps
+                        || boundariesJob.state.status === 'running'
                       }
-                      title="Run fast boundary refinement independently. Useful before running slow ORTH/IPA models."
+                      title={
+                        !selectedSpeakers[0]
+                          ? 'Select a speaker first.'
+                          : !sttHasWordTimestamps
+                            ? 'No STT word timestamps for this speaker yet. Run STT first (Actions → Run STT) — boundary refinement uses those words as alignment seeds.'
+                            : 'Run fast boundary refinement independently. Useful before running slow ORTH/IPA models.'
+                      }
                       className="flex w-full items-center gap-2 rounded-md bg-amber-50 px-2.5 py-1.5 text-[11px] font-semibold text-amber-800 ring-1 ring-amber-200 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Scissors className="h-3.5 w-3.5"/>


### PR DESCRIPTION
## Why
PR [#239](https://github.com/ArdeleanLucas/PARSE/pull/239) shipped the standalone BND job (`_compute_speaker_boundaries` → `tiers.ortho_words`) end-to-end but explicitly deferred MCP exposure. PR [#241](https://github.com/ArdeleanLucas/PARSE/pull/241) closed the same gap for boundary-constrained STT; this PR does it for the BND job itself.

While auditing the BND button I also noticed it had the parallel disabled-state gap that #241 fixed for the BND-STT button: it was always enabled, even on speakers with no cached STT word timestamps. Since the backend already raises "Run STT first" in that case, this PR surfaces the same precondition in the UI as a disable + tooltip.

## MCP exposure
- `compute_boundaries_start` + `compute_boundaries_status` `ChatToolSpec` entries in `python/ai/chat_tools.py`. Parameters mirror the dispatch layer (`speaker`, `overwrite`, `dryRun`); the description spells out the distinction from `forced_align_start` (writes a `*.aligned.json` artifact, not the BND tier) and from `retranscribe_with_boundaries_start` (which goes the *other* direction — BND → STT).
- Both registered in `DEFAULT_MCP_TOOL_NAMES` so external agents see them without flipping `expose_all_tools`.
- Proper mutability: `stateful_job` for start. Proper precondition: `stt_word_timestamps_cached` (file presence — alignment uses cached words as seeds). Proper postcondition: `boundaries_job_started`.
- Handler `_tool_compute_boundaries_start` dispatches the canonical `boundaries` compute_type — never `forced_align`, never an alias — so the dispatcher always lands on `_compute_speaker_boundaries`. A trio-distinctness regression test pins this so a future rename can't silently hijack one workflow into another.
- Matching `@mcp.tool()` wrappers in `python/adapters/mcp_adapter.py`, plus the tool list in the module docstring.

## UI gate
- The "Refine Boundaries (BND)" button now disables when the active speaker's STT cache (`sttBySpeaker[speaker]` from the transcription-lanes store) has no segment carrying word-level timestamps.
- Tooltip swaps across three states: no-speaker, no-STT-words ("Run STT first"), and ready-to-go (the original "Run fast boundary refinement…" copy).
- New `sttHasWordTimestamps` selector reads from the existing lanes store; no new API calls or stores introduced.

## Tests
- Backend: 5 new dispatch tests in `python/adapters/test_mcp_adapter.py` (canonical compute_type, overwrite passthrough, dryRun preview, status snapshot read, plus a trio-distinctness guard across `forced_align` / `compute_boundaries` / `retranscribe_with_boundaries`). `stateful_job_starters` test list extended.
- Tool-count assertions bumped: defaults 38 → 40, all-tools 56 → 58, `parseChatToolCount` 52 → 54.
- Frontend: 2 new vitest cases for the BND button gate (disabled with no STT word timestamps, enabled when the lanes store has at least one segment with non-empty `words[]`).
- `tsc --noEmit` clean; `vitest run` 286 → 288 (all pass).
- Backend sweep: 53 passed across mcp_adapter / compute_speaker_boundaries / compute_speaker_retranscribe / transcribe_segments_in_memory. The 2 pre-existing `test_stt_start_supports_dry_run_preview` / `test_audio_normalize_start_supports_dry_run_preview` failures use Python-3.10 `str | None` syntax incompatible with the local 3.9 testvenv — confirmed they fail identically on origin/main and have failed on every recent PR (#240, #241).

## Test plan
- [x] `python -m pytest python/adapters/test_mcp_adapter.py -k 'compute_boundaries or distinct or stateful_job_starters'` — 10/10
- [x] `tsc --noEmit` clean; `vitest run` 288/288
- [ ] **Lucas**: open Annotate mode on a fresh speaker (no STT yet), hover the "Refine Boundaries (BND)" button, confirm it's disabled with the "Run STT first" tooltip
- [ ] **Lucas**: run STT, confirm the button enables and the tooltip swaps to "Run fast boundary refinement independently…"
- [ ] **Lucas**: from a connected MCP client (Claude Code, Cursor, etc.), call `compute_boundaries_start` with a speaker name, poll with `compute_boundaries_status`, verify the BND lane updates
- [ ] **Lucas**: `dryRun=true` should return `{status: "dry_run", tool: "compute_boundaries_start", plan: {...}}` without launching anything
- [ ] **Lucas**: confirm `mcp_get_exposure_mode` reports the new tools (defaults 40, all-tools 58)

## Notes / scope
- Single-speaker per call. The original prompt mentioned "speaker name (or list of speakers)" — multi-speaker batch fits naturally on the existing `TranscriptionRunModal` flow as a follow-up.
- Source-marker form unchanged — this PR doesn't touch any cache schema.
- Browser-preview verification skipped: the disabled-state gate is observable in principle, but flipping it from disabled → enabled needs a live PARSE workspace + Python backend + a real STT cache on disk to seed `sttBySpeaker[speaker]` from `/api/stt-segments/<speaker>`. The vitest gate test covers the same store contract end-to-end against the rendered button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)